### PR TITLE
Rename carbon-resoruces to resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.31)
-project(carbon-resources VERSION 2.1.0)
+project(resources VERSION 2.1.0)
 
 if(NOT DEFINED ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
     message(FATAL_ERROR "Missing required environment variable CCP_EVE_PERFORCE_BRANCH_PATH")
@@ -67,34 +67,34 @@ set(SRC_FILES
     src/ParameterVersion.cpp
 )
 
-ccp_add_library(carbon-resources SHARED ${SRC_FILES})
+ccp_add_library(resources SHARED ${SRC_FILES})
 
-target_compile_definitions(carbon-resources PRIVATE EXPORT_LIBRARY)
+target_compile_definitions(resources PRIVATE EXPORT_LIBRARY)
 
 # Version is required in code
 # Added as config
 configure_file(src/Version.h.in include/Version.h @ONLY)
 
 if(WIN32)
-    target_compile_definitions(carbon-resources PRIVATE NOMINMAX) # Do not define min/max macros.
+    target_compile_definitions(resources PRIVATE NOMINMAX) # Do not define min/max macros.
 endif()
 
-target_link_libraries(carbon-resources PRIVATE resources-tools yaml-cpp::yaml-cpp)
+target_link_libraries(resources PRIVATE resources-tools yaml-cpp::yaml-cpp)
 
-target_include_directories(carbon-resources
+target_include_directories(resources
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
 
-get_target_property(_SOURCES carbon-resources SOURCES)
+get_target_property(_SOURCES resources SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
         PREFIX "Sources"
         FILES ${_SOURCES}
 )
 
-set_target_properties(carbon-resources PROPERTIES OUTPUT_NAME "_carbon-resources")
+set_target_properties(resources PROPERTIES OUTPUT_NAME "_resources")
 
 # Static lib, exported and used for cli
 ccp_add_library(resources-static STATIC ${SRC_FILES})
@@ -153,16 +153,16 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
                 INSTALL_DESTINATION documentation
         )
 
-        # Ensure that carbon-resources is built before Spinx target
-        add_dependencies(Sphinx carbon-resources)
+        # Ensure that resources is built before Spinx target
+        add_dependencies(Sphinx resources)
     endif()
 
     set(INSTALL_BIN_ONLY OFF CACHE BOOL "Do not Install configuration files meant to be read by projects using this project as a dependency (Cmake Config/ header files etc . . .). Set this to ON when installing this component to the perforce vendor folder")
     if(INSTALL_BIN_ONLY)
         # Install rule to ensure that our runtime files are in the expected, platform-specific folder
         install(
-                TARGETS carbon-resources resources-static
-                EXPORT carbon-resourcesTarget
+                TARGETS resources resources-static
+                EXPORT resourcesTarget
                 CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
                 LIBRARY DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
                 ARCHIVE DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
@@ -171,8 +171,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     else()
         # Install rule to ensure that our runtime and linker files are in the expected, platform-specific folders
         install(
-                TARGETS carbon-resources resources-static
-                EXPORT carbon-resourcesTarget
+                TARGETS resources resources-static
+                EXPORT resourcesTarget
                 CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
                 LIBRARY DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
                 ARCHIVE DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
@@ -184,12 +184,12 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include DESTINATION . FILES_MATCHING PATTERN "*.h")
 
         install(
-                EXPORT carbon-resourcesTarget
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/share/carbon-resources
-                FILE carbon-resources.cmake)
+                EXPORT resourcesTarget
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/share/resources
+                FILE resources.cmake)
         install(
-                FILES carbon-resourcesConfig.cmake
-                DESTINATION ${CMAKE_INSTALL_PREFIX}/share/carbon-resources)
+                FILES resourcesConfig.cmake
+                DESTINATION ${CMAKE_INSTALL_PREFIX}/share/resources)
     endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(cmake/CcpGlobalSettings.cmake)
 include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)
 
-find_package(yaml-cpp CONFIG REQUIRED) ## Can it be in tools?
+find_package(yaml-cpp CONFIG REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Add subdirectory for resource tools static library
@@ -79,7 +79,7 @@ if(WIN32)
     target_compile_definitions(carbon-resources PRIVATE NOMINMAX) # Do not define min/max macros.
 endif()
 
-target_link_libraries(carbon-resources PRIVATE carbon-resources-tools yaml-cpp::yaml-cpp)
+target_link_libraries(carbon-resources PRIVATE resources-tools yaml-cpp::yaml-cpp)
 
 target_include_directories(carbon-resources
         PUBLIC
@@ -107,7 +107,7 @@ if(WIN32)
     target_compile_definitions(carbon-resources-static PRIVATE NOMINMAX) # Do not define min/max macros.
 endif()
 
-target_link_libraries(carbon-resources-static PRIVATE $<BUILD_LOCAL_INTERFACE:carbon-resources-tools> yaml-cpp::yaml-cpp)
+target_link_libraries(carbon-resources-static PRIVATE $<BUILD_LOCAL_INTERFACE:resources-tools> yaml-cpp::yaml-cpp)
 
 target_include_directories(carbon-resources-static
         PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.31)
-project(resources VERSION 2.1.0)
+project(resources VERSION 3.0.0)
 
 if(NOT DEFINED ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
     message(FATAL_ERROR "Missing required environment variable CCP_EVE_PERFORCE_BRANCH_PATH")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,19 +97,19 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
 set_target_properties(carbon-resources PROPERTIES OUTPUT_NAME "_carbon-resources")
 
 # Static lib, exported and used for cli
-ccp_add_library(carbon-resources-static STATIC ${SRC_FILES})
+ccp_add_library(resources-static STATIC ${SRC_FILES})
 
-set_target_properties(carbon-resources-static PROPERTIES OUTPUT_NAME "_carbon-resources-static")
+set_target_properties(resources-static PROPERTIES OUTPUT_NAME "_resources-static")
 
-target_compile_definitions(carbon-resources-static PUBLIC CARBON_RESOURCES_STATIC)
+target_compile_definitions(resources-static PUBLIC CARBON_RESOURCES_STATIC)
 
 if(WIN32)
-    target_compile_definitions(carbon-resources-static PRIVATE NOMINMAX) # Do not define min/max macros.
+    target_compile_definitions(resources-static PRIVATE NOMINMAX) # Do not define min/max macros.
 endif()
 
-target_link_libraries(carbon-resources-static PRIVATE $<BUILD_LOCAL_INTERFACE:resources-tools> yaml-cpp::yaml-cpp)
+target_link_libraries(resources-static PRIVATE $<BUILD_LOCAL_INTERFACE:resources-tools> yaml-cpp::yaml-cpp)
 
-target_include_directories(carbon-resources-static
+target_include_directories(resources-static
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
@@ -161,7 +161,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     if(INSTALL_BIN_ONLY)
         # Install rule to ensure that our runtime files are in the expected, platform-specific folder
         install(
-                TARGETS carbon-resources carbon-resources-static
+                TARGETS carbon-resources resources-static
                 EXPORT carbon-resourcesTarget
                 CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
                 LIBRARY DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
@@ -171,7 +171,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     else()
         # Install rule to ensure that our runtime and linker files are in the expected, platform-specific folders
         install(
-                TARGETS carbon-resources carbon-resources-static
+                TARGETS carbon-resources resources-static
                 EXPORT carbon-resourcesTarget
                 CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
                 LIBRARY DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 CCP Games
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,14 @@
+Carbon Resources for Carbon Engine.
+
+© 2025 CCP Games.
+
+Licensed under the [MIT Licence](LICENSE.txt). (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/license/MIT
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+This software is provided by CCP Games and does not include or distribute any third-party libraries or frameworks.
+
+This product includes software developed for the purpose of managing and delivering resources intended for use by Carbon titles.
+
+Trademark Notice: CCP Games is a trademark of CCP ehf. Nothing in this License grants any rights to CCP Games' trademarks or game content.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# carbon-resources
+# resources
 
 [![license](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.txt)
 
 ## Overview
 
-*carbon-resources* provides a suite of tools to manage/manipulate and deliver resources for Carbon titles.
+*resources* provides a suite of tools to manage/manipulate and deliver resource files for Carbon titles.
 
 ## 🛠️ Building
 
@@ -13,10 +13,10 @@ Build using provided `CMakeLists` in the repository root.
 ## 🔍 Accessing the Documentation
 
 Documentation provides:
-1. carbon-resources API.
-2. carbon-resources CLI Information.
-3. carbon-resources guides.
-4. carbon-resources usage examples.
+1. resources API.
+2. resources CLI Information.
+3. resources guides.
+4. resources usage examples.
 
 ### Current requirements for documentation generation
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.31)
-project(carbon-resources-cli VERSION 1.0.0)
+project(resources-cli VERSION 1.0.0)
 
 find_package(argparse CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
@@ -31,11 +31,11 @@ set(SRC_FILES
     src/UnpackBundleCliOperation.h
 )
 
-ccp_add_executable(carbon-resources-cli ${SRC_FILES})
+ccp_add_executable(resources-cli ${SRC_FILES})
 
-target_link_libraries(carbon-resources-cli PRIVATE carbon-resources-static argparse::argparse yaml-cpp::yaml-cpp)
+target_link_libraries(resources-cli PRIVATE carbon-resources-static argparse::argparse yaml-cpp::yaml-cpp)
 
-get_target_property(_SOURCES carbon-resources-cli SOURCES)
+get_target_property(_SOURCES resources-cli SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
         PREFIX "Sources"
         FILES ${_SOURCES}
@@ -44,15 +44,15 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
 option(DEV_FEATURES "Expose unsupported features")
 
 if(DEV_FEATURES)
-    target_compile_definitions( carbon-resources-cli PRIVATE DEV_FEATURES )
+    target_compile_definitions( resources-cli PRIVATE DEV_FEATURES )
 endif()
 
-set_target_properties(carbon-resources-cli PROPERTIES OUTPUT_NAME "carbon-resources")
+set_target_properties(resources-cli PROPERTIES OUTPUT_NAME "carbon-resources")
 
 # Install rule to ensure that our runtime files are in the expected, platform-specific folder
 install(
-        TARGETS carbon-resources-cli
-        EXPORT carbon-resources-cliTarget
+        TARGETS resources-cli
+        EXPORT resources-cliTarget
         CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
         RUNTIME DESTINATION bin/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
 )

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -47,7 +47,7 @@ if(DEV_FEATURES)
     target_compile_definitions( resources-cli PRIVATE DEV_FEATURES )
 endif()
 
-set_target_properties(resources-cli PROPERTIES OUTPUT_NAME "carbon-resources")
+set_target_properties(resources-cli PROPERTIES OUTPUT_NAME "resources")
 
 # Install rule to ensure that our runtime files are in the expected, platform-specific folder
 install(

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -33,7 +33,7 @@ set(SRC_FILES
 
 ccp_add_executable(resources-cli ${SRC_FILES})
 
-target_link_libraries(resources-cli PRIVATE carbon-resources-static argparse::argparse yaml-cpp::yaml-cpp)
+target_link_libraries(resources-cli PRIVATE resources-static argparse::argparse yaml-cpp::yaml-cpp)
 
 get_target_property(_SOURCES resources-cli SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/cli/src/Cli.cpp
+++ b/cli/src/Cli.cpp
@@ -87,9 +87,9 @@ int Cli::ProcessCommandLine( int argc, char** argv )
 
 void Cli::PrintCliHeader()
 {
-	std::cout << "====================" << std::endl;
-	std::cout << "carbon-resources-cli" << std::endl;
-	std::cout << "Version: " << m_version << std::endl;
+    std::cout << "====================" << std::endl;
+    std::cout << "resources-cli" << std::endl;
+    std::cout << "Version: " << m_version << std::endl;
     std::cout << "====================\n" << std::endl;
 
 }

--- a/cli/src/Cli.cpp
+++ b/cli/src/Cli.cpp
@@ -7,14 +7,15 @@
 #include "Defines.h"
 
 Cli::Cli( const std::string& name, const std::string& version ):
+	m_name(name),
 	m_version(version)
 {
-	
+
 }
 
 Cli::~Cli()
 {
-	
+
 }
 
 void Cli::AddOperation( CliOperation* operation )
@@ -89,6 +90,7 @@ void Cli::PrintCliHeader()
 {
     std::cout << "====================" << std::endl;
     std::cout << "resources-cli" << std::endl;
+    std::cout << "Name:" << m_name << std::endl;
     std::cout << "Version: " << m_version << std::endl;
     std::cout << "====================\n" << std::endl;
 

--- a/cli/src/Cli.h
+++ b/cli/src/Cli.h
@@ -33,6 +33,8 @@ private:
 
 private:
 
+    std::string m_name;
+
     std::string m_version;
 
 	std::vector<CliOperation*> m_operations;

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -33,7 +33,7 @@ std::string CalculateVersionString()
 
 int main( int argc, char** argv )
 {
-	Cli cli( "carbon-resources", CalculateVersionString() );
+    Cli cli( "resources", CalculateVersionString() );
 
     CreateResourceGroupCliOperation createResourceGroupOperation;
 

--- a/doc/source/DesignDocuments/filesystemDesign.rst
+++ b/doc/source/DesignDocuments/filesystemDesign.rst
@@ -1,7 +1,7 @@
 Filesystem Design - Local/Remote
 ================================
 
-carbon-resources works with 3 filesystem target types:
+resources works with 3 filesystem target types:
 
 1. ``LOCAL_RELATIVE``
 2. ``LOCAL_CDN``
@@ -44,7 +44,7 @@ Files created this way mean that if a files content changes the filename also ch
 REMOTE_CDN
 ----------
 
-Reading/Writing resources using ``REMOTE_CDN`` do slightly different things, however in the future this may change if uploading is added to carbon-resources.
+Reading/Writing file resources using ``REMOTE_CDN`` do slightly different things, however in the future this may change if uploading is added to resources.
 
 Reading resources using ``REMOTE_CDN`` will download the resource following the same naming rules as ``LOCAL_CDN``.
 

--- a/doc/source/DesignDocuments/resourceGroupFileFormat.rst
+++ b/doc/source/DesignDocuments/resourceGroupFileFormat.rst
@@ -6,7 +6,7 @@ Resource Groups are human readable Yaml files which encapsulate all data associa
 The word 'Resources' is used here, however the term is interchangeable with 'file'.
 
 Resource Groups are an evolution of the resfileindex.txt files used in EVE and Frontier. Many of the file management
-concepts of carbon-resources originate there.
+concepts of resources originate there.
 
 Most operations require Resource Groups as inputs. Operations output may also contain generated ResourceGroups.
 

--- a/doc/source/Guides/HowToApplyAPatch.rst
+++ b/doc/source/Guides/HowToApplyAPatch.rst
@@ -71,7 +71,7 @@ The following command will perform the same action as above given the same input
 
 .. code::
     
-    .\carbon-resources.exe apply-patch Patch/PatchResourceGroup.yaml --patch-binaries-base-path Patch/LocalCDNPatches/ --resources-to-patch-base-path Patch/PreviousBuildResources/ --next-resources-base-path Patch/NextBuildResources/
+    .\resources.exe apply-patch Patch/PatchResourceGroup.yaml --patch-binaries-base-path Patch/LocalCDNPatches/ --resources-to-patch-base-path Patch/PreviousBuildResources/ --next-resources-base-path Patch/NextBuildResources/
 
 
 **Arguments:**

--- a/doc/source/Guides/HowToCreateABundle.rst
+++ b/doc/source/Guides/HowToCreateABundle.rst
@@ -7,7 +7,7 @@ Furthermore, once the patch binaries are compressed their size may reduce dramat
 
 This gives a patch which is created of many very small files which is not ideal for transfer over the internet.
 
-In order to solve this carbon-resources also provides a concept of bundling.
+In order to solve this resources also provides a concept of bundling.
 
 Bundling joins files together into chunks based on their final combined compressed size.
 
@@ -16,7 +16,7 @@ Note: This document refers to filesystem types, see :doc:`../DesignDocuments/fil
 
 .. code::
     
-    .\carbon-resources.exe create-bundle PatchOut\PatchResourceGroup.yaml --resource-source-path PatchOut\Patches --resource-source-type LOCAL_CDN --resourcegroup-type PatchResourceGroup --chunk-destination-type REMOTE_CDN
+    .\resources.exe create-bundle PatchOut\PatchResourceGroup.yaml --resource-source-path PatchOut\Patches --resource-source-type LOCAL_CDN --resourcegroup-type PatchResourceGroup --chunk-destination-type REMOTE_CDN
     
 
 **Arguments:**

--- a/doc/source/Guides/HowToCreateAPatch.rst
+++ b/doc/source/Guides/HowToCreateAPatch.rst
@@ -7,7 +7,7 @@ Note: This document refers to filesystem types, see :doc:`../DesignDocuments/fil
 
 .. code::
 
-    .\carbon-resources.exe create-patch PreviousResourceGroup.yaml NextResourceGroup.yaml --resource-source-base-path-previous C:\PreviousBuild --resource-source-base-path-next C:\NextBuild
+    .\resources.exe create-patch PreviousResourceGroup.yaml NextResourceGroup.yaml --resource-source-base-path-previous C:\PreviousBuild --resource-source-base-path-next C:\NextBuild
 
 **Arguments:**
 

--- a/doc/source/Guides/HowToCreateAResourceGroup.rst
+++ b/doc/source/Guides/HowToCreateAResourceGroup.rst
@@ -5,7 +5,7 @@ Resource Groups can be created via the lib or CLI. This example uses the CLI.
 
 .. code::
 
-    .\carbon-resources.exe create-group C:\Build --output-file ResourceGroup.yaml
+    .\resources.exe create-group C:\Build --output-file ResourceGroup.yaml
 
 **Arguments:**
 

--- a/doc/source/Guides/HowToUnpackABundle.rst
+++ b/doc/source/Guides/HowToUnpackABundle.rst
@@ -60,7 +60,7 @@ The following command will perform the same action as above given the same input
 
 .. code::
     
-    .\carbon-resources.exe unpack-bundle Bundle\BundleResourceGroup.yaml --chunk-source-base-path \Bundle\Chunks --resource-destination-type LOCAL_RELATIVE
+    .\resources.exe unpack-bundle Bundle\BundleResourceGroup.yaml --chunk-source-base-path \Bundle\Chunks --resource-destination-type LOCAL_RELATIVE
 
 
 **Arguments:**

--- a/doc/source/OverviewDocuments/patchingProcess.rst
+++ b/doc/source/OverviewDocuments/patchingProcess.rst
@@ -7,10 +7,10 @@ This document presents a graphical overview of patch creation and patch applicat
 
 For further practical examples refer to :doc:`../QuickStart/ExamplePatchCreationProcedure` and :doc:`../guides`
 
-*Note this is just one example use case, carbon-resources is able to handle many usage scenarios.*
+*Note this is just one example use case, resources is able to handle many usage scenarios.*
 
 .. note::
-    File uploading to CDN is outside the scope of carbon-resources currently.
+    File uploading to CDN is outside the scope of resources currently.
 
 Patch Creation
 --------------
@@ -19,14 +19,14 @@ Patches are created with the following requirements
 
 1. Latest build available on the local machine following a standard filesystem pathing structure ``LOCAL_RELATIVE``
 2. Previous build available via a CDN following pathing structure ``REMOTE_CDN``
-3. carbon-resources CLI is available on local machine.
+3. resources CLI is available on local machine.
 
 Patch Application
 -----------------
 
 Patches are applied with the following requirements
 
-1. carbon-resources lib is included inside a launcher style application.
+1. resources lib is included inside a launcher style application.
 2. System patch application is running on has access to files on CDN.
 
 .. image:: Overview.png

--- a/doc/source/QuickStart/ExamplePatchCreationProcedure.rst
+++ b/doc/source/QuickStart/ExamplePatchCreationProcedure.rst
@@ -20,8 +20,8 @@ This example uses two directories.
 
 .. code::
 
-    .\carbon-resources.exe create-group C:\PreviousBuild --output-file PreviousResourceGroup.yaml
-    .\carbon-resources.exe create-group C:\NextBuild --output-file NextResourceGroup.yaml
+    .\resources.exe create-group C:\PreviousBuild --output-file PreviousResourceGroup.yaml
+    .\resources.exe create-group C:\NextBuild --output-file NextResourceGroup.yaml
 
 These two commands will create two resource groups
 
@@ -37,7 +37,7 @@ The resource groups generated in the previous section can now be use to generate
 
 .. code::
 
-    .\carbon-resources.exe create-patch PreviousResourceGroup.yaml NextResourceGroup.yaml --resource-source-base-path-previous C:\PreviousBuild --resource-source-base-path-next C:\NextBuild
+    .\resources.exe create-patch PreviousResourceGroup.yaml NextResourceGroup.yaml --resource-source-base-path-previous C:\PreviousBuild --resource-source-base-path-next C:\NextBuild
 
 The command is passed 4 required arguments
 
@@ -67,14 +67,14 @@ Furthermore, once the patch binaries are compressed their size may reduce dramat
 
 This gives a patch which is created of many very small files which is not ideal for transfer over the internet.
 
-In order to solve this carbon-resources also provides a concept of bundling.
+In order to solve this resources also provides a concept of bundling.
 
 Bundling joins files together into chunks based on their final combined compressed size.
 
 
 .. code::
     
-    .\carbon-resources.exe create-bundle PatchOut\PatchResourceGroup.yaml --resource-source-path PatchOut\Patches --resource-source-type LOCAL_CDN --chunk-destination-type REMOTE_CDN
+    .\resources.exe create-bundle PatchOut\PatchResourceGroup.yaml --resource-source-path PatchOut\Patches --resource-source-type LOCAL_CDN --chunk-destination-type REMOTE_CDN
     
 
 Arguments:
@@ -92,7 +92,7 @@ There are many more exposed options than discussed here. For exhaustive list ref
 
 .. code::
 
-    .\carbon-resources.exe -h
-    .\carbon-resources.exe create-group -h
-    .\carbon-resources.exe create-patch -h
-    .\carbon-resources.exe create-bundle -h
+    .\resources.exe -h
+    .\resources.exe create-group -h
+    .\resources.exe create-patch -h
+    .\resources.exe create-bundle -h

--- a/doc/source/Tools/Api/CallbackStructures.rst
+++ b/doc/source/Tools/Api/CallbackStructures.rst
@@ -1,7 +1,7 @@
 Callback Structures
 ===================
 
-Long running main operations all allow the passing of an optional callback for use in receiving status updates from carbon-resources.
+Long running main operations all allow the passing of an optional callback for use in receiving status updates from resources.
 
 .. doxygentypedef:: CarbonResources::StatusCallback
 

--- a/doc/source/Tools/Api/FilesystemStructs.rst
+++ b/doc/source/Tools/Api/FilesystemStructs.rst
@@ -3,7 +3,7 @@ Filesystem Structures
 
 Resources are handled differently based on which filesystem type they follow.
 
-Structures in this document can be used to alter filesystem settings for carbon-resources operations.
+Structures in this document can be used to alter filesystem settings for resources operations.
 
 See :doc:`../../DesignDocuments/filesystemDesign` for further details.
 

--- a/doc/source/Tools/Api/ResultStructures.rst
+++ b/doc/source/Tools/Api/ResultStructures.rst
@@ -1,7 +1,7 @@
 Result Structures
 =================
 
-Resources returns as much useful information as possible to the caller.
+resources returns as much useful information as possible to the caller.
 
 This is especially important when encountering errors.
 

--- a/doc/source/Tools/Api/ResultStructures.rst
+++ b/doc/source/Tools/Api/ResultStructures.rst
@@ -1,7 +1,7 @@
 Result Structures
 =================
 
-Carbon-resources returns as much useful information as possible to the caller.
+Resources returns as much useful information as possible to the caller.
 
 This is especially important when encountering errors.
 

--- a/doc/source/Tools/api.rst
+++ b/doc/source/Tools/api.rst
@@ -1,7 +1,7 @@
-carbon-resources library API
+resources library API
 ============================
 
-The carbon-resources API is centered around the concept of a :doc:`Api/ResourceGroup`. Where a :doc:`Api/ResourceGroup` holds a collection of Resources.
+The resources API is centered around the concept of a :doc:`Api/ResourceGroup`. Where a :doc:`Api/ResourceGroup` holds a collection of Resources.
 
 There are extensions to this type, see :doc:`Api/BundleResourceGroup` and :doc:`Api/PatchResourceGroup` which are targeted at specific data types chunks and patches respectively.
 

--- a/doc/source/Tools/cli.rst
+++ b/doc/source/Tools/cli.rst
@@ -1,9 +1,9 @@
-carbon-resources CLI
+resources CLI
 ====================
 
 The CLI exposes operations to be performed on the CI to create patches and bundles.
 
-carbon-resources operations are exposed along with the same input variables as the lib target.
+resources operations are exposed along with the same input variables as the lib target.
 
 
 .. list-table:: CLI operations
@@ -24,12 +24,12 @@ Detailed help refer to the CLI documentation.
 
 .. code::
 
-   $ .\carbon-resources -h
-   $ .\carbon-resources create-group -h
-   $ .\carbon-resources create-patch -h
-   $ .\carbon-resources create-bundle -h
+   $ .\resources -h
+   $ .\resources create-group -h
+   $ .\resources create-patch -h
+   $ .\resources create-bundle -h
 
-Alternatively as the operations map directly to the carbon-resources library, the :doc:`api` documentation can be referred to for further information.
+Alternatively as the operations map directly to the resources library, the :doc:`api` documentation can be referred to for further information.
 
 Return Values
 -------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'carbon-resources'
+project = 'resources'
 copyright = 'Copyright © 2025 CCP ehf'
 author = 'CCP Games'
 release = '0.1'

--- a/doc/source/designDocuments.rst
+++ b/doc/source/designDocuments.rst
@@ -1,7 +1,7 @@
 Design Documents
 ================
 
-Documents contained in this section detail design approaches in  carbon-resources.
+Documents contained in this section detail design approaches in resources.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
-carbon-resources Documentation
+resources Documentation
 ==============================
 
-*carbon-resources* provides a suite of tools to manage/manipulate and deliver resources for Carbon titles.
+*resources* provides a suite of tools to manage/manipulate and deliver resources for Carbon titles.
 
 See :doc:`installation` section for further installation information.
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-carbon-resources supports Windows and macOS.
+resources supports Windows and macOS.
 
 Dependencies are sourced via `VCPKG <https://learn.microsoft.com/en-us/vcpkg/>`_
 

--- a/doc/source/tools.rst
+++ b/doc/source/tools.rst
@@ -1,10 +1,10 @@
 Tools
 =====
 
-carbon-resources consists of two base tools.
+*resources* consists of two base tools.
 
-1. carbon-resources library
-2. carbon-resources CLI
+1. resources library
+2. resources CLI
 
 More information can be found below.
 

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -179,7 +179,7 @@ namespace CarbonResources
     };
 
     /** @struct Result
-    *  @brief Return structure for carbon-resources operations
+    *  @brief Return structure for resources operations
     *  @var Result::type
     *  Type of result returned
     *  @var Result::info
@@ -248,14 +248,14 @@ namespace CarbonResources
 		unsigned int patch;
     };
 
-    static const Version S_LIBRARY_VERSION = { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH }; /*!< Current version of the carbon-resources */
+    static const Version S_LIBRARY_VERSION = { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH }; /*!< Current version of the resources */
 
-    static const Version S_DOCUMENT_VERSION = { 0, 1, 0 }; /*!< Maximum document version supported by carbon-resources */
+    static const Version S_DOCUMENT_VERSION = { 0, 1, 0 }; /*!< Maximum document version supported by resources */
 
     static const std::vector S_VALID_DOCUMENT_VERSIONS = { 
                                                             Version{ 0, 0, 0 },
 														    Version{ 0, 1, 0 }
-                                                         }; /*!< List of valid document version supported by carbon-resources */
+                                                         }; /*!< List of valid document version supported by resources */
 
 }
 

--- a/resourcesConfig.cmake
+++ b/resourcesConfig.cmake
@@ -1,7 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 # ${CMAKE_CURRENT_LIST_DIR}/project_name.cmake is generated automatically by cmake as part of the install step
-include(${CMAKE_CURRENT_LIST_DIR}/carbon-resources.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/resources.cmake)
 
 # Please specify all of this projects transitive dependencies here
 # In order for a consuming cmake project system to locate any transitive dependencies of this project, they must be

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -662,7 +662,7 @@ namespace CarbonResources
         {
 			if( statusCallback )
             {
-				statusCallback( StatusLevel::OVERVIEW, StatusProgressType::WARNING, 0, "Supplied resource group version greater than carbon-resources build max version. Some data may be lost during import." );
+				statusCallback( StatusLevel::OVERVIEW, StatusProgressType::WARNING, 0, "Supplied resource group version greater than resources build max version. Some data may be lost during import." );
             }
 			version = S_DOCUMENT_VERSION;
         }

--- a/src/src.md
+++ b/src/src.md
@@ -2,4 +2,4 @@
 
 This folder is where all the source files for the project can be stored.
 
-[See an example here](https://github.com/ccpgames/carbon-blue/tree/main/src)
+[See an example here](https://github.com/carbonengine/resources/tree/main/src)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(resources-test PUBLIC ${CMAKE_CURRENT_LIST_DIR}/inclu
 
 target_include_directories(resources-test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library carbon-resources resources-tools)
+target_link_libraries(resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library resources resources-tools)
 
 if(DEV_FEATURES)
     target_compile_definitions( resources-test PRIVATE DEV_FEATURES )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(resources-test PUBLIC ${CMAKE_CURRENT_LIST_DIR}/inclu
 
 target_include_directories(resources-test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library carbon-resources carbon-resources-tools)
+target_link_libraries(resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library carbon-resources resources-tools)
 
 if(DEV_FEATURES)
     target_compile_definitions( resources-test PRIVATE DEV_FEATURES )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SRC_FILES
     src/CliTestFixture.cpp
     src/CliTestFixture.h
     src/CarbonResourcesLibraryTest.cpp
-    src/CarbonResourcesCliTest.cpp
+    src/ResourcesCliTest.cpp
     src/ResourceToolsLibraryTest.cpp
 )
 
@@ -25,7 +25,7 @@ add_executable(carbon-resources-test ${SRC_FILES})
 target_compile_definitions(carbon-resources-test
         PRIVATE
         TEST_DATA_BASE_PATH="${CMAKE_SOURCE_DIR}/tests/testData"
-        CARBON_RESOURCES_CLI_EXE_NAME=\"$<TARGET_FILE_BASE_NAME:carbon-resources-cli>\")
+        CARBON_RESOURCES_CLI_EXE_NAME=\"$<TARGET_FILE_BASE_NAME:resources-cli>\")
 
 target_include_directories(carbon-resources-test PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -42,7 +42,7 @@ if(WIN32)
     # Get CLI exe
     add_custom_command(
         TARGET carbon-resources-test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:carbon-resources-cli> $<TARGET_FILE_DIR:carbon-resources-test>
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:carbon-resources-test>
         COMMAND_EXPAND_LISTS
     )
 
@@ -57,7 +57,7 @@ elseif(APPLE)
     # Get CLI exe
     add_custom_command(
             TARGET carbon-resources-test POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:carbon-resources-cli> $<TARGET_FILE_DIR:carbon-resources-test>
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:carbon-resources-test>
             COMMAND_EXPAND_LISTS
 
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-project(carbon-resources-test)
+project(resources-test)
 
 find_package(CURL CONFIG REQUIRED)
 find_package(GTest CONFIG REQUIRED)
@@ -11,53 +11,53 @@ find_package(tiny-process-library CONFIG REQUIRED)
 include(GoogleTest)
 
 set(SRC_FILES
-    src/CarbonResourcesTestFixture.cpp
-    src/CarbonResourcesTestFixture.h
+    src/ResourcesTestFixture.cpp
+    src/ResourcesTestFixture.h
     src/CliTestFixture.cpp
     src/CliTestFixture.h
-    src/CarbonResourcesLibraryTest.cpp
+    src/ResourcesLibraryTest.cpp
     src/ResourcesCliTest.cpp
     src/ResourceToolsLibraryTest.cpp
 )
 
-add_executable(carbon-resources-test ${SRC_FILES})
+add_executable(resources-test ${SRC_FILES})
 
-target_compile_definitions(carbon-resources-test
+target_compile_definitions(resources-test
         PRIVATE
         TEST_DATA_BASE_PATH="${CMAKE_SOURCE_DIR}/tests/testData"
         CARBON_RESOURCES_CLI_EXE_NAME=\"$<TARGET_FILE_BASE_NAME:resources-cli>\")
 
-target_include_directories(carbon-resources-test PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(resources-test PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_include_directories(carbon-resources-test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(resources-test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(carbon-resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library carbon-resources carbon-resources-tools)
+target_link_libraries(resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library carbon-resources carbon-resources-tools)
 
 if(DEV_FEATURES)
-    target_compile_definitions( carbon-resources-test PRIVATE DEV_FEATURES )
+    target_compile_definitions( resources-test PRIVATE DEV_FEATURES )
 endif()
 
 if(WIN32)
 
     # Get CLI exe
     add_custom_command(
-        TARGET carbon-resources-test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:carbon-resources-test>
+        TARGET resources-test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:resources-test>
         COMMAND_EXPAND_LISTS
     )
 
     # Binaries
     add_custom_command(
-        TARGET carbon-resources-test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:carbon-resources-test> $<TARGET_FILE_DIR:carbon-resources-test>
+        TARGET resources-test POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:resources-test> $<TARGET_FILE_DIR:resources-test>
         COMMAND_EXPAND_LISTS
     )
 
 elseif(APPLE)
     # Get CLI exe
     add_custom_command(
-            TARGET carbon-resources-test POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:carbon-resources-test>
+            TARGET resources-test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:resources-test>
             COMMAND_EXPAND_LISTS
 
     )
@@ -66,9 +66,9 @@ endif()
 cmake_path(SET TEST_DATA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/testData)
 
 gtest_discover_tests(
-        carbon-resources-test capiTests
+        resources-test capiTests
         PROPERTIES
             ENVIRONMENT "TEST_DATA_PATH=${TEST_DATA_PATH}"
-            WORKING_DIRECTORY $<TARGET_FILE_DIR:carbon-resources-test>  # So that we can find the CLI executable.
+            WORKING_DIRECTORY $<TARGET_FILE_DIR:resources-test>  # So that we can find the CLI executable.
         DISCOVERY_MODE PRE_TEST # Workaround to get builds working on macOS on ARM https://gitlab.kitware.com/cmake/cmake/-/issues/21845
 )

--- a/tests/src/CliTestFixture.h
+++ b/tests/src/CliTestFixture.h
@@ -7,9 +7,9 @@
 #include <vector>
 #include <string>
 
-#include "CarbonResourcesTestFixture.h"
+#include "ResourcesTestFixture.h"
 
-struct CliTestFixture : public CarbonResourcesTestFixture
+struct CliTestFixture : public ResourcesTestFixture
 {
 
     int RunCli( std::vector<std::string> &arguments, std::string &output );

--- a/tests/src/ResourceToolsLibraryTest.cpp
+++ b/tests/src/ResourceToolsLibraryTest.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-#include "CarbonResourcesTestFixture.h"
+#include "ResourcesTestFixture.h"
 #include "ChunkIndex.h"
 #include "FileDataStreamIn.h"
 #include "FileDataStreamOut.h"
@@ -21,7 +21,7 @@
 #include "Patching.h"
 #include "RollingChecksum.h"
 
-struct ResourceToolsTest : public CarbonResourcesTestFixture
+struct ResourceToolsTest : public ResourcesTestFixture
 {
 };
 

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -2,9 +2,9 @@
 
 #include "CliTestFixture.h"
 
-struct CarbonResourcesCliTest : public CliTestFixture{};
+struct ResourcesCliTest : public CliTestFixture{};
 
-TEST_F( CarbonResourcesCliTest, RunWithoutArguments )
+TEST_F( ResourcesCliTest, RunWithoutArguments )
 {
 	std::string output;
 
@@ -16,7 +16,7 @@ TEST_F( CarbonResourcesCliTest, RunWithoutArguments )
     ASSERT_EQ( res, 4 );
 }
 
-TEST_F( CarbonResourcesCliTest, RunWithNonesenseArguments )
+TEST_F( ResourcesCliTest, RunWithNonesenseArguments )
 {
 	std::string output;
 
@@ -30,7 +30,7 @@ TEST_F( CarbonResourcesCliTest, RunWithNonesenseArguments )
 	ASSERT_EQ( res, 3 );
 }
 
-TEST_F( CarbonResourcesCliTest, RunCreateGroupWithNoArguments )
+TEST_F( ResourcesCliTest, RunCreateGroupWithNoArguments )
 {
 	std::string output;
 
@@ -44,7 +44,7 @@ TEST_F( CarbonResourcesCliTest, RunCreateGroupWithNoArguments )
 	ASSERT_EQ( res, 2 );
 }
 
-TEST_F( CarbonResourcesCliTest, RunCreatePatchWithNoArguments )
+TEST_F( ResourcesCliTest, RunCreatePatchWithNoArguments )
 {
 	std::string output;
 
@@ -58,7 +58,7 @@ TEST_F( CarbonResourcesCliTest, RunCreatePatchWithNoArguments )
 	ASSERT_EQ( res, 2 );
 }
 
-TEST_F( CarbonResourcesCliTest, RunCreateBundleWithNoArguments )
+TEST_F( ResourcesCliTest, RunCreateBundleWithNoArguments )
 {
 	std::string output;
 
@@ -74,7 +74,7 @@ TEST_F( CarbonResourcesCliTest, RunCreateBundleWithNoArguments )
 
 #ifdef DEV_FEATURES
 
-TEST_F( CarbonResourcesCliTest, RunApplyPatchWithNoArguments )
+TEST_F( ResourcesCliTest, RunApplyPatchWithNoArguments )
 {
 	std::string output;
 
@@ -88,7 +88,7 @@ TEST_F( CarbonResourcesCliTest, RunApplyPatchWithNoArguments )
 	ASSERT_EQ( res, 2 );
 }
 
-TEST_F( CarbonResourcesCliTest, RunUnpackBundleWithNoArguments )
+TEST_F( ResourcesCliTest, RunUnpackBundleWithNoArguments )
 {
 	std::string output;
 
@@ -102,7 +102,7 @@ TEST_F( CarbonResourcesCliTest, RunUnpackBundleWithNoArguments )
 	ASSERT_EQ( res, 2 );
 }
 
-TEST_F( CarbonResourcesCliTest, CreateOperationWithInvalidInput )
+TEST_F( ResourcesCliTest, CreateOperationWithInvalidInput )
 {
 
 	std::string output;
@@ -125,7 +125,7 @@ TEST_F( CarbonResourcesCliTest, CreateOperationWithInvalidInput )
 }
 
 #endif
-TEST_F( CarbonResourcesCliTest, CreateResourceGroupFromDirectory )
+TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectory )
 {
 	std::string output;
 
@@ -157,7 +157,7 @@ TEST_F( CarbonResourcesCliTest, CreateResourceGroupFromDirectory )
     EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
 }
 
-TEST_F( CarbonResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
+TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
 {
 	std::string output;
 
@@ -192,7 +192,7 @@ TEST_F( CarbonResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentForma
     EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.csv" ) );
 }
 
-TEST_F( CarbonResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithPrefix )
+TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithPrefix )
 {
 	std::string output;
 
@@ -230,7 +230,7 @@ TEST_F( CarbonResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentForma
     EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroupPrefixed.csv" ) );
 }
 
-TEST_F( CarbonResourcesCliTest, CreateBundle )
+TEST_F( ResourcesCliTest, CreateBundle )
 {
 	std::string output;
 
@@ -277,7 +277,7 @@ TEST_F( CarbonResourcesCliTest, CreateBundle )
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "CreateBundleOut" ) );
 }
 
-TEST_F( CarbonResourcesCliTest, RemoveResourcesWithUnknownResourceIgnoreOnResourceNotFound )
+TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResourceIgnoreOnResourceNotFound )
 {
 	std::string output;
 
@@ -309,7 +309,7 @@ TEST_F( CarbonResourcesCliTest, RemoveResourcesWithUnknownResourceIgnoreOnResour
 	EXPECT_EQ( res, 0 );
 }
 
-TEST_F( CarbonResourcesCliTest, RemoveResourcesWithUnknownResourceWithInvalidPathToResourcesFile )
+TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResourceWithInvalidPathToResourcesFile )
 {
 	std::string output;
 
@@ -339,7 +339,7 @@ TEST_F( CarbonResourcesCliTest, RemoveResourcesWithUnknownResourceWithInvalidPat
 	EXPECT_EQ( res, 1 );
 }
 
-TEST_F( CarbonResourcesCliTest, RemoveResourcesWithUnknownResource )
+TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResource )
 {
 	std::string output;
 
@@ -370,7 +370,7 @@ TEST_F( CarbonResourcesCliTest, RemoveResourcesWithUnknownResource )
 
 }
 
-TEST_F( CarbonResourcesCliTest, RemoveResources )
+TEST_F( ResourcesCliTest, RemoveResources )
 {
 	std::string output;
 
@@ -405,7 +405,7 @@ TEST_F( CarbonResourcesCliTest, RemoveResources )
 	EXPECT_TRUE( FilesMatch( goldFile, resourceGroupAfterRemovePath ) );
 }
 
-TEST_F( CarbonResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
+TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
 {
 	std::string output;
 
@@ -444,7 +444,7 @@ TEST_F( CarbonResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
 	EXPECT_TRUE( FilesMatch( goldFile, outputPath ) );
 }
 
-TEST_F( CarbonResourcesCliTest, DiffResourceGroupsWithTwoChanges )
+TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoChanges )
 {
 	std::string output;
 
@@ -483,7 +483,7 @@ TEST_F( CarbonResourcesCliTest, DiffResourceGroupsWithTwoChanges )
 	EXPECT_TRUE( FilesMatch( goldFile, outputPath ) );
 }
 
-TEST_F( CarbonResourcesCliTest, DiffResourceGroupsWithTwoSubtractions )
+TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoSubtractions )
 {
 	std::string output;
 
@@ -522,7 +522,7 @@ TEST_F( CarbonResourcesCliTest, DiffResourceGroupsWithTwoSubtractions )
 	EXPECT_TRUE( FilesMatch( goldFile, outputPath ) );
 }
 
-TEST_F( CarbonResourcesCliTest, MergeGroup )
+TEST_F( ResourcesCliTest, MergeGroup )
 {
 	std::string output;
 
@@ -557,7 +557,7 @@ TEST_F( CarbonResourcesCliTest, MergeGroup )
 	EXPECT_TRUE( FilesMatch( goldFile, mergedOutputPath ) );
 }
 
-TEST_F( CarbonResourcesCliTest, CreatePatch )
+TEST_F( ResourcesCliTest, CreatePatch )
 {
 	std::string output;
 
@@ -613,7 +613,7 @@ TEST_F( CarbonResourcesCliTest, CreatePatch )
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "PatchOut/Patches" ) );
 }
 
-TEST_F( CarbonResourcesCliTest, CreateGroup )
+TEST_F( ResourcesCliTest, CreateGroup )
 {
 	std::string output;
 
@@ -630,7 +630,7 @@ TEST_F( CarbonResourcesCliTest, CreateGroup )
 
     arguments.push_back( "--output-file" );
 
-    std::string outputFilename = "CarbonResourcesCliTestResourceGroup.yaml";
+    std::string outputFilename = "ResourcesCliTestResourceGroup.yaml";
 
     arguments.push_back( outputFilename );
 
@@ -651,7 +651,7 @@ TEST_F( CarbonResourcesCliTest, CreateGroup )
 
 #ifdef DEV_FEATURES
 
-TEST_F( CarbonResourcesCliTest, ApplyPatch )
+TEST_F( ResourcesCliTest, ApplyPatch )
 {
 	std::string output;
 
@@ -706,7 +706,7 @@ TEST_F( CarbonResourcesCliTest, ApplyPatch )
 	EXPECT_TRUE( DirectoryIsSubset( outputBasePath, goldDirectory ) );
 }
 
-TEST_F( CarbonResourcesCliTest, UnpackBundle )
+TEST_F( ResourcesCliTest, UnpackBundle )
 {
 	std::string output;
 

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -4,18 +4,18 @@
 #include <BundleResourceGroup.h>
 #include <PatchResourceGroup.h>
 
-#include "CarbonResourcesTestFixture.h"
+#include "ResourcesTestFixture.h"
 
 #include <gtest/gtest.h>
 
 #include <FileDataStreamOut.h>
 
-struct CarbonResourcesLibraryTest : public CarbonResourcesTestFixture{};
+struct ResourcesLibraryTest : public ResourcesTestFixture{};
 
 // Import ResourceGroup V0.0.0
 // Export should output as V0.1.0
 // This is the only instance that exporting a file of a lower version results in a version bump
-TEST_F( CarbonResourcesLibraryTest, BinaryGroupImportExport_V_0_0_0_To_V_0_1_0 )
+TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_0_0_To_V_0_1_0 )
 {
 
 	CarbonResources::ResourceGroup binaryResourceGroup;
@@ -38,7 +38,7 @@ TEST_F( CarbonResourcesLibraryTest, BinaryGroupImportExport_V_0_0_0_To_V_0_1_0 )
 }
 
 // Import a BinaryResourceGroup v0.1.0 and export it again checking input == output
-TEST_F( CarbonResourcesLibraryTest, BinaryGroupImportExport_V_0_1_0 )
+TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_1_0 )
 {
 	CarbonResources::ResourceGroup binaryResourceGroup;
 
@@ -60,7 +60,7 @@ TEST_F( CarbonResourcesLibraryTest, BinaryGroupImportExport_V_0_1_0 )
 // Import ResourceGroup V0.0.0 
 // Export should output as V0.1.0
 // This is the only instance that exporting a file of a lower version results in a version bump
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0 )
+TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0 )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -81,7 +81,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0
 	EXPECT_TRUE( FilesMatch( exportParams.filename, goldStandardFilename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, ImportEmptyResourceGroup )
+TEST_F( ResourcesLibraryTest, ImportEmptyResourceGroup )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -89,7 +89,7 @@ TEST_F( CarbonResourcesLibraryTest, ImportEmptyResourceGroup )
 	EXPECT_EQ(resourceGroup.ImportFromFile( importParams ).type,CarbonResources::ResultType::SUCCESS);
 }
 
-TEST_F( CarbonResourcesLibraryTest, ImportResourceGroupWithOutOfBoundsBinaryOperation )
+TEST_F( ResourcesLibraryTest, ImportResourceGroupWithOutOfBoundsBinaryOperation )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -128,7 +128,7 @@ CarbonResources::Result AttemptImportResourceGroupMissingParameter( const std::s
 
 // Import a ResourceGroup with missing parameters that are expected for the version provided
 // This should fail gracefully and give appropriate feedback to user
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupHandleImportMissingParametersForVersion )
+TEST_F( ResourcesLibraryTest, ResourceGroupHandleImportMissingParametersForVersion )
 {
 	std::filesystem::path emptyResourceGroupPath = GetTestFileFileAbsolutePath( "ResourceGroups/EmptyResourceGroup.yaml" );
 	EXPECT_EQ( AttemptImportResourceGroupMissingParameter( "Version", emptyResourceGroupPath ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_GROUP );
@@ -140,7 +140,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupHandleImportMissingParametersFo
 }
 
 
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadInvalidYaml )
+TEST_F( ResourcesLibraryTest, ResourceGroupLoadInvalidYaml )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -150,7 +150,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadInvalidYaml )
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::FAILED_TO_PARSE_YAML );
 }
 
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadInvalidCsv )
+TEST_F( ResourcesLibraryTest, ResourceGroupLoadInvalidCsv )
 {
 
 	CarbonResources::ResourceGroup resourceGroup;
@@ -162,7 +162,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadInvalidCsv )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadCsvWithInvalidCompressedSizeField )
+TEST_F( ResourcesLibraryTest, ResourceGroupLoadCsvWithInvalidCompressedSizeField )
 {
 
 	CarbonResources::ResourceGroup resourceGroup;
@@ -173,7 +173,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadCsvWithInvalidCompressedSiz
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_INPUT );
 }
 
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadEmptyCsv )
+TEST_F( ResourcesLibraryTest, ResourceGroupLoadEmptyCsv )
 {
 
 	CarbonResources::ResourceGroup resourceGroup;
@@ -185,7 +185,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadEmptyCsv )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadNonexistantFileFails )
+TEST_F( ResourcesLibraryTest, ResourceGroupLoadNonexistantFileFails )
 {
 
 	CarbonResources::ResourceGroup resourceGroup;
@@ -196,7 +196,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupLoadNonexistantFileFails )
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::FAILED_TO_OPEN_FILE );
 }
 
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupWithInvalidExtensionFails )
+TEST_F( ResourcesLibraryTest, ResourceGroupWithInvalidExtensionFails )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -209,7 +209,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupWithInvalidExtensionFails )
 // Import a ResourceGroup with version greater than current document minor version specified in enums.h
 // This should open ignoring anything extra added in the future version
 // The version of the imported ResourceGroup should be set at the max supported version in enums.h
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportNewerMinorVersion )
+TEST_F( ResourcesLibraryTest, ResourceGroupImportNewerMinorVersion )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -219,7 +219,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportNewerMinorVersion )
 
 // Import a ResourceGroup with version greater than current document major version specified in enums.h
 // This should gracefully fail to open
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportNewerMajorVersion )
+TEST_F( ResourcesLibraryTest, ResourceGroupImportNewerMajorVersion )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -229,7 +229,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportNewerMajorVersion )
 
 // Import a ResourceGroup that doesn't exist
 // This should gracefully fail
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportNonExistantFile )
+TEST_F( ResourcesLibraryTest, ResourceGroupImportNonExistantFile )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -241,7 +241,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportNonExistantFile )
 }
 
 // Import a ResourceGroup v0.1.0 and export it again checking input == output
-TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportExport_V_0_1_0 )
+TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_1_0 )
 {
 
 	CarbonResources::ResourceGroup resourceGroup;
@@ -261,7 +261,7 @@ TEST_F( CarbonResourcesLibraryTest, ResourceGroupImportExport_V_0_1_0 )
 	EXPECT_TRUE( FilesMatch( importParams.filename, exportParams.filename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, UnpackBundle )
+TEST_F( ResourcesLibraryTest, UnpackBundle )
 {
 	// Load the bundle file
 	CarbonResources::BundleResourceGroup bundleResourceGroup;
@@ -293,7 +293,7 @@ TEST_F( CarbonResourcesLibraryTest, UnpackBundle )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
+TEST_F( ResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
 {
 	// Load the bundle file
 	CarbonResources::BundleResourceGroup bundleResourceGroup;
@@ -321,7 +321,7 @@ TEST_F( CarbonResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocal
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, UnpackRemoteBundleAsLocal )
+TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 {
 	// Import ResourceGroup
 	CarbonResources::ResourceGroup resourceGroup;
@@ -359,7 +359,7 @@ TEST_F( CarbonResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 	EXPECT_EQ( bundleResourceGroup.Unpack( bundleUnpackParams ).type, CarbonResources::ResultType::FAILED_TO_PARSE_YAML );
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreateBundleWithZeroChunkSize )
+TEST_F( ResourcesLibraryTest, CreateBundleWithZeroChunkSize )
 {
 	// Import ResourceGroup
 	CarbonResources::ResourceGroup resourceGroup;
@@ -396,7 +396,7 @@ TEST_F( CarbonResourcesLibraryTest, CreateBundleWithZeroChunkSize )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreateBundle )
+TEST_F( ResourcesLibraryTest, CreateBundle )
 {
 	// Import ResourceGroup
 	CarbonResources::ResourceGroup resourceGroup;
@@ -436,7 +436,7 @@ TEST_F( CarbonResourcesLibraryTest, CreateBundle )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreateAndUnpackBundle )
+TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
 {
 	// Import ResourceGroup
 	CarbonResources::ResourceGroup resourceGroup;
@@ -503,7 +503,7 @@ TEST_F( CarbonResourcesLibraryTest, CreateAndUnpackBundle )
 	EXPECT_TRUE( std::filesystem::exists( unpackedGroupPath ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, ApplyPatch )
+TEST_F( ResourcesLibraryTest, ApplyPatch )
 {
 	// Load the patch file
 	CarbonResources::PatchResourceGroup patchResourceGroup;
@@ -550,7 +550,7 @@ TEST_F( CarbonResourcesLibraryTest, ApplyPatch )
 	EXPECT_TRUE( DirectoryIsSubset( patchApplyParams.resourcesToPatchDestinationSettings.basePath , goldDirectory ));
 
 }
-TEST_F( CarbonResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
+TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 {
 	// Previous ResourceGroup
 	CarbonResources::ResourceGroup resourceGroupPrevious;
@@ -606,7 +606,7 @@ TEST_F( CarbonResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreatePatch )
+TEST_F( ResourcesLibraryTest, CreatePatch )
 {
     // Previous ResourceGroup
 	CarbonResources::ResourceGroup resourceGroupPrevious;
@@ -667,7 +667,7 @@ TEST_F( CarbonResourcesLibraryTest, CreatePatch )
     
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreatePatchZeroInputChunkSize )
+TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )
 {
 	// Previous ResourceGroup
 	CarbonResources::ResourceGroup resourceGroupPrevious;
@@ -721,7 +721,7 @@ TEST_F( CarbonResourcesLibraryTest, CreatePatchZeroInputChunkSize )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, ApplyPatchWithChunking )
+TEST_F( ResourcesLibraryTest, ApplyPatchWithChunking )
 {
 	// Load the patch file
 	CarbonResources::PatchResourceGroup patchResourceGroup;
@@ -764,7 +764,7 @@ TEST_F( CarbonResourcesLibraryTest, ApplyPatchWithChunking )
 	EXPECT_TRUE( FilesMatch( nextTestResource, patchApplyParams.resourcesToPatchDestinationSettings.basePath / "testresource2.txt" ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreatePatchWithChunking )
+TEST_F( ResourcesLibraryTest, CreatePatchWithChunking )
 {
 	// Previous ResourceGroup
 	CarbonResources::ResourceGroup resourceGroupPrevious;
@@ -825,7 +825,7 @@ TEST_F( CarbonResourcesLibraryTest, CreatePatchWithChunking )
 	EXPECT_TRUE( DirectoryIsSubset(  goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreateResourceGroupFromDirectory )
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -851,7 +851,7 @@ TEST_F( CarbonResourcesLibraryTest, CreateResourceGroupFromDirectory )
     EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreateResourceGroupFromDirectoryOutputPathIsInvalid )
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryOutputPathIsInvalid )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -869,7 +869,7 @@ TEST_F( CarbonResourcesLibraryTest, CreateResourceGroupFromDirectoryOutputPathIs
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, CreateResourceGroupFailsWithInvalidInputDirectory )
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFailsWithInvalidInputDirectory )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -880,7 +880,7 @@ TEST_F( CarbonResourcesLibraryTest, CreateResourceGroupFailsWithInvalidInputDire
 	EXPECT_EQ( resourceGroup.CreateFromDirectory( createResourceGroupParams ).type, CarbonResources::ResultType::INPUT_DIRECTORY_DOESNT_EXIST);
 }
 
-TEST_F( CarbonResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
+TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 {
     // Load base group
 	CarbonResources::ResourceGroup baseResourceGroup;
@@ -929,7 +929,7 @@ TEST_F( CarbonResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 
 }
 
-TEST_F( CarbonResourcesLibraryTest, DiffResourceGroupsWithTwoChanges )
+TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoChanges )
 {
 	// Load base group
 	CarbonResources::ResourceGroup baseResourceGroup;
@@ -977,7 +977,7 @@ TEST_F( CarbonResourcesLibraryTest, DiffResourceGroupsWithTwoChanges )
 	EXPECT_EQ( additions.size(), 2 );
 }
 
-TEST_F( CarbonResourcesLibraryTest, DiffResourceGroupsWithTwoSubtractions )
+TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoSubtractions )
 {
 	// Load base group
 	CarbonResources::ResourceGroup baseResourceGroup;
@@ -1025,7 +1025,7 @@ TEST_F( CarbonResourcesLibraryTest, DiffResourceGroupsWithTwoSubtractions )
 	EXPECT_EQ( subtractions.size(), 2 );
 }
 
-TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsAdditive )
+TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -1076,7 +1076,7 @@ TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsAdditive )
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsIdentical )
+TEST_F( ResourcesLibraryTest, MergeResourceGroupsIdentical )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -1127,7 +1127,7 @@ TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsIdentical )
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
+TEST_F( ResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -1180,7 +1180,7 @@ TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
+TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
@@ -1233,7 +1233,7 @@ TEST_F( CarbonResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
-TEST_F( CarbonResourcesLibraryTest, RemoveResource )
+TEST_F( ResourcesLibraryTest, RemoveResource )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 

--- a/tests/src/ResourcesTestFixture.cpp
+++ b/tests/src/ResourcesTestFixture.cpp
@@ -1,6 +1,6 @@
 // Copyright © 2025 CCP ehf.
 
-#include "CarbonResourcesTestFixture.h"
+#include "ResourcesTestFixture.h"
 
 #include <process.hpp>
 
@@ -12,22 +12,22 @@
 
 #include <ResourceTools.h>
 
-void CarbonResourcesTestFixture::SetUp()
+void ResourcesTestFixture::SetUp()
 {
 
 }
 
-void CarbonResourcesTestFixture::TearDown()
+void ResourcesTestFixture::TearDown()
 {
 	
 }
 
-bool CarbonResourcesTestFixture::FileExists( const std::filesystem::path& filePath )
+bool ResourcesTestFixture::FileExists( const std::filesystem::path& filePath )
 {
 	return std::filesystem::exists( filePath );
 }
 
-bool CarbonResourcesTestFixture::FilesMatch( const std::filesystem::path& file1Path, const std::filesystem::path& file2Path )
+bool ResourcesTestFixture::FilesMatch( const std::filesystem::path& file1Path, const std::filesystem::path& file2Path )
 {
     // Open files generate data checksums and compare
 
@@ -80,7 +80,7 @@ bool CarbonResourcesTestFixture::FilesMatch( const std::filesystem::path& file1P
     
 }
 
-bool CarbonResourcesTestFixture::DirectoryIsSubset( const std::filesystem::path& dir1, const std::filesystem::path& dir2 )
+bool ResourcesTestFixture::DirectoryIsSubset( const std::filesystem::path& dir1, const std::filesystem::path& dir2 )
 {
 	for( auto entry : std::filesystem::recursive_directory_iterator( dir1 ) )
 	{
@@ -96,7 +96,7 @@ bool CarbonResourcesTestFixture::DirectoryIsSubset( const std::filesystem::path&
 	return true;
 }
 
-std::filesystem::path CarbonResourcesTestFixture::GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath )
+std::filesystem::path ResourcesTestFixture::GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath )
 {
     std::filesystem::path basePath( TEST_DATA_BASE_PATH );
 

--- a/tests/src/ResourcesTestFixture.h
+++ b/tests/src/ResourcesTestFixture.h
@@ -10,7 +10,7 @@
 
 #include <filesystem>
 
-struct CarbonResourcesTestFixture : public ::testing::Test
+struct ResourcesTestFixture : public ::testing::Test
 {
 	void SetUp();
 

--- a/tests/tests.md
+++ b/tests/tests.md
@@ -2,7 +2,4 @@
 
 This folder is where all the tests for the project should be stored, whether they be Python tests or C++ tests.
 
-[See a C++ example here](https://github.com/ccpgames/carbon-destiny/tree/main/tests)
-
-[See a Python example here](https://github.com/ccpgames/carbon-fsd/tree/main/tests)
-
+[See a C++ example here](https://github.com/carbonengine/resources/tree/main/tests/src)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SRC_FILES
 
 add_library(carbon-resources-tools STATIC ${SRC_FILES})
 
-#target_link_libraries(carbon-resources-cli P)
+#target_link_libraries(resources-cli P)
 find_package(bsdiff CONFIG REQUIRED)
 
 get_target_property(_SOURCES carbon-resources-tools SOURCES)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.31)
-project(carbon-resources-tools VERSION 1.0.0)
+project(resources-tools VERSION 1.0.0)
 
 find_package(cryptopp CONFIG REQUIRED)
 find_package(CURL CONFIG REQUIRED)
@@ -40,21 +40,21 @@ set(SRC_FILES
     src/RollingChecksum.cpp
 )
 
-add_library(carbon-resources-tools STATIC ${SRC_FILES})
+add_library(resources-tools STATIC ${SRC_FILES})
 
 #target_link_libraries(resources-cli P)
 find_package(bsdiff CONFIG REQUIRED)
 
-get_target_property(_SOURCES carbon-resources-tools SOURCES)
+get_target_property(_SOURCES resources-tools SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
         PREFIX "Sources"
         FILES ${_SOURCES}
 )
 
 if(WIN32)
-    target_compile_definitions(carbon-resources-tools PRIVATE NOMINMAX) # Do not define min/max macros.
+    target_compile_definitions(resources-tools PRIVATE NOMINMAX) # Do not define min/max macros.
 endif()
 
-target_link_libraries(carbon-resources-tools PRIVATE cryptopp::cryptopp CURL::libcurl ZLIB::ZLIB static_bsdiff)
+target_link_libraries(resources-tools PRIVATE cryptopp::cryptopp CURL::libcurl ZLIB::ZLIB static_bsdiff)
 
-target_include_directories(carbon-resources-tools PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(resources-tools PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,7 +42,6 @@ set(SRC_FILES
 
 add_library(resources-tools STATIC ${SRC_FILES})
 
-#target_link_libraries(resources-cli P)
 find_package(bsdiff CONFIG REQUIRED)
 
 get_target_property(_SOURCES resources-tools SOURCES)


### PR DESCRIPTION
As part of the prep work for taking the project open source, do the following:
- Renaming carbon-resources to resources (remove name stuttering)
- Add in a Licence and Notice info.
- Update hyperlinks in .md files