### PR TITLE
Apply .clang-format to all files in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ CMakeUserPresets.json
 ### VCPKG ###
 # Temporary measure which fixes build agent issue
 vcpkg_registry_cache/
-/vcpkg_registry_cache/git/.vcpkg-lock

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ CMakeUserPresets.json
 ### VCPKG ###
 # Temporary measure which fixes build agent issue
 vcpkg_registry_cache/
+/vcpkg_registry_cache/git/.vcpkg-lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,17 @@
 cmake_minimum_required(VERSION 3.31)
 project(resources VERSION 3.0.0)
 
-if(NOT DEFINED ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
+if (NOT DEFINED ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
     message(FATAL_ERROR "Missing required environment variable CCP_EVE_PERFORCE_BRANCH_PATH")
-elseif(NOT IS_ABSOLUTE $ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
+elseif (NOT IS_ABSOLUTE $ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
     message(FATAL_ERROR "CCP_EVE_PERFORCE_BRANCH_PATH needs to be an absolute path")
-elseif(NOT EXISTS $ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
+elseif (NOT EXISTS $ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
     message(FATAL_ERROR "CCP_EVE_PERFORCE_BRANCH_PATH is pointing at a non-existing location $ENV{CCP_EVE_PERFORCE_BRANCH_PATH}")
-elseif(NOT IS_DIRECTORY $ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
+elseif (NOT IS_DIRECTORY $ENV{CCP_EVE_PERFORCE_BRANCH_PATH})
     message(FATAL_ERROR "CCP_EVE_PERFORCE_BRANCH_PATH needs to be a directory")
-else()
+else ()
     message(STATUS "Using CCP_EVE_PERFORCE_BRANCH_PATH located at $ENV{CCP_EVE_PERFORCE_BRANCH_PATH}")
-endif()
+endif ()
 
 file(TO_CMAKE_PATH "$ENV{CCP_EVE_PERFORCE_BRANCH_PATH}" BRANCH_ROOT_DIR)
 list(INSERT CMAKE_MODULE_PATH 0 ${BRANCH_ROOT_DIR}/cmake)
@@ -29,42 +29,42 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_subdirectory(tools)
 
 set(SRC_FILES
-    include/BundleResourceGroup.h
-    include/Exports.h
-    include/PatchResourceGroup.h
-    include/ResourceGroup.h
-    include/Enums.h
-    include/Version.h
+        include/BundleResourceGroup.h
+        include/Exports.h
+        include/PatchResourceGroup.h
+        include/ResourceGroup.h
+        include/Enums.h
+        include/Version.h
 
-    src/BundleResourceGroup.cpp
-    src/BundleResourceGroupImpl.cpp
-    src/BundleResourceGroupImpl.h
-    src/PatchResourceGroup.cpp
-    src/PatchResourceGroupImpl.cpp
-    src/PatchResourceGroupImpl.h
-    src/ResourceGroup.cpp
-    src/ResourceGroupFactory.h
-    src/ResourceGroupFactory.cpp
-    src/ResourceGroupImpl.cpp
-    src/ResourceGroupImpl.h
-    src/Enums.cpp
-    src/VersionInternal.h
-    src/VersionInternal.cpp
+        src/BundleResourceGroup.cpp
+        src/BundleResourceGroupImpl.cpp
+        src/BundleResourceGroupImpl.h
+        src/PatchResourceGroup.cpp
+        src/PatchResourceGroupImpl.cpp
+        src/PatchResourceGroupImpl.h
+        src/ResourceGroup.cpp
+        src/ResourceGroupFactory.h
+        src/ResourceGroupFactory.cpp
+        src/ResourceGroupImpl.cpp
+        src/ResourceGroupImpl.h
+        src/Enums.cpp
+        src/VersionInternal.h
+        src/VersionInternal.cpp
 
-    src/ResourceInfo/BundleResourceInfo.cpp
-    src/ResourceInfo/BundleResourceInfo.h
-    src/ResourceInfo/PatchResourceInfo.cpp
-    src/ResourceInfo/PatchResourceInfo.h
-    src/ResourceInfo/ResourceInfo.cpp
-    src/ResourceInfo/ResourceInfo.h
-    src/ResourceInfo/ResourceGroupInfo.h
-    src/ResourceInfo/ResourceGroupInfo.cpp
-    src/ResourceInfo/PatchResourceGroupInfo.h
-    src/ResourceInfo/PatchResourceGroupInfo.cpp
-    src/ResourceInfo/BundleResourceGroupInfo.h
-    src/ResourceInfo/BundleResourceGroupInfo.cpp
-    src/ParameterVersion.h
-    src/ParameterVersion.cpp
+        src/ResourceInfo/BundleResourceInfo.cpp
+        src/ResourceInfo/BundleResourceInfo.h
+        src/ResourceInfo/PatchResourceInfo.cpp
+        src/ResourceInfo/PatchResourceInfo.h
+        src/ResourceInfo/ResourceInfo.cpp
+        src/ResourceInfo/ResourceInfo.h
+        src/ResourceInfo/ResourceGroupInfo.h
+        src/ResourceInfo/ResourceGroupInfo.cpp
+        src/ResourceInfo/PatchResourceGroupInfo.h
+        src/ResourceInfo/PatchResourceGroupInfo.cpp
+        src/ResourceInfo/BundleResourceGroupInfo.h
+        src/ResourceInfo/BundleResourceGroupInfo.cpp
+        src/ParameterVersion.h
+        src/ParameterVersion.cpp
 )
 
 ccp_add_library(resources SHARED ${SRC_FILES})
@@ -75,9 +75,9 @@ target_compile_definitions(resources PRIVATE EXPORT_LIBRARY)
 # Added as config
 configure_file(src/Version.h.in include/Version.h @ONLY)
 
-if(WIN32)
+if (WIN32)
     target_compile_definitions(resources PRIVATE NOMINMAX) # Do not define min/max macros.
-endif()
+endif ()
 
 target_link_libraries(resources PRIVATE resources-tools yaml-cpp::yaml-cpp)
 
@@ -103,9 +103,9 @@ set_target_properties(resources-static PROPERTIES OUTPUT_NAME "_resources-static
 
 target_compile_definitions(resources-static PUBLIC CARBON_RESOURCES_STATIC)
 
-if(WIN32)
+if (WIN32)
     target_compile_definitions(resources-static PRIVATE NOMINMAX) # Do not define min/max macros.
-endif()
+endif ()
 
 target_link_libraries(resources-static PRIVATE $<BUILD_LOCAL_INTERFACE:resources-tools> yaml-cpp::yaml-cpp)
 
@@ -124,19 +124,19 @@ add_subdirectory(tests)
 
 
 # Provide an install target if this is the top level project only
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # Determine if/when to generate/build documentation. The rules are as follows:
     # - If running locally - Build documentation is OFF by default
     # - If running on a build agent (TeamCity) - Build documentation is ON by default
     # - If -DBUILD_DOCUMENTATION=ON/OFF flag is explicitly set, use it.
     set(BUILD_DOCUMENTATION_DEFAULT_FLAG OFF)
-    if(DEFINED ENV{TEAMCITY_VERSION})
+    if (DEFINED ENV{TEAMCITY_VERSION})
         set(BUILD_DOCUMENTATION_DEFAULT_FLAG ON)
-    endif()
+    endif ()
     message(STATUS "Document generation settings: default=${BUILD_DOCUMENTATION_DEFAULT_FLAG}, option BUILD_DOCUMENTATION=${BUILD_DOCUMENTATION}")
     option(BUILD_DOCUMENTATION "Build Documentation" ${BUILD_DOCUMENTATION_DEFAULT_FLAG})
 
-    if(BUILD_DOCUMENTATION)
+    if (BUILD_DOCUMENTATION)
         # Run sphinx
         set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/doc/source)
         set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/doc/build)
@@ -155,10 +155,10 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 
         # Ensure that resources is built before Spinx target
         add_dependencies(Sphinx resources)
-    endif()
+    endif ()
 
     set(INSTALL_BIN_ONLY OFF CACHE BOOL "Do not Install configuration files meant to be read by projects using this project as a dependency (Cmake Config/ header files etc . . .). Set this to ON when installing this component to the perforce vendor folder")
-    if(INSTALL_BIN_ONLY)
+    if (INSTALL_BIN_ONLY)
         # Install rule to ensure that our runtime files are in the expected, platform-specific folder
         install(
                 TARGETS resources resources-static
@@ -168,7 +168,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
                 ARCHIVE DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
                 RUNTIME DESTINATION bin/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
         )
-    else()
+    else ()
         # Install rule to ensure that our runtime and linker files are in the expected, platform-specific folders
         install(
                 TARGETS resources resources-static
@@ -190,6 +190,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         install(
                 FILES resourcesConfig.cmake
                 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/resources)
-    endif()
+    endif ()
 
-endif()
+endif ()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -7,28 +7,28 @@ find_package(argparse CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)
 
 set(SRC_FILES
-    src/ApplyPatchCliOperation.h
-    src/ApplyPatchCliOperation.cpp
-    src/Cli.cpp
-    src/Cli.h
-    src/CliOperation.cpp
-    src/CliOperation.h
-    src/CreateBundleCliOperation.cpp
-    src/CreateBundleCliOperation.h
-    src/CreatePatchCliOperation.cpp
-    src/CreatePatchCliOperation.h
-    src/CreateResourceGroupCliOperation.cpp
-    src/CreateResourceGroupCliOperation.h
-    src/Defines.h
-    src/DiffResourceGroupCliOperation.cpp
-    src/DiffResourceGroupCliOperation.h
-    src/main.cpp
-    src/MergeResourceGroupCliOperation.cpp
-    src/MergeResourceGroupCliOperation.h
-    src/RemoveResourcesCliOperation.cpp
-    src/RemoveResourcesCliOperation.h
-    src/UnpackBundleCliOperation.cpp
-    src/UnpackBundleCliOperation.h
+        src/ApplyPatchCliOperation.h
+        src/ApplyPatchCliOperation.cpp
+        src/Cli.cpp
+        src/Cli.h
+        src/CliOperation.cpp
+        src/CliOperation.h
+        src/CreateBundleCliOperation.cpp
+        src/CreateBundleCliOperation.h
+        src/CreatePatchCliOperation.cpp
+        src/CreatePatchCliOperation.h
+        src/CreateResourceGroupCliOperation.cpp
+        src/CreateResourceGroupCliOperation.h
+        src/Defines.h
+        src/DiffResourceGroupCliOperation.cpp
+        src/DiffResourceGroupCliOperation.h
+        src/main.cpp
+        src/MergeResourceGroupCliOperation.cpp
+        src/MergeResourceGroupCliOperation.h
+        src/RemoveResourcesCliOperation.cpp
+        src/RemoveResourcesCliOperation.h
+        src/UnpackBundleCliOperation.cpp
+        src/UnpackBundleCliOperation.h
 )
 
 ccp_add_executable(resources-cli ${SRC_FILES})
@@ -43,9 +43,9 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
 
 option(DEV_FEATURES "Expose unsupported features")
 
-if(DEV_FEATURES)
-    target_compile_definitions( resources-cli PRIVATE DEV_FEATURES )
-endif()
+if (DEV_FEATURES)
+    target_compile_definitions(resources-cli PRIVATE DEV_FEATURES)
+endif ()
 
 set_target_properties(resources-cli PROPERTIES OUTPUT_NAME "resources")
 

--- a/cli/src/ApplyPatchCliOperation.cpp
+++ b/cli/src/ApplyPatchCliOperation.cpp
@@ -8,16 +8,16 @@
 #include <argparse/argparse.hpp>
 
 ApplyPatchCliOperation::ApplyPatchCliOperation() :
-	CliOperation("apply-patch", "Applies a patch supplied via a Patch Resource Group to a directory [Only available in extended feature development build]"),
-	m_patchResourceGroupPathArgumentId("patch-resource-group-path"),
-	m_patchBinariesSourceBasePathsArgumentId("--patch-binaries-base-path"),
-	m_patchBinariesSourceTypeArgumentId("--patch-binaries-source-type"),
-	m_resourcesToPatchSourceBasePathsArgumentId("--resources-to-patch-base-path"),
-	m_resourcesToPatchSourceTypeArgumentId("--resources-to-patch-source-type"),
-	m_nextResourcesBasePathsArgumentId("--next-resources-base-path"),
-	m_nextResourcesSourceTypeArgumentId("--next-resources-source-type"),
-	m_resourcesToPatchDestinationPathArgumentId("--output-base-path"),
-	m_resourcesToPatchDestinationTypeArgumentId("--output-destination-type")
+	CliOperation( "apply-patch", "Applies a patch supplied via a Patch Resource Group to a directory [Only available in extended feature development build]" ),
+	m_patchResourceGroupPathArgumentId( "patch-resource-group-path" ),
+	m_patchBinariesSourceBasePathsArgumentId( "--patch-binaries-base-path" ),
+	m_patchBinariesSourceTypeArgumentId( "--patch-binaries-source-type" ),
+	m_resourcesToPatchSourceBasePathsArgumentId( "--resources-to-patch-base-path" ),
+	m_resourcesToPatchSourceTypeArgumentId( "--resources-to-patch-source-type" ),
+	m_nextResourcesBasePathsArgumentId( "--next-resources-base-path" ),
+	m_nextResourcesSourceTypeArgumentId( "--next-resources-source-type" ),
+	m_resourcesToPatchDestinationPathArgumentId( "--output-base-path" ),
+	m_resourcesToPatchDestinationTypeArgumentId( "--output-destination-type" )
 {
 	AddRequiredPositionalArgument( m_patchResourceGroupPathArgumentId, "The path to the PatchResourceGroup.yaml file." );
 
@@ -25,9 +25,9 @@ ApplyPatchCliOperation::ApplyPatchCliOperation() :
 
 	AddArgument( m_patchBinariesSourceBasePathsArgumentId, "The paths to the folders containing the patch binaries.", true, true, PathsToString( defaultParams.patchBinarySourceSettings.basePaths ) );
 
-    AddArgument( m_resourcesToPatchSourceBasePathsArgumentId, "The paths to the folders containing resources to patch.", true, true, PathsToString( defaultParams.resourcesToPatchSourceSettings.basePaths ) );
+	AddArgument( m_resourcesToPatchSourceBasePathsArgumentId, "The paths to the folders containing resources to patch.", true, true, PathsToString( defaultParams.resourcesToPatchSourceSettings.basePaths ) );
 
-    AddArgument( m_nextResourcesBasePathsArgumentId, "The path to resources after the patch. This is used to get fully added files which are not included in the generated patch files.", true, true, PathListToString( defaultParams.nextBuildResourcesSourceSettings.basePaths ) );
+	AddArgument( m_nextResourcesBasePathsArgumentId, "The path to resources after the patch. This is used to get fully added files which are not included in the generated patch files.", true, true, PathListToString( defaultParams.nextBuildResourcesSourceSettings.basePaths ) );
 
 	AddArgument( m_patchBinariesSourceTypeArgumentId, "The type of repository the patch binaries are sourced from.", false, false, SourceTypeToString( defaultParams.patchBinarySourceSettings.sourceType ), ResourceSourceTypeChoicesAsString() );
 
@@ -51,7 +51,7 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 		return false;
 	}
-    importParamsPrevious.filename = filename.value();
+	importParamsPrevious.filename = filename.value();
 
 	CarbonResources::PatchApplyParams patchApplyParams;
 
@@ -106,7 +106,7 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 	{
 		resourcesToPatchSourceSettingsBasePaths.push_back( path );
 	}
-    patchApplyParams.resourcesToPatchSourceSettings.basePaths = resourcesToPatchSourceSettingsBasePaths;
+	patchApplyParams.resourcesToPatchSourceSettings.basePaths = resourcesToPatchSourceSettingsBasePaths;
 	std::string resourcesToPatchType = m_argumentParser->get( m_resourcesToPatchSourceTypeArgumentId );
 	if( !StringToResourceSourceType( resourcesToPatchType, patchApplyParams.resourcesToPatchSourceSettings.sourceType ) )
 	{
@@ -115,17 +115,17 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 		return false;
 	}
 
-    patchApplyParams.resourcesToPatchDestinationSettings.basePath = m_argumentParser->get( m_resourcesToPatchDestinationPathArgumentId );
+	patchApplyParams.resourcesToPatchDestinationSettings.basePath = m_argumentParser->get( m_resourcesToPatchDestinationPathArgumentId );
 
 	std::string outputType = m_argumentParser->get( m_resourcesToPatchDestinationTypeArgumentId );
-	if( !StringToResourceDestinationType( outputType , patchApplyParams.resourcesToPatchDestinationSettings.destinationType ) )
+	if( !StringToResourceDestinationType( outputType, patchApplyParams.resourcesToPatchDestinationSettings.destinationType ) )
 	{
 		returnErrorMessage = "Invalid resources to patch destination type";
 
 		return false;
 	}
 
-    patchApplyParams.temporaryFilePath = "tempFile.resource";
+	patchApplyParams.temporaryFilePath = "tempFile.resource";
 
 	PrintStartBanner( importParamsPrevious, patchApplyParams );
 
@@ -134,7 +134,7 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 
 
-void ApplyPatchCliOperation::PrintStartBanner(const CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, const CarbonResources::PatchApplyParams patchApplyParams) const
+void ApplyPatchCliOperation::PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, const CarbonResources::PatchApplyParams patchApplyParams ) const
 {
 	if( s_verbosityLevel == CarbonResources::StatusLevel::OFF )
 	{
@@ -143,7 +143,7 @@ void ApplyPatchCliOperation::PrintStartBanner(const CarbonResources::ResourceGro
 
 	std::cout << "---Applying Patch---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Patch Resource Group: " << importParamsPrevious.filename << std::endl;
 	std::cout << "Patch Binaries Base Paths: " << PathsToString( patchApplyParams.patchBinarySourceSettings.basePaths ) << std::endl;
@@ -155,10 +155,11 @@ void ApplyPatchCliOperation::PrintStartBanner(const CarbonResources::ResourceGro
 	std::cout << "Output Path Base Path: " << patchApplyParams.resourcesToPatchDestinationSettings.basePath << std::endl;
 	std::cout << "Output Path Destination Type: " << DestinationTypeToString( patchApplyParams.resourcesToPatchDestinationSettings.destinationType ) << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
-bool ApplyPatchCliOperation::ApplyPatch(CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, CarbonResources::PatchApplyParams patchApplyParams) const
+bool ApplyPatchCliOperation::ApplyPatch( CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, CarbonResources::PatchApplyParams patchApplyParams ) const
 {
 	CarbonResources::StatusCallback statusCallback = GetStatusCallback();
 
@@ -170,39 +171,39 @@ bool ApplyPatchCliOperation::ApplyPatch(CarbonResources::ResourceGroupImportFrom
 	// Load the patch file
 	CarbonResources::PatchResourceGroup patchResourceGroup;
 
-    importParamsPrevious.statusCallback = statusCallback;
+	importParamsPrevious.statusCallback = statusCallback;
 
 	if( patchResourceGroup.ImportFromFile( importParamsPrevious ).type != CarbonResources::ResultType::SUCCESS )
 	{
 		return false;
 	}
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 20, "Applying patches from resource group" );
 	}
 
-    patchApplyParams.statusCallback = statusCallback;
+	patchApplyParams.statusCallback = statusCallback;
 
-    // Apply the patch
-    CarbonResources::Result applyPatchResult = patchResourceGroup.Apply( patchApplyParams );
+	// Apply the patch
+	CarbonResources::Result applyPatchResult = patchResourceGroup.Apply( patchApplyParams );
 
-    if (applyPatchResult.type != CarbonResources::ResultType::SUCCESS)
-    {
-    	std::string out;
-    	CarbonResources::ResultTypeToString( applyPatchResult.type, out );
-    	std::cerr << "Failed to apply patch: " << out << std::endl;
-    	if( s_verbosityLevel >= CarbonResources::StatusLevel::DETAIL && !applyPatchResult.info.empty() )
-    	{
-    		std::cerr << applyPatchResult.info;
-    	}
-    	exit(1);
-    }
+	if( applyPatchResult.type != CarbonResources::ResultType::SUCCESS )
+	{
+		std::string out;
+		CarbonResources::ResultTypeToString( applyPatchResult.type, out );
+		std::cerr << "Failed to apply patch: " << out << std::endl;
+		if( s_verbosityLevel >= CarbonResources::StatusLevel::DETAIL && !applyPatchResult.info.empty() )
+		{
+			std::cerr << applyPatchResult.info;
+		}
+		exit( 1 );
+	}
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Successfully applied patch" );
 	}
-    
+
 	return true;
 }

--- a/cli/src/ApplyPatchCliOperation.h
+++ b/cli/src/ApplyPatchCliOperation.h
@@ -13,10 +13,9 @@ public:
 	bool Execute( std::string& returnErrorMessage ) const final;
 
 private:
+	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, const CarbonResources::PatchApplyParams patchApplyParams ) const;
 
-	void PrintStartBanner(const CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, const CarbonResources::PatchApplyParams patchApplyParams) const;
-
-	bool ApplyPatch(CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, CarbonResources::PatchApplyParams patchApplyParams) const;
+	bool ApplyPatch( CarbonResources::ResourceGroupImportFromFileParams& importParamsPrevious, CarbonResources::PatchApplyParams patchApplyParams ) const;
 
 	std::string m_patchResourceGroupPathArgumentId;
 	std::string m_patchBinariesSourceBasePathsArgumentId;
@@ -28,4 +27,3 @@ private:
 	std::string m_resourcesToPatchDestinationPathArgumentId;
 	std::string m_resourcesToPatchDestinationTypeArgumentId;
 };
-

--- a/cli/src/Cli.cpp
+++ b/cli/src/Cli.cpp
@@ -6,16 +6,14 @@
 
 #include "Defines.h"
 
-Cli::Cli( const std::string& name, const std::string& version ):
-	m_name(name),
-	m_version(version)
+Cli::Cli( const std::string& name, const std::string& version ) :
+	m_name( name ),
+	m_version( version )
 {
-
 }
 
 Cli::~Cli()
 {
-
 }
 
 void Cli::AddOperation( CliOperation* operation )
@@ -29,31 +27,31 @@ void Cli::PrintError()
 
 	std::cout << "Operations:" << std::endl;
 
-    for (auto operation : m_operations)
-    {
+	for( auto operation : m_operations )
+	{
 		std::string operationName = operation->GetName();
 
 		std::cout << "\t" << operation->GetName();
 
 		std::cout << "\t\t" << operation->GetDescription() << std::endl;
-    }
+	}
 }
 
 int Cli::ProcessCommandLine( int argc, char** argv )
 {
 	std::string baseCommandName = argv[1];
 
-    for (auto operation : m_operations)
-    {
+	for( auto operation : m_operations )
+	{
 		if( baseCommandName == operation->GetName() )
 		{
-            if (argc == 2)
-            {
-                // Command was used but no further arguments supplied
-				operation->PrintError( );
+			if( argc == 2 )
+			{
+				// Command was used but no further arguments supplied
+				operation->PrintError();
 
 				return FAILED_INVALID_OPERATION_ARGUMENTS_RETURN;
-            }
+			}
 
 			if( operation->ProcessCommandLine( argc, argv ) )
 			{
@@ -63,35 +61,34 @@ int Cli::ProcessCommandLine( int argc, char** argv )
 				{
 					operation->PrintError( optionalReturnMessage );
 
-                    return FAILED_OPERATION_RETURN;
+					return FAILED_OPERATION_RETURN;
 				}
-                else
-                {
+				else
+				{
 					return SUCCESSFUL_RETURN;
-                }
+				}
 			}
-            else
-            {
-				operation->PrintError("Error processing arguments.Ensure all required arguments are supplied.");
+			else
+			{
+				operation->PrintError( "Error processing arguments.Ensure all required arguments are supplied." );
 
 				return FAILED_INVALID_OPERATION_ARGUMENTS_RETURN;
-            }
+			}
 		}
-    }
+	}
 
-    // Print general error message
-    PrintError();
+	// Print general error message
+	PrintError();
 
-    return FAILED_INVALID_OPERATION_SPECIFIED_RETURN;
-
+	return FAILED_INVALID_OPERATION_SPECIFIED_RETURN;
 }
 
 void Cli::PrintCliHeader()
 {
-    std::cout << "====================" << std::endl;
-    std::cout << "resources-cli" << std::endl;
-    std::cout << "Name:" << m_name << std::endl;
-    std::cout << "Version: " << m_version << std::endl;
-    std::cout << "====================\n" << std::endl;
-
+	std::cout << "====================" << std::endl;
+	std::cout << "resources-cli" << std::endl;
+	std::cout << "Name:" << m_name << std::endl;
+	std::cout << "Version: " << m_version << std::endl;
+	std::cout << "====================\n"
+			  << std::endl;
 }

--- a/cli/src/Cli.h
+++ b/cli/src/Cli.h
@@ -28,14 +28,12 @@ public:
 	int ProcessCommandLine( int argc, char** argv );
 
 private:
-
-    void PrintCliHeader();
+	void PrintCliHeader();
 
 private:
+	std::string m_name;
 
-    std::string m_name;
-
-    std::string m_version;
+	std::string m_version;
 
 	std::vector<CliOperation*> m_operations;
 };

--- a/cli/src/CliOperation.cpp
+++ b/cli/src/CliOperation.cpp
@@ -14,10 +14,9 @@ CliOperation::CliOperation( const std::string& name, const std::string& descript
 {
 	m_argumentParser = new argparse::ArgumentParser( name );
 
-    m_argumentParser->add_description( description );
+	m_argumentParser->add_description( description );
 
-    AddArgument( m_verbosityLevelId, "Set verbosity to level", false, false, "0", "0,1,2,3" );
-
+	AddArgument( m_verbosityLevelId, "Set verbosity to level", false, false, "0", "0,1,2,3" );
 }
 
 CliOperation ::~CliOperation()
@@ -38,7 +37,7 @@ bool CliOperation::AddRequiredPositionalArgument( const std::string& argumentId,
 	m_argumentParser->add_argument( argumentId )
 		.help( helpString );
 
-    return true;
+	return true;
 }
 
 bool CliOperation::AddArgumentFlag( const std::string& argumentId, const std::string& helpString )
@@ -53,7 +52,7 @@ bool CliOperation::AddArgumentFlag( const std::string& argumentId, const std::st
 
 	argument.default_value( false );
 
-    argument.implicit_value( true );
+	argument.implicit_value( true );
 
 	return true;
 }
@@ -65,22 +64,22 @@ bool CliOperation::AddArgument( const std::string& argumentId, const std::string
 		return false;
 	}
 
-    // Some useful information is added to help string based on argument inputs specified
-    std::string helpStringExtended = helpString;
+	// Some useful information is added to help string based on argument inputs specified
+	std::string helpStringExtended = helpString;
 
-    if( choicesString != "" )
-    {
+	if( choicesString != "" )
+	{
 		std::stringstream ss;
 
-        ss << helpStringExtended << " [Choices: " << choicesString << "]";
+		ss << helpStringExtended << " [Choices: " << choicesString << "]";
 
-        helpStringExtended = ss.str();
-    }
+		helpStringExtended = ss.str();
+	}
 
-    if (append)
-    {
+	if( append )
+	{
 		helpStringExtended = helpStringExtended + " [Accepts multiple]";
-    }
+	}
 
 	argparse::Argument& argument = m_argumentParser->add_argument( argumentId )
 									   .help( helpStringExtended );
@@ -94,12 +93,12 @@ bool CliOperation::AddArgument( const std::string& argumentId, const std::string
 		argument.default_value( defaultValue );
 	}
 
-    if (append)
-    {
+	if( append )
+	{
 		argument.append();
-    }
+	}
 
-    return true;
+	return true;
 }
 
 argparse::ArgumentParser* CliOperation::GetParser() const
@@ -109,17 +108,17 @@ argparse::ArgumentParser* CliOperation::GetParser() const
 
 void CliOperation::PrintError( std::string message /*= ""*/ ) const
 {
-    if (message != "")
-    {
+	if( message != "" )
+	{
 		std::cerr << "[ERROR: " << message << "]\n\n";
-    }
+	}
 
 	std::cout << *m_argumentParser;
 }
 
 void CliOperation::PrintCommonOperationHeaderInformation() const
 {
-	std::cout << "Verbosity Level: " << VerbosityLevelToString(s_verbosityLevel) << std::endl;
+	std::cout << "Verbosity Level: " << VerbosityLevelToString( s_verbosityLevel ) << std::endl;
 }
 
 void CliOperation::PrintCarbonResourcesError( CarbonResources::Result result ) const
@@ -130,56 +129,50 @@ void CliOperation::PrintCarbonResourcesError( CarbonResources::Result result ) c
 
 	std::cerr << "[ERROR: " << errorMessage << "]\n\n";
 
-    if (result.info != "")
-    {
+	if( result.info != "" )
+	{
 		std::cout << "\n======ERROR INFORMATION======\n";
 		std::cout << result.info << "\n";
 		std::cout << "============================\n";
-    }
+	}
 
 	std::cout << std::endl;
 }
 
 char CliOperation::GetBusyChar()
 {
-    switch (s_currentBusyAnimationChar)
-    {
-	    case '/':
-        {
-		    s_currentBusyAnimationChar = '-';
+	switch( s_currentBusyAnimationChar )
+	{
+	case '/': {
+		s_currentBusyAnimationChar = '-';
 
-		    break;
-        }
-		
-	    case '-':
-        {
-		    s_currentBusyAnimationChar = '\\';
+		break;
+	}
 
-            break;
-        }
-		
-	    case '\\':
-        {
-		    s_currentBusyAnimationChar = '|';
+	case '-': {
+		s_currentBusyAnimationChar = '\\';
 
-            break;
-        }
-		
-	    case '|':
-        {
-		    s_currentBusyAnimationChar = '/';
+		break;
+	}
 
-            break;
-        }
-		
-	    default:
-        {
-		    s_currentBusyAnimationChar = '-';
-        }
-		
-    }
+	case '\\': {
+		s_currentBusyAnimationChar = '|';
 
-    return s_currentBusyAnimationChar;
+		break;
+	}
+
+	case '|': {
+		s_currentBusyAnimationChar = '/';
+
+		break;
+	}
+
+	default: {
+		s_currentBusyAnimationChar = '-';
+	}
+	}
+
+	return s_currentBusyAnimationChar;
 }
 
 CarbonResources::StatusCallback CliOperation::GetStatusCallback() const
@@ -189,46 +182,44 @@ CarbonResources::StatusCallback CliOperation::GetStatusCallback() const
 
 void CliOperation::StatusUpdate( CarbonResources::StatusLevel level, CarbonResources::StatusProgressType type, int progress, const std::string& info )
 {
-    // No update is shown for status updates for layers greater than the verbosity level
-	if( level > s_verbosityLevel ) 
-    {
+	// No update is shown for status updates for layers greater than the verbosity level
+	if( level > s_verbosityLevel )
+	{
 		return;
-    }
+	}
 
-    // Verbosity level affects if a progres bar is shown or detail.
-    // This level can be incremented to adjust detail of log output
+	// Verbosity level affects if a progres bar is shown or detail.
+	// This level can be incremented to adjust detail of log output
 	if( level <= s_verbosityLevel )
 	{
 		// Show detail of the process
 		std::stringstream ss;
 
-        // Apply indent based on layer
+		// Apply indent based on layer
 		ss << GetVerbosityLevelIndent( level );
 
-        ss << "[";
+		ss << "[";
 
-        // If progress is unbounded then show busy
-        // Else print percentage progress
-        if (type == CarbonResources::StatusProgressType::UNBOUNDED)
-        {
+		// If progress is unbounded then show busy
+		// Else print percentage progress
+		if( type == CarbonResources::StatusProgressType::UNBOUNDED )
+		{
 			ss << GetBusyChar();
-        }
-        else
-        {
+		}
+		else
+		{
 			ss << progress << "%";
-        }
-        
+		}
+
 		ss << "] " << info;
 
-        std::string message = ss.str();
+		std::string message = ss.str();
 
-        std::cout << "\r";
+		std::cout << "\r";
 
 		std::cout << message;
-        std::cout << std::endl;
-
+		std::cout << std::endl;
 	}
-
 }
 
 bool CliOperation::ProcessCommandLine( int argc, char** argv )
@@ -237,39 +228,37 @@ bool CliOperation::ProcessCommandLine( int argc, char** argv )
 	{
 		std::vector<std::string> arguments;
 
-        arguments.push_back( argv[0] );
+		arguments.push_back( argv[0] );
 
-        if (argc > 2)
-        {
+		if( argc > 2 )
+		{
 			for( int i = 2; i < argc; i++ )
 			{
 				std::string argument( argv[i] );
 
 				arguments.push_back( argument );
 			}
-        }
+		}
 
 		m_argumentParser->parse_args( arguments );
-
 	}
 	catch( const std::runtime_error& )
 	{
 
 		return false;
-
 	}
 
-    if (!SetVerbosityLevel())
-    {
+	if( !SetVerbosityLevel() )
+	{
 		return false;
-    }
+	}
 
 	return true;
 }
 
 std::string CliOperation::GetName() const
 {
-    return m_name;
+	return m_name;
 }
 
 std::string CliOperation::GetDescription() const
@@ -279,8 +268,8 @@ std::string CliOperation::GetDescription() const
 
 std::string CliOperation::VerbosityLevelToString( CarbonResources::StatusLevel level ) const
 {
-    switch (level)
-    {
+	switch( level )
+	{
 	case CarbonResources::StatusLevel::OFF:
 		return "0 - (Off)";
 
@@ -295,10 +284,10 @@ std::string CliOperation::VerbosityLevelToString( CarbonResources::StatusLevel l
 
 	default:
 		return "Unknown";
-    }
+	}
 }
 
-std::string CliOperation::GetVerbosityLevelIndent(CarbonResources::StatusLevel level)
+std::string CliOperation::GetVerbosityLevelIndent( CarbonResources::StatusLevel level )
 {
 	switch( level )
 	{
@@ -375,14 +364,14 @@ std::string CliOperation::PathListToString( std::vector<std::filesystem::path>& 
 		}
 	}
 
-    return ss.str();
+	return ss.str();
 }
 
 std::string CliOperation::SourceTypeToString( CarbonResources::ResourceSourceType type ) const
 {
 	switch( type )
 	{
-	case CarbonResources::ResourceSourceType::LOCAL_RELATIVE :
+	case CarbonResources::ResourceSourceType::LOCAL_RELATIVE:
 		return "LOCAL_RELATIVE";
 
 	case CarbonResources::ResourceSourceType::LOCAL_CDN:
@@ -402,7 +391,7 @@ std::string CliOperation::SizeToString( uintmax_t size ) const
 
 	ss << size;
 
-    return ss.str();
+	return ss.str();
 }
 
 std::string CliOperation::SecondsToString( std::chrono::seconds seconds ) const
@@ -411,7 +400,7 @@ std::string CliOperation::SecondsToString( std::chrono::seconds seconds ) const
 
 	ss << seconds.count();
 
-    return ss.str();
+	return ss.str();
 }
 
 std::string CliOperation::VersionToString( CarbonResources::Version& version ) const
@@ -454,10 +443,10 @@ std::string CliOperation::DestinationTypeToString( CarbonResources::ResourceDest
 std::string PathsToString( const std::vector<std::filesystem::path>& v )
 {
 	std::string result;
-	bool first{true};
+	bool first{ true };
 	for( const auto& s : v )
 	{
-		if(!first)
+		if( !first )
 		{
 			result += ",";
 		}
@@ -471,14 +460,14 @@ bool CliOperation::SetVerbosityLevel()
 {
 	std::string verbosityLevelString = m_argumentParser->get<std::string>( m_verbosityLevelId );
 
-    if( verbosityLevelString == "0" )
-    {
+	if( verbosityLevelString == "0" )
+	{
 		s_verbosityLevel = CarbonResources::StatusLevel::OFF;
-    }
+	}
 	else if( verbosityLevelString == "1" )
-    {
+	{
 		s_verbosityLevel = CarbonResources::StatusLevel::OVERVIEW;
-    }
+	}
 	else if( verbosityLevelString == "2" )
 	{
 		s_verbosityLevel = CarbonResources::StatusLevel::PROCEDURE;
@@ -487,10 +476,10 @@ bool CliOperation::SetVerbosityLevel()
 	{
 		s_verbosityLevel = CarbonResources::StatusLevel::DETAIL;
 	}
-    else
-    {
+	else
+	{
 		return false;
-    }
+	}
 
 	return true;
 }

--- a/cli/src/CliOperation.h
+++ b/cli/src/CliOperation.h
@@ -13,8 +13,8 @@
 
 namespace CarbonResources
 {
-    enum class ResourceSourceType;
-    enum class ResourceDestinationType;
+enum class ResourceSourceType;
+enum class ResourceDestinationType;
 }
 
 namespace argparse
@@ -25,7 +25,6 @@ class ArgumentParser;
 class CliOperation
 {
 public:
-
 	CliOperation( const std::string& name, const std::string& description );
 
 	~CliOperation();
@@ -36,64 +35,61 @@ public:
 
 	virtual bool Execute( std::string& returnErrorMessage ) const = 0;
 
-    bool ProcessCommandLine( int argc, char** argv );
+	bool ProcessCommandLine( int argc, char** argv );
 
-    std::string GetName() const;
+	std::string GetName() const;
 
-    std::string GetDescription() const;
+	std::string GetDescription() const;
 
-    std::string VerbosityLevelToString(CarbonResources::StatusLevel level) const;
+	std::string VerbosityLevelToString( CarbonResources::StatusLevel level ) const;
 
-    static std::string GetVerbosityLevelIndent( CarbonResources::StatusLevel level );
+	static std::string GetVerbosityLevelIndent( CarbonResources::StatusLevel level );
 
 protected:
+	void PrintCommonOperationHeaderInformation() const;
 
-    void PrintCommonOperationHeaderInformation() const;
+	void PrintCarbonResourcesError( CarbonResources::Result result ) const;
 
-    void PrintCarbonResourcesError( CarbonResources::Result result ) const;
-
-    bool AddRequiredPositionalArgument( const std::string& argumentId, const std::string& helpString );
+	bool AddRequiredPositionalArgument( const std::string& argumentId, const std::string& helpString );
 
 	bool AddArgument( const std::string& argumentId, const std::string& helpString, bool required = false, bool append = false, std::string defaultValue = "", std::string choicesString = "" );
 
-    bool AddArgumentFlag( const std::string& argumentId, const std::string& helpString );
+	bool AddArgumentFlag( const std::string& argumentId, const std::string& helpString );
 
-    argparse::ArgumentParser* m_argumentParser;
+	argparse::ArgumentParser* m_argumentParser;
 
-    CarbonResources::StatusCallback GetStatusCallback() const;
+	CarbonResources::StatusCallback GetStatusCallback() const;
 
 	bool StringToResourceSourceType( const std::string& stringRepresentation, CarbonResources::ResourceSourceType& out ) const;
 
 	bool StringToResourceDestinationType( const std::string& stringRepresentation, CarbonResources::ResourceDestinationType& out ) const;
 
-    std::string PathListToString(std::vector<std::filesystem::path>& paths) const;
+	std::string PathListToString( std::vector<std::filesystem::path>& paths ) const;
 
-    std::string SourceTypeToString( CarbonResources::ResourceSourceType type ) const;
+	std::string SourceTypeToString( CarbonResources::ResourceSourceType type ) const;
 
-    std::string DestinationTypeToString( CarbonResources::ResourceDestinationType type ) const;
+	std::string DestinationTypeToString( CarbonResources::ResourceDestinationType type ) const;
 
-    std::string SizeToString( uintmax_t size ) const;
+	std::string SizeToString( uintmax_t size ) const;
 
-    std::string SecondsToString( std::chrono::seconds seconds ) const;
+	std::string SecondsToString( std::chrono::seconds seconds ) const;
 
-    std::string VersionToString( CarbonResources::Version &version ) const;
+	std::string VersionToString( CarbonResources::Version& version ) const;
 
 	std::string ResourceSourceTypeChoicesAsString() const;
 
 	std::string ResourceDestinationTypeChoicesAsString() const;
 
-    bool ParseDocumentVersion( const std::string& version, CarbonResources::Version& documentVersion ) const;
+	bool ParseDocumentVersion( const std::string& version, CarbonResources::Version& documentVersion ) const;
 
 private:
+	static void StatusUpdate( CarbonResources::StatusLevel level, CarbonResources::StatusProgressType type, int progress, const std::string& info );
 
-    static void StatusUpdate( CarbonResources::StatusLevel level, CarbonResources::StatusProgressType type, int progress, const std::string& info );
+	static char GetBusyChar();
 
-    static char GetBusyChar();
-
-    bool SetVerbosityLevel();
+	bool SetVerbosityLevel();
 
 protected:
-
 	static inline CarbonResources::StatusLevel s_verbosityLevel = CarbonResources::StatusLevel::OFF;
 
 private:
@@ -102,9 +98,8 @@ private:
 	std::string m_name;
 
 	std::string m_description;
-    
-	static inline char s_currentBusyAnimationChar = '/';
 
+	static inline char s_currentBusyAnimationChar = '/';
 };
 
 std::string PathsToString( const std::vector<std::filesystem::path>& v );

--- a/cli/src/CreateBundleCliOperation.cpp
+++ b/cli/src/CreateBundleCliOperation.cpp
@@ -26,7 +26,7 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
 {
 	AddRequiredPositionalArgument( m_inputResourceGroupPathArgumentId, "Path to ResourceGroup to bundle." );
 
-    // Struct is inspected to ascertain default values
+	// Struct is inspected to ascertain default values
 	// This keeps default value settings in one place
 	// Lib defaults matches CLI
 	CarbonResources::BundleCreateParams defaultParams;
@@ -34,20 +34,20 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
 	AddArgument( m_resourceSourceBasePathArgumentId, "Represents the base path where the resources will be sourced.", true, true, PathListToString( defaultParams.resourceSourceSettings.basePaths ) );
 
 	AddArgument( m_resourceSourceTypeArgumentId, "Represents the type of repository where resources will be sourced.", false, false, SourceTypeToString( defaultParams.resourceSourceSettings.sourceType ), ResourceSourceTypeChoicesAsString() );
-    
+
 	AddArgument( m_resourceGroupRelativePathArgumentId, "Relative path to save a ResourceGroup the Bundle was based off", false, false, defaultParams.resourceGroupRelativePath.string() );
 
-    AddArgument( m_bundleResourceGroupRelativePathArgumentId, "Relative path to save a Bundle ResourceGroup", false, false, defaultParams.resourceGroupBundleRelativePath.string() );
+	AddArgument( m_bundleResourceGroupRelativePathArgumentId, "Relative path to save a Bundle ResourceGroup", false, false, defaultParams.resourceGroupBundleRelativePath.string() );
 
-    AddArgument( m_chunkDestinationTypeArgumentId, "Represents the type of repository where chunks will be saved.", false, false, DestinationTypeToString( defaultParams.chunkDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+	AddArgument( m_chunkDestinationTypeArgumentId, "Represents the type of repository where chunks will be saved.", false, false, DestinationTypeToString( defaultParams.chunkDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
 
 	AddArgument( m_chunkDestinationBasePathArgumentId, "Represents the base path where the chunks will be saved.", false, false, defaultParams.chunkDestinationSettings.basePath.string() );
 
-    AddArgument( m_bundleResourceGroupDestinationTypeArgumentId, "Represents the type of repository where the bundle ResourceGroup will be saved.", false, false, DestinationTypeToString( defaultParams.resourceBundleResourceGroupDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+	AddArgument( m_bundleResourceGroupDestinationTypeArgumentId, "Represents the type of repository where the bundle ResourceGroup will be saved.", false, false, DestinationTypeToString( defaultParams.resourceBundleResourceGroupDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
 
 	AddArgument( m_bundleResourceGroupDestinationBasePathArgumentId, "Represents the base path where the bundle ResourceGroup will be saved.", false, false, defaultParams.resourceBundleResourceGroupDestinationSettings.basePath.string() );
 
-    AddArgument( m_chunkSizeArgumentId, "Represents the maximum size of the produced chunks in bytes.", false, false, SizeToString( defaultParams.chunkSize ) );
+	AddArgument( m_chunkSizeArgumentId, "Represents the maximum size of the produced chunks in bytes.", false, false, SizeToString( defaultParams.chunkSize ) );
 
 	AddArgument( m_downloadRetrySecondsArgumentId, "The number of seconds before attempt to download a resource fails with a network related error", false, false, SecondsToString( defaultParams.downloadRetrySeconds ) );
 }
@@ -56,51 +56,51 @@ bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 {
 	CarbonResources::ResourceGroupImportFromFileParams resourceGroupParams;
 
-    resourceGroupParams.filename = m_argumentParser->get<std::string>( m_inputResourceGroupPathArgumentId );
+	resourceGroupParams.filename = m_argumentParser->get<std::string>( m_inputResourceGroupPathArgumentId );
 
-    CarbonResources::BundleCreateParams bundleCreateParams;
+	CarbonResources::BundleCreateParams bundleCreateParams;
 
 	bundleCreateParams.resourceGroupRelativePath = m_argumentParser->get<std::string>( m_resourceGroupRelativePathArgumentId );
 
 	bundleCreateParams.resourceGroupBundleRelativePath = m_argumentParser->get<std::string>( m_bundleResourceGroupRelativePathArgumentId );
 
-	std::string resourceSourceType = m_argumentParser->get(m_resourceSourceTypeArgumentId);
+	std::string resourceSourceType = m_argumentParser->get( m_resourceSourceTypeArgumentId );
 
-    if( !StringToResourceSourceType( resourceSourceType, bundleCreateParams.resourceSourceSettings.sourceType ) )
-    {
+	if( !StringToResourceSourceType( resourceSourceType, bundleCreateParams.resourceSourceSettings.sourceType ) )
+	{
 		returnErrorMessage = "Invalid resources source type";
 
 		return false;
-    }
+	}
 
-    for (const std::string& basePath : m_argumentParser->get<std::vector<std::string>>(m_resourceSourceBasePathArgumentId))
-    {
-		bundleCreateParams.resourceSourceSettings.basePaths.push_back(basePath);
-    }
+	for( const std::string& basePath : m_argumentParser->get<std::vector<std::string>>( m_resourceSourceBasePathArgumentId ) )
+	{
+		bundleCreateParams.resourceSourceSettings.basePaths.push_back( basePath );
+	}
 
 	std::string chunkDesinationType = m_argumentParser->get<std::string>( m_chunkDestinationTypeArgumentId );
 
-    if (!StringToResourceDestinationType(chunkDesinationType, bundleCreateParams.chunkDestinationSettings.destinationType))
-    {
+	if( !StringToResourceDestinationType( chunkDesinationType, bundleCreateParams.chunkDestinationSettings.destinationType ) )
+	{
 		returnErrorMessage = "Invalid chunk destination type";
 
 		return false;
-    }
+	}
 
 	bundleCreateParams.chunkDestinationSettings.basePath = m_argumentParser->get<std::string>( m_chunkDestinationBasePathArgumentId );
 
 	std::string bundleResourceGroupDestinationType = m_argumentParser->get<std::string>( m_bundleResourceGroupDestinationTypeArgumentId );
 
-    if (!StringToResourceDestinationType(bundleResourceGroupDestinationType, bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType))
-    {
+	if( !StringToResourceDestinationType( bundleResourceGroupDestinationType, bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType ) )
+	{
 		returnErrorMessage = "Invalid Resource Group destination type";
 
 		return false;
-    }
+	}
 
 	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = m_argumentParser->get<std::string>( m_bundleResourceGroupDestinationBasePathArgumentId );
 
-	long long retrySeconds{120};
+	long long retrySeconds{ 120 };
 	try
 	{
 		bundleCreateParams.chunkSize = std::stoull( m_argumentParser->get( m_chunkSizeArgumentId ) );
@@ -116,7 +116,7 @@ bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 	}
 	bundleCreateParams.downloadRetrySeconds = std::chrono::seconds( retrySeconds );
 
-    if( s_verbosityLevel != CarbonResources::StatusLevel::OFF )
+	if( s_verbosityLevel != CarbonResources::StatusLevel::OFF )
 	{
 		PrintStartBanner( resourceGroupParams, bundleCreateParams );
 	}
@@ -133,50 +133,51 @@ void CreateBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
 
 	std::cout << "---Running Bundle Creation---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Resource Group: " << resourceGroupParams.filename << std::endl;
 
 	std::cout << "Resource Group Relative Path: " << bundleCreateParams.resourceGroupRelativePath << std::endl;
 
-    std::cout << "Bundle Resource Group Relative Path: " << bundleCreateParams.resourceGroupBundleRelativePath << std::endl;
+	std::cout << "Bundle Resource Group Relative Path: " << bundleCreateParams.resourceGroupBundleRelativePath << std::endl;
 
-    std::cout << "Resource Source Type: " << SourceTypeToString( bundleCreateParams.resourceSourceSettings.sourceType ) << std::endl;
+	std::cout << "Resource Source Type: " << SourceTypeToString( bundleCreateParams.resourceSourceSettings.sourceType ) << std::endl;
 
-    for (std::filesystem::path basePath : bundleCreateParams.resourceSourceSettings.basePaths)
-    {
+	for( std::filesystem::path basePath : bundleCreateParams.resourceSourceSettings.basePaths )
+	{
 		std::cout << "Resource Source Base Path: " << basePath << std::endl;
-    }
+	}
 
-    std::cout << "Chunk Destination Type: " << DestinationTypeToString( bundleCreateParams.chunkDestinationSettings.destinationType ) << std::endl;
+	std::cout << "Chunk Destination Type: " << DestinationTypeToString( bundleCreateParams.chunkDestinationSettings.destinationType ) << std::endl;
 
 	std::cout << "Chunk Destination Base Path: " << bundleCreateParams.chunkDestinationSettings.basePath << std::endl;
 
-    std::cout << "Bundle Resource Group Destination Type: " << DestinationTypeToString( bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType ) << std::endl;
+	std::cout << "Bundle Resource Group Destination Type: " << DestinationTypeToString( bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType ) << std::endl;
 
 	std::cout << "Bundle Resource Group Destination Base Path: " << bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath << std::endl;
 
-    std::cout << "Chunk Size: " << bundleCreateParams.chunkSize << " Bytes" << std::endl;
+	std::cout << "Chunk Size: " << bundleCreateParams.chunkSize << " Bytes" << std::endl;
 
 	std::cout << "Download Retry Seconds: " << bundleCreateParams.downloadRetrySeconds.count() << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool CreateBundleCliOperation::CreateBundle( CarbonResources::ResourceGroupImportFromFileParams& resourceGroupParams, CarbonResources::BundleCreateParams bundleCreateParams, std::string& returnErrorMessage ) const
 {
 	CarbonResources::StatusCallback statusCallback = GetStatusCallback();
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Creating Bundle." );
 	}
 
-    if (!std::filesystem::exists(resourceGroupParams.filename))
-    {
+	if( !std::filesystem::exists( resourceGroupParams.filename ) )
+	{
 		returnErrorMessage = resourceGroupParams.filename.string() + " not found";
 		return false;
-    }
+	}
 
 	std::string extension = resourceGroupParams.filename.extension().string();
 	std::string inputResourceGroupType;
@@ -208,63 +209,63 @@ bool CreateBundleCliOperation::CreateBundle( CarbonResources::ResourceGroupImpor
 	{
 		std::stringstream ss;
 
-        ss << "Unexpected file extension for resource group '" << extension << "'.";
+		ss << "Unexpected file extension for resource group '" << extension << "'.";
 		returnErrorMessage = ss.str();
 		return false;
 	}
 
 	// Import ResourceGroup
-    CarbonResources::ResourceGroup* resourceGroup;
+	CarbonResources::ResourceGroup* resourceGroup;
 
 	// Note: This information could be ascertained directly from file
-    if (inputResourceGroupType == "ResourceGroup")
-    {
+	if( inputResourceGroupType == "ResourceGroup" )
+	{
 		resourceGroup = new CarbonResources::ResourceGroup();
-    }
-    else if (inputResourceGroupType == "PatchGroup")
-    {
+	}
+	else if( inputResourceGroupType == "PatchGroup" )
+	{
 		resourceGroup = new CarbonResources::PatchResourceGroup();
-    }
-    else
-    {
-        // Unknown resource group type provided
+	}
+	else
+	{
+		// Unknown resource group type provided
 		returnErrorMessage = "Unexpected resource group type : " + inputResourceGroupType;
 		return false;
-    }
+	}
 
-    resourceGroupParams.statusCallback = statusCallback;
+	resourceGroupParams.statusCallback = statusCallback;
 
-    CarbonResources::Result importResourceGroupResult = resourceGroup->ImportFromFile( resourceGroupParams );
+	CarbonResources::Result importResourceGroupResult = resourceGroup->ImportFromFile( resourceGroupParams );
 
-    if (importResourceGroupResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( importResourceGroupResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( importResourceGroupResult );
 
-        return false;
-    }
+		return false;
+	}
 
-    bundleCreateParams.statusCallback = GetStatusCallback();
+	bundleCreateParams.statusCallback = GetStatusCallback();
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 50, "Processing bundle files." );
 	}
 
-    CarbonResources::Result createBundleResult = resourceGroup->CreateBundle( bundleCreateParams );
+	CarbonResources::Result createBundleResult = resourceGroup->CreateBundle( bundleCreateParams );
 
-    delete resourceGroup;
+	delete resourceGroup;
 
-    if (createBundleResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( createBundleResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( createBundleResult );
 
-        return false;
-    }
+		return false;
+	}
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Bundle created succesfully" );
 	}
 
-    return true;
+	return true;
 }

--- a/cli/src/CreateBundleCliOperation.h
+++ b/cli/src/CreateBundleCliOperation.h
@@ -18,7 +18,7 @@ public:
 	virtual bool Execute( std::string& returnErrorMessage ) const override;
 
 private:
-    void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& resourceGroupParams, CarbonResources::BundleCreateParams bundleCreateParams ) const;
+	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& resourceGroupParams, CarbonResources::BundleCreateParams bundleCreateParams ) const;
 	bool CreateBundle( CarbonResources::ResourceGroupImportFromFileParams& resourceGroupParams, CarbonResources::BundleCreateParams bundleCreateParams, std::string& returnErrorMessage ) const;
 
 private:
@@ -29,21 +29,21 @@ private:
 
 	std::string m_resourceGroupRelativePathArgumentId;
 
-    std::string m_bundleResourceGroupRelativePathArgumentId;
+	std::string m_bundleResourceGroupRelativePathArgumentId;
 
-    std::string m_resourceSourceTypeArgumentId;
+	std::string m_resourceSourceTypeArgumentId;
 
-    std::string m_resourceSourceBasePathArgumentId;
+	std::string m_resourceSourceBasePathArgumentId;
 
-    std::string m_chunkDestinationTypeArgumentId;
+	std::string m_chunkDestinationTypeArgumentId;
 
 	std::string m_chunkDestinationBasePathArgumentId;
 
-    std::string m_bundleResourceGroupDestinationTypeArgumentId;
+	std::string m_bundleResourceGroupDestinationTypeArgumentId;
 
 	std::string m_bundleResourceGroupDestinationBasePathArgumentId;
 
-    std::string m_chunkSizeArgumentId;
+	std::string m_chunkSizeArgumentId;
 
 	std::string m_downloadRetrySecondsArgumentId;
 };

--- a/cli/src/CreatePatchCliOperation.cpp
+++ b/cli/src/CreatePatchCliOperation.cpp
@@ -28,36 +28,36 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 
 	AddRequiredPositionalArgument( m_previousResourceGroupPathArgumentId, "Filename to previous resourceGroup." );
 
-    AddRequiredPositionalArgument( m_nextResourceGroupPathArgumentId, "Filename to next resourceGroup." );
+	AddRequiredPositionalArgument( m_nextResourceGroupPathArgumentId, "Filename to next resourceGroup." );
 
-    // Struct is inspected to ascertain default values
+	// Struct is inspected to ascertain default values
 	// This keeps default value settings in one place
 	// Lib defaults matches CLI
-    CarbonResources::PatchCreateParams defaultParams;
+	CarbonResources::PatchCreateParams defaultParams;
 
-    AddArgument( m_resourceSourceBasePathPreviousArgumentId, "Represents the base path to source resources for previous.", true, true, PathListToString( defaultParams.resourceSourceSettingsPrevious.basePaths ) );
+	AddArgument( m_resourceSourceBasePathPreviousArgumentId, "Represents the base path to source resources for previous.", true, true, PathListToString( defaultParams.resourceSourceSettingsPrevious.basePaths ) );
 
-    AddArgument( m_resourceSourceBasePathNextArgumentId, "Represents the base path to source resources for next.", true, true, PathListToString( defaultParams.resourceSourceSettingsNext.basePaths ) );
+	AddArgument( m_resourceSourceBasePathNextArgumentId, "Represents the base path to source resources for next.", true, true, PathListToString( defaultParams.resourceSourceSettingsNext.basePaths ) );
 
-    AddArgument( m_resourceSourceTypeNextArgumentId, "Represents the type of repository to source resources for next.", false, false, SourceTypeToString( defaultParams.resourceSourceSettingsNext.sourceType ), ResourceSourceTypeChoicesAsString() );
+	AddArgument( m_resourceSourceTypeNextArgumentId, "Represents the type of repository to source resources for next.", false, false, SourceTypeToString( defaultParams.resourceSourceSettingsNext.sourceType ), ResourceSourceTypeChoicesAsString() );
 
 	AddArgument( m_patchBinaryDestinationTypeArgumentId, "Represents the type of repository where binary patches will be saved.", false, false, DestinationTypeToString( defaultParams.resourcePatchBinaryDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
 
-    AddArgument( m_resourceGroupRelativePathArgumentId, "Relative path for output resourceGroup which will contain the diff between the supplied previous ResourceGroup and next ResourceGroup.", false, false, defaultParams.resourceGroupRelativePath.string() );
+	AddArgument( m_resourceGroupRelativePathArgumentId, "Relative path for output resourceGroup which will contain the diff between the supplied previous ResourceGroup and next ResourceGroup.", false, false, defaultParams.resourceGroupRelativePath.string() );
 
-    AddArgument( m_patchResourceGroupRelativePathArgumentId, "Relative path for output PatchResourceGroup which will contain all the patches produced.", false, false, defaultParams.resourceGroupPatchRelativePath.string() );
+	AddArgument( m_patchResourceGroupRelativePathArgumentId, "Relative path for output PatchResourceGroup which will contain all the patches produced.", false, false, defaultParams.resourceGroupPatchRelativePath.string() );
 
-    AddArgument( m_resourceSourceTypePreviousArgumentId, "Represents the type of repository to source resources for previous.", false, false, SourceTypeToString( defaultParams.resourceSourceSettingsPrevious.sourceType ), ResourceSourceTypeChoicesAsString() );
+	AddArgument( m_resourceSourceTypePreviousArgumentId, "Represents the type of repository to source resources for previous.", false, false, SourceTypeToString( defaultParams.resourceSourceSettingsPrevious.sourceType ), ResourceSourceTypeChoicesAsString() );
 
 	AddArgument( m_patchBinaryDestinationBasePathArgumentId, "Represents the base path where binary patches will be saved.", false, false, defaultParams.resourcePatchBinaryDestinationSettings.basePath.string() );
 
-    AddArgument( m_patchResourceGroupDestinationTypeArgumentId, "Represents the type of repository where the patch ResourceGroup will be saved.", false, false, DestinationTypeToString( defaultParams.resourcePatchResourceGroupDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+	AddArgument( m_patchResourceGroupDestinationTypeArgumentId, "Represents the type of repository where the patch ResourceGroup will be saved.", false, false, DestinationTypeToString( defaultParams.resourcePatchResourceGroupDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
 
 	AddArgument( m_patchResourceGroupDestinationBasePathArgumentId, "Represents the base path where the patch ResourceGroup will be saved.", false, false, defaultParams.resourcePatchResourceGroupDestinationSettings.basePath.string() );
 
-    AddArgument( m_patchFileRelativePathPrefixArgumentId, "Relative path prefix for produced patch binaries. Default is 'Patches/Patch' which will produce patches such as Patches/Patch.1 ...", false, false, defaultParams.patchFileRelativePathPrefix.string() );
+	AddArgument( m_patchFileRelativePathPrefixArgumentId, "Relative path prefix for produced patch binaries. Default is 'Patches/Patch' which will produce patches such as Patches/Patch.1 ...", false, false, defaultParams.patchFileRelativePathPrefix.string() );
 
-    AddArgument( m_maxInputChunkSizeArgumentId, "Files are processed in chunks, maxInputFileChunkSize indicate the size of this chunk. Files smaller than chunk will be processed in one pass.", false, false, SizeToString( defaultParams.maxInputFileChunkSize ) );
+	AddArgument( m_maxInputChunkSizeArgumentId, "Files are processed in chunks, maxInputFileChunkSize indicate the size of this chunk. Files smaller than chunk will be processed in one pass.", false, false, SizeToString( defaultParams.maxInputFileChunkSize ) );
 
 	AddArgument( m_downloadRetrySecondsArgumentId, "The number of seconds before attempt to download a resource fails with a network related error", false, false, SecondsToString( defaultParams.downloadRetrySeconds ) );
 
@@ -68,13 +68,13 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 {
 	CarbonResources::ResourceGroupImportFromFileParams previousResourceGroupParams;
 
-    previousResourceGroupParams.filename = m_argumentParser->get<std::string>( m_previousResourceGroupPathArgumentId );
+	previousResourceGroupParams.filename = m_argumentParser->get<std::string>( m_previousResourceGroupPathArgumentId );
 
-    CarbonResources::ResourceGroupImportFromFileParams nextResourceGroupParams;
+	CarbonResources::ResourceGroupImportFromFileParams nextResourceGroupParams;
 
-    nextResourceGroupParams.filename = m_argumentParser->get<std::string>( m_nextResourceGroupPathArgumentId );
+	nextResourceGroupParams.filename = m_argumentParser->get<std::string>( m_nextResourceGroupPathArgumentId );
 
-    CarbonResources::PatchCreateParams createPatchParams;
+	CarbonResources::PatchCreateParams createPatchParams;
 
 	createPatchParams.resourceGroupRelativePath = m_argumentParser->get<std::string>( m_resourceGroupRelativePathArgumentId );
 
@@ -82,57 +82,57 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	std::string resourceSourceTypePrevious = m_argumentParser->get<std::string>( m_resourceSourceTypePreviousArgumentId );
 
-    if (!StringToResourceSourceType(resourceSourceTypePrevious, createPatchParams.resourceSourceSettingsPrevious.sourceType))
-    {
+	if( !StringToResourceSourceType( resourceSourceTypePrevious, createPatchParams.resourceSourceSettingsPrevious.sourceType ) )
+	{
 		returnErrorMessage = "Invalid resource source previous type";
 
 		return false;
-    }
+	}
 
-    for (std::string basePath : m_argumentParser->get<std::vector<std::string>>(m_resourceSourceBasePathPreviousArgumentId))
-    {
+	for( std::string basePath : m_argumentParser->get<std::vector<std::string>>( m_resourceSourceBasePathPreviousArgumentId ) )
+	{
 		createPatchParams.resourceSourceSettingsPrevious.basePaths.push_back( basePath );
-    }
+	}
 
 	std::string resourceSourceTypeNext = m_argumentParser->get<std::string>( m_resourceSourceTypeNextArgumentId );
 
-    if (!StringToResourceSourceType(resourceSourceTypeNext, createPatchParams.resourceSourceSettingsNext.sourceType))
-    {
+	if( !StringToResourceSourceType( resourceSourceTypeNext, createPatchParams.resourceSourceSettingsNext.sourceType ) )
+	{
 		returnErrorMessage = "Invalid resource source next type";
 
 		return false;
-    }
+	}
 
-    for (std::string basePath : m_argumentParser->get<std::vector<std::string>>(m_resourceSourceBasePathNextArgumentId))
-    {
+	for( std::string basePath : m_argumentParser->get<std::vector<std::string>>( m_resourceSourceBasePathNextArgumentId ) )
+	{
 		createPatchParams.resourceSourceSettingsNext.basePaths.push_back( basePath );
-    }
+	}
 
 	std::string patchBinaryDestinationType = m_argumentParser->get<std::string>( m_patchBinaryDestinationTypeArgumentId );
 
-    if (!StringToResourceDestinationType(patchBinaryDestinationType, createPatchParams.resourcePatchBinaryDestinationSettings.destinationType))
-    {
+	if( !StringToResourceDestinationType( patchBinaryDestinationType, createPatchParams.resourcePatchBinaryDestinationSettings.destinationType ) )
+	{
 		returnErrorMessage = "Invalid patch binary destination type";
 
 		return false;
-    }
+	}
 
 	createPatchParams.resourcePatchBinaryDestinationSettings.basePath = m_argumentParser->get<std::string>( m_patchBinaryDestinationBasePathArgumentId );
 
 	std::string patchResourceGroupDestinationType = m_argumentParser->get<std::string>( m_patchResourceGroupDestinationTypeArgumentId );
 
-    if (!StringToResourceDestinationType(patchResourceGroupDestinationType, createPatchParams.resourcePatchResourceGroupDestinationSettings.destinationType))
-    {
+	if( !StringToResourceDestinationType( patchResourceGroupDestinationType, createPatchParams.resourcePatchResourceGroupDestinationSettings.destinationType ) )
+	{
 		returnErrorMessage = "Invalid resource group destination type";
 
 		return false;
-    }
+	}
 
 	createPatchParams.resourcePatchResourceGroupDestinationSettings.basePath = m_argumentParser->get<std::string>( m_patchResourceGroupDestinationBasePathArgumentId );
 
 	createPatchParams.patchFileRelativePathPrefix = m_argumentParser->get<std::string>( m_patchFileRelativePathPrefixArgumentId );
 
-	
+
 	try
 	{
 		unsigned long in = std::stoul( m_argumentParser->get( m_maxInputChunkSizeArgumentId ) );
@@ -154,9 +154,9 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 		return false;
 	}
 
-    long long retrySeconds{ 120 };
+	long long retrySeconds{ 120 };
 
-    try
+	try
 	{
 		retrySeconds = std::stoll( m_argumentParser->get( m_downloadRetrySecondsArgumentId ) );
 	}
@@ -175,10 +175,10 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	createPatchParams.downloadRetrySeconds = std::chrono::seconds( retrySeconds );
 
-    if( s_verbosityLevel != CarbonResources::StatusLevel::OFF )
-    {
+	if( s_verbosityLevel != CarbonResources::StatusLevel::OFF )
+	{
 		PrintStartBanner( previousResourceGroupParams, nextResourceGroupParams, createPatchParams );
-    }
+	}
 
 	createPatchParams.indexFolder = m_argumentParser->get( m_indexFolderArgumentId );
 
@@ -189,7 +189,7 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 {
 	std::cout << "---Running Patch Creation---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Previous Resource Group: " << previousResourceGroupParams.filename << std::endl;
 
@@ -203,14 +203,14 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 
 	std::cout << "Patch File Relative Path Prefix: " << createPatchParams.patchFileRelativePathPrefix << std::endl;
 
-    for( std::filesystem::path basePath : createPatchParams.resourceSourceSettingsPrevious.basePaths )
+	for( std::filesystem::path basePath : createPatchParams.resourceSourceSettingsPrevious.basePaths )
 	{
 		std::cout << "Resource Source Settings From Base Path: " << basePath << std::endl;
 	}
 
 	std::cout << "Resource Source Settings From Source Type: " << SourceTypeToString( createPatchParams.resourceSourceSettingsPrevious.sourceType ) << std::endl;
 
-    for( std::filesystem::path basePath : createPatchParams.resourceSourceSettingsNext.basePaths )
+	for( std::filesystem::path basePath : createPatchParams.resourceSourceSettingsNext.basePaths )
 	{
 		std::cout << "Resource Source Settings To Base Path: " << basePath << std::endl;
 	}
@@ -225,18 +225,19 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 
 	std::cout << "Resource Patch Resource Group Destination Settings Destination Type: " << DestinationTypeToString( createPatchParams.resourcePatchResourceGroupDestinationSettings.destinationType ) << std::endl;
 
-	std::cout << "Download Retry Seconds: " <<  createPatchParams.downloadRetrySeconds.count() << std::endl;
+	std::cout << "Download Retry Seconds: " << createPatchParams.downloadRetrySeconds.count() << std::endl;
 
 	std::cout << "Index File Folder: " << createPatchParams.indexFolder << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool CreatePatchCliOperation::CreatePatch( CarbonResources::ResourceGroupImportFromFileParams& previousResourceGroupParams, CarbonResources::ResourceGroupImportFromFileParams& nextResourceGroupParams, CarbonResources::PatchCreateParams& createPatchParams ) const
 {
 	CarbonResources::StatusCallback statusCallback = GetStatusCallback();
 
-    // Get status callback relevant to verbosity level
+	// Get status callback relevant to verbosity level
 	createPatchParams.statusCallback = statusCallback;
 
 	// Previous ResourceGroup
@@ -247,7 +248,7 @@ bool CreatePatchCliOperation::CreatePatch( CarbonResources::ResourceGroupImportF
 
 	CarbonResources::ResourceGroup resourceGroupPrevious;
 
-    previousResourceGroupParams.statusCallback = statusCallback;
+	previousResourceGroupParams.statusCallback = statusCallback;
 
 	CarbonResources::Result importPreviousFromFileResult = resourceGroupPrevious.ImportFromFile( previousResourceGroupParams );
 
@@ -266,7 +267,7 @@ bool CreatePatchCliOperation::CreatePatch( CarbonResources::ResourceGroupImportF
 
 	CarbonResources::ResourceGroup resourceGroupLatest;
 
-    nextResourceGroupParams.statusCallback = statusCallback;
+	nextResourceGroupParams.statusCallback = statusCallback;
 
 	CarbonResources::Result importNextFromFileResult = resourceGroupLatest.ImportFromFile( nextResourceGroupParams );
 
@@ -277,9 +278,9 @@ bool CreatePatchCliOperation::CreatePatch( CarbonResources::ResourceGroupImportF
 		return false;
 	}
 
-    createPatchParams.previousResourceGroup = &resourceGroupPrevious;
+	createPatchParams.previousResourceGroup = &resourceGroupPrevious;
 
-    // Create Patch
+	// Create Patch
 	if( createPatchParams.statusCallback )
 	{
 		createPatchParams.statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 75, "Creating Patch." );
@@ -294,10 +295,10 @@ bool CreatePatchCliOperation::CreatePatch( CarbonResources::ResourceGroupImportF
 		return false;
 	}
 
-    if( createPatchParams.statusCallback )
+	if( createPatchParams.statusCallback )
 	{
 		createPatchParams.statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Patch created succesfully." );
 	}
 
-    return true;
+	return true;
 }

--- a/cli/src/CreatePatchCliOperation.h
+++ b/cli/src/CreatePatchCliOperation.h
@@ -14,46 +14,43 @@
 class CreatePatchCliOperation : public CliOperation
 {
 public:
-
 	CreatePatchCliOperation();
 
 	virtual bool Execute( std::string& returnErrorMessage ) const override;
 
 private:
-
-    void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& previousResourceGroupParams, const CarbonResources::ResourceGroupImportFromFileParams& nextResourceGroupParams, CarbonResources::PatchCreateParams& createPatchParams ) const;
+	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& previousResourceGroupParams, const CarbonResources::ResourceGroupImportFromFileParams& nextResourceGroupParams, CarbonResources::PatchCreateParams& createPatchParams ) const;
 
 	bool CreatePatch( CarbonResources::ResourceGroupImportFromFileParams& previousResourceGroupParams, CarbonResources::ResourceGroupImportFromFileParams& nextResourceGroupParams, CarbonResources::PatchCreateParams& createPatchParams ) const;
 
 private:
-
 	std::string m_previousResourceGroupPathArgumentId;
 
 	std::string m_nextResourceGroupPathArgumentId;
 
-    std::string m_resourceGroupRelativePathArgumentId;
+	std::string m_resourceGroupRelativePathArgumentId;
 
-    std::string m_patchResourceGroupRelativePathArgumentId;
+	std::string m_patchResourceGroupRelativePathArgumentId;
 
-    std::string m_resourceSourceTypePreviousArgumentId;
+	std::string m_resourceSourceTypePreviousArgumentId;
 
-    std::string m_resourceSourceBasePathPreviousArgumentId;
+	std::string m_resourceSourceBasePathPreviousArgumentId;
 
-    std::string m_resourceSourceTypeNextArgumentId;
+	std::string m_resourceSourceTypeNextArgumentId;
 
 	std::string m_resourceSourceBasePathNextArgumentId;
 
-    std::string m_patchBinaryDestinationTypeArgumentId;
+	std::string m_patchBinaryDestinationTypeArgumentId;
 
 	std::string m_patchBinaryDestinationBasePathArgumentId;
 
-    std::string m_patchResourceGroupDestinationTypeArgumentId;
+	std::string m_patchResourceGroupDestinationTypeArgumentId;
 
 	std::string m_patchResourceGroupDestinationBasePathArgumentId;
 
-    std::string m_patchFileRelativePathPrefixArgumentId;
+	std::string m_patchFileRelativePathPrefixArgumentId;
 
-    std::string m_maxInputChunkSizeArgumentId;
+	std::string m_maxInputChunkSizeArgumentId;
 
 	std::string m_downloadRetrySecondsArgumentId;
 

--- a/cli/src/CreateResourceGroupCliOperation.cpp
+++ b/cli/src/CreateResourceGroupCliOperation.cpp
@@ -11,17 +11,17 @@ CreateResourceGroupCliOperation::CreateResourceGroupCliOperation() :
 	m_createResourceGroupPathArgumentId( "input-directory" ),
 	m_createResourceGroupOutputFileArgumentId( "--output-file" ),
 	m_createResourceGroupDocumentVersionArgumentId( "--document-version" ),
-	m_createResourceGroupResourcePrefixArgumentId("--resource-prefix")
+	m_createResourceGroupResourcePrefixArgumentId( "--resource-prefix" )
 {
 
 	AddRequiredPositionalArgument( m_createResourceGroupPathArgumentId, "Base directory to create resource group from." );
 
-    // Struct is inspected to ascertain default values
+	// Struct is inspected to ascertain default values
 	// This keeps default value settings in one place
 	// Lib defaults matches CLI
 	CarbonResources::CreateResourceGroupFromDirectoryParams defaultImportParams;
 
-    CarbonResources::ResourceGroupExportToFileParams defaultExportParams;
+	CarbonResources::ResourceGroupExportToFileParams defaultExportParams;
 
 	AddArgument( m_createResourceGroupOutputFileArgumentId, "Filename for created resource group.", false, false, defaultExportParams.filename.string() );
 
@@ -44,11 +44,11 @@ bool CreateResourceGroupCliOperation::Execute( std::string& returnErrorMessage )
 
 	PrintStartBanner( inputDirectory, outputFile, version, resourcePrefix );
 
-	bool versionIsValid = ParseDocumentVersion( version, documentVersion);
+	bool versionIsValid = ParseDocumentVersion( version, documentVersion );
 
 	if( !versionIsValid )
 	{
-        returnErrorMessage = "Invalid document version";
+		returnErrorMessage = "Invalid document version";
 
 		return false;
 	}
@@ -64,17 +64,18 @@ void CreateResourceGroupCliOperation::PrintStartBanner( const std::filesystem::p
 
 	std::cout << "---Creating Resource Group---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Input Directory: " << inputDirectory << std::endl;
 
-	std::cout << "Output File: " << outputFile<< std::endl;
+	std::cout << "Output File: " << outputFile << std::endl;
 
 	std::cout << "Output Document Version: " << version << std::endl;
 
 	std::cout << "Resource Prefix: " << resourcePrefix << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool CreateResourceGroupCliOperation::CreateResourceGroup( const std::filesystem::path& inputDirectory, const std::filesystem::path& resourceGroupOutputFile, CarbonResources::Version documentVersion, const std::string& resourcePrefix ) const
@@ -92,7 +93,7 @@ bool CreateResourceGroupCliOperation::CreateResourceGroup( const std::filesystem
 	createResourceGroupParams.statusCallback = GetStatusCallback();
 
 
-    if( createResourceGroupParams.statusCallback )
+	if( createResourceGroupParams.statusCallback )
 	{
 		createResourceGroupParams.statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Creating Resource Group from directory" );
 	}
@@ -114,7 +115,7 @@ bool CreateResourceGroupCliOperation::CreateResourceGroup( const std::filesystem
 
 	exportParams.statusCallback = GetStatusCallback();
 
-    if( exportParams.statusCallback )
+	if( exportParams.statusCallback )
 	{
 		exportParams.statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 50, "Exporting Resource Group to file." );
 	}
@@ -128,7 +129,7 @@ bool CreateResourceGroupCliOperation::CreateResourceGroup( const std::filesystem
 		return false;
 	}
 
-    if( exportParams.statusCallback )
+	if( exportParams.statusCallback )
 	{
 		exportParams.statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Resource Group successfully created from directory." );
 	}

--- a/cli/src/CreateResourceGroupCliOperation.h
+++ b/cli/src/CreateResourceGroupCliOperation.h
@@ -16,11 +16,10 @@ public:
 	virtual bool Execute( std::string& returnErrorMessage ) const final;
 
 private:
-    void PrintStartBanner( const std::filesystem::path& inputDirectory, const std::filesystem::path& resourceGroupOutputDirectory, const std::string& version, const std::string& resourcePrefix ) const;
+	void PrintStartBanner( const std::filesystem::path& inputDirectory, const std::filesystem::path& resourceGroupOutputDirectory, const std::string& version, const std::string& resourcePrefix ) const;
 	bool CreateResourceGroup( const std::filesystem::path& inputDirectory, const std::filesystem::path& resourceGroupOutputFile, CarbonResources::Version documentVersion, const std::string& resourcePrefix ) const;
 
 private:
-
 	std::string m_createResourceGroupPathArgumentId;
 
 	std::string m_createResourceGroupOutputFileArgumentId;

--- a/cli/src/DiffResourceGroupCliOperation.cpp
+++ b/cli/src/DiffResourceGroupCliOperation.cpp
@@ -7,7 +7,7 @@
 #include <fstream>
 
 DiffResourceGroupCliOperation::DiffResourceGroupCliOperation() :
-	CliOperation("diff-group", "Outputs a list of additions and subtractions between the two provided ResourceGroups."),
+	CliOperation( "diff-group", "Outputs a list of additions and subtractions between the two provided ResourceGroups." ),
 	m_baseResourceGroupPathArgumentId( "base-resource-group-path" ),
 	m_diffResourceGroupPathArgumentId( "diff-resource-group-path" ),
 	m_diffOutputPath( "--diff-output-path" )
@@ -16,7 +16,7 @@ DiffResourceGroupCliOperation::DiffResourceGroupCliOperation() :
 
 	AddRequiredPositionalArgument( m_diffResourceGroupPathArgumentId, "The path to the Resource Group to act as a target for the diff." );
 
-    AddArgument( m_diffOutputPath, "The path in which to place diff output.", false, false, "Diff.txt" );
+	AddArgument( m_diffOutputPath, "The path in which to place diff output.", false, false, "Diff.txt" );
 }
 
 bool DiffResourceGroupCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -32,7 +32,7 @@ bool DiffResourceGroupCliOperation::Execute( std::string& returnErrorMessage ) c
 	}
 	importParamsBase.filename = filename.value();
 
-    CarbonResources::ResourceGroupImportFromFileParams importParamsDiff;
+	CarbonResources::ResourceGroupImportFromFileParams importParamsDiff;
 
 	std::optional<std::string> filenameDiff = m_argumentParser->present<std::string>( m_diffResourceGroupPathArgumentId );
 	if( !filename.has_value() )
@@ -43,8 +43,8 @@ bool DiffResourceGroupCliOperation::Execute( std::string& returnErrorMessage ) c
 	}
 	importParamsDiff.filename = filenameDiff.value();
 
-	
-    std::filesystem::path outputPath = m_argumentParser->get( m_diffOutputPath );
+
+	std::filesystem::path outputPath = m_argumentParser->get( m_diffOutputPath );
 
 
 	PrintStartBanner( importParamsBase, importParamsDiff, outputPath );
@@ -63,13 +63,14 @@ void DiffResourceGroupCliOperation::PrintStartBanner( const CarbonResources::Res
 
 	std::cout << "---Running Diff---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Base Resource Group: " << importParamsBase.filename << std::endl;
 	std::cout << "Diff Resource Group: " << importParamsDiff.filename << std::endl;
 	std::cout << "Diff Output path: " << outputPath.string() << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool DiffResourceGroupCliOperation::Diff( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsDiff, std::filesystem::path& outputPath ) const
@@ -81,8 +82,8 @@ bool DiffResourceGroupCliOperation::Diff( const CarbonResources::ResourceGroupIm
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Calculating Diff." );
 	}
 
-    // Import base resource group
-    CarbonResources::ResourceGroup baseResourceGroup;
+	// Import base resource group
+	CarbonResources::ResourceGroup baseResourceGroup;
 
 	CarbonResources::Result importBaseGroupResult = baseResourceGroup.ImportFromFile( importParamsBase );
 
@@ -93,7 +94,7 @@ bool DiffResourceGroupCliOperation::Diff( const CarbonResources::ResourceGroupIm
 		return false;
 	}
 
-    // Import diff resource group
+	// Import diff resource group
 	CarbonResources::ResourceGroup diffResourceGroup;
 
 	CarbonResources::Result importDiffGroupResult = diffResourceGroup.ImportFromFile( importParamsDiff );
@@ -105,43 +106,43 @@ bool DiffResourceGroupCliOperation::Diff( const CarbonResources::ResourceGroupIm
 		return false;
 	}
 
-    // Run diff
+	// Run diff
 	std::vector<std::filesystem::path> additions;
 
-    std::vector<std::filesystem::path> subtractions;
+	std::vector<std::filesystem::path> subtractions;
 
-    CarbonResources::ResourceGroupDiffAgainstGroupParams diffParams;
+	CarbonResources::ResourceGroupDiffAgainstGroupParams diffParams;
 
-    diffParams.resourceGroupToDiffAgainst = &baseResourceGroup;
+	diffParams.resourceGroupToDiffAgainst = &baseResourceGroup;
 
-    diffParams.additions = &additions;
+	diffParams.additions = &additions;
 
-    diffParams.subtractions = &subtractions;
+	diffParams.subtractions = &subtractions;
 
-    CarbonResources::Result diffResult = diffResourceGroup.DiffAgainstGroup( diffParams );
+	CarbonResources::Result diffResult = diffResourceGroup.DiffAgainstGroup( diffParams );
 
-    if( diffResult.type != CarbonResources::ResultType::SUCCESS )
+	if( diffResult.type != CarbonResources::ResultType::SUCCESS )
 	{
 		PrintCarbonResourcesError( diffResult );
 
 		return false;
 	}
 
-    // Output the results to file
-    std::ofstream out;
-	
-    out.open( outputPath, std::ios::out | std::ios::binary );
+	// Output the results to file
+	std::ofstream out;
 
-    if (!out)
-    {
+	out.open( outputPath, std::ios::out | std::ios::binary );
+
+	if( !out )
+	{
 		std::string out;
 
 		std::cerr << "Failed to open output file for writing: " << outputPath << std::endl;
 
 		return false;
-    }
+	}
 
-    for( auto addition : additions )
+	for( auto addition : additions )
 	{
 		out << "+ " << addition.string() << "\n";
 	}
@@ -153,11 +154,11 @@ bool DiffResourceGroupCliOperation::Diff( const CarbonResources::ResourceGroupIm
 
 	out.close();
 
-	
-    if( statusCallback )
+
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Diff complete" );
 	}
-    
+
 	return true;
 }

--- a/cli/src/DiffResourceGroupCliOperation.h
+++ b/cli/src/DiffResourceGroupCliOperation.h
@@ -13,7 +13,6 @@ public:
 	bool Execute( std::string& returnErrorMessage ) const final;
 
 private:
-
 	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsDiff, std::filesystem::path& outputPath ) const;
 
 	bool Diff( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsDiff, std::filesystem::path& outputPath ) const;
@@ -21,6 +20,4 @@ private:
 	std::string m_baseResourceGroupPathArgumentId;
 	std::string m_diffResourceGroupPathArgumentId;
 	std::string m_diffOutputPath;
-	
 };
-

--- a/cli/src/MergeResourceGroupCliOperation.cpp
+++ b/cli/src/MergeResourceGroupCliOperation.cpp
@@ -8,7 +8,7 @@
 #include <argparse/argparse.hpp>
 
 MergeResourceGroupCliOperation::MergeResourceGroupCliOperation() :
-	CliOperation("merge-group", "Merge two Resource Groups together"),
+	CliOperation( "merge-group", "Merge two Resource Groups together" ),
 	m_baseResourceGroupPathArgumentId( "base-resource-group-path" ),
 	m_mergeResourceGroupPathArgumentId( "merge-resource-group-path" ),
 	m_mergedResourceGroupDocumentVersionArgumentId( "--document-version" ),
@@ -16,14 +16,13 @@ MergeResourceGroupCliOperation::MergeResourceGroupCliOperation() :
 {
 	AddRequiredPositionalArgument( m_baseResourceGroupPathArgumentId, "The path to the Resource Group to act as a base for the merge." );
 
-    AddRequiredPositionalArgument( m_mergeResourceGroupPathArgumentId, "The path to the Resource Group to act as a target for the merge." );
+	AddRequiredPositionalArgument( m_mergeResourceGroupPathArgumentId, "The path to the Resource Group to act as a target for the merge." );
 
 	CarbonResources::ResourceGroupExportToFileParams defaultParams;
 
-    AddArgument( m_mergedResourceGroupDocumentVersionArgumentId, "Document version for created resource group.", false, false, VersionToString( defaultParams.outputDocumentVersion ) );
+	AddArgument( m_mergedResourceGroupDocumentVersionArgumentId, "Document version for created resource group.", false, false, VersionToString( defaultParams.outputDocumentVersion ) );
 
-    AddArgument( m_mergedResourceGroupOutputArgumentId, "The path in which to place the merged Resource Group.", false, false, defaultParams.filename.string() );
-
+	AddArgument( m_mergedResourceGroupOutputArgumentId, "The path in which to place the merged Resource Group.", false, false, defaultParams.filename.string() );
 }
 
 bool MergeResourceGroupCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -42,7 +41,7 @@ bool MergeResourceGroupCliOperation::Execute( std::string& returnErrorMessage ) 
 
 
 
-    CarbonResources::ResourceGroupImportFromFileParams importParamsMerge;
+	CarbonResources::ResourceGroupImportFromFileParams importParamsMerge;
 
 	std::optional<std::string> mergeResourceGroupFilename = m_argumentParser->present<std::string>( m_mergeResourceGroupPathArgumentId );
 	if( !mergeResourceGroupFilename.has_value() )
@@ -53,25 +52,25 @@ bool MergeResourceGroupCliOperation::Execute( std::string& returnErrorMessage ) 
 	}
 	importParamsMerge.filename = mergeResourceGroupFilename.value();
 
-    CarbonResources::ResourceGroupExportToFileParams exportParams;
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = m_argumentParser->get<std::string>( m_mergedResourceGroupOutputArgumentId );
+	exportParams.filename = m_argumentParser->get<std::string>( m_mergedResourceGroupOutputArgumentId );
 
-    std::string version = m_argumentParser->get( m_mergedResourceGroupDocumentVersionArgumentId );
+	std::string version = m_argumentParser->get( m_mergedResourceGroupDocumentVersionArgumentId );
 
-    CarbonResources::Version documentVersion;
+	CarbonResources::Version documentVersion;
 
-    bool versionIsValid = ParseDocumentVersion( version, documentVersion );
+	bool versionIsValid = ParseDocumentVersion( version, documentVersion );
 
-    if( !versionIsValid )
+	if( !versionIsValid )
 	{
 		returnErrorMessage = "Invalid document version";
 
 		return false;
 	}
 
-    exportParams.outputDocumentVersion = documentVersion;
-       
+	exportParams.outputDocumentVersion = documentVersion;
+
 	PrintStartBanner( importParamsBase, importParamsMerge, exportParams, version );
 
 	return Merge( importParamsBase, importParamsMerge, exportParams );
@@ -86,69 +85,70 @@ void MergeResourceGroupCliOperation::PrintStartBanner( const CarbonResources::Re
 
 	std::cout << "---Merging Groups---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Base Resource Group: " << importParamsBase.filename << std::endl;
 	std::cout << "Merge Resource Group: " << importParamsMerge.filename << std::endl;
 	std::cout << "Output merged Path: " << exportParams.filename << std::endl;
 	std::cout << "Output Document Version: " << version << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool MergeResourceGroupCliOperation::Merge( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsMerge, CarbonResources::ResourceGroupExportToFileParams exportParams ) const
 {
-    // Import base Resource Group
+	// Import base Resource Group
 	CarbonResources::ResourceGroup baseResourceGroup;
 
-    CarbonResources::Result importBaseGroupResult = baseResourceGroup.ImportFromFile( importParamsBase );
+	CarbonResources::Result importBaseGroupResult = baseResourceGroup.ImportFromFile( importParamsBase );
 
-    if (importBaseGroupResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( importBaseGroupResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( importBaseGroupResult );
 
 		return false;
-    }
+	}
 
-    // Import merge Resource Group
+	// Import merge Resource Group
 	CarbonResources::ResourceGroup mergeResourceGroup;
 
-    CarbonResources::Result importMergeGroupResult = mergeResourceGroup.ImportFromFile( importParamsMerge );
+	CarbonResources::Result importMergeGroupResult = mergeResourceGroup.ImportFromFile( importParamsMerge );
 
-    if (importMergeGroupResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( importMergeGroupResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( importMergeGroupResult );
 
 		return false;
-    }
+	}
 
-    // Perform merge
+	// Perform merge
 	CarbonResources::ResourceGroupMergeParams mergeParams;
 
-    CarbonResources::ResourceGroup mergedResultResourceGroup;
+	CarbonResources::ResourceGroup mergedResultResourceGroup;
 
-    mergeParams.resourceGroupToMerge = &mergeResourceGroup;
+	mergeParams.resourceGroupToMerge = &mergeResourceGroup;
 
-    mergeParams.mergedResourceGroup = &mergedResultResourceGroup;
+	mergeParams.mergedResourceGroup = &mergedResultResourceGroup;
 
 	CarbonResources::Result mergeResult = baseResourceGroup.Merge( mergeParams );
 
-    if (mergeResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( mergeResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( mergeResult );
 
-        return false;
-    }
+		return false;
+	}
 
-    // Export
+	// Export
 	CarbonResources::Result exportResult = mergedResultResourceGroup.ExportToFile( exportParams );
 
-    if (exportResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( exportResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( exportResult );
 
-        return false;
-    }
+		return false;
+	}
 
-    return true;
+	return true;
 }

--- a/cli/src/MergeResourceGroupCliOperation.h
+++ b/cli/src/MergeResourceGroupCliOperation.h
@@ -13,15 +13,12 @@ public:
 	bool Execute( std::string& returnErrorMessage ) const final;
 
 private:
-
 	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsMerge, CarbonResources::ResourceGroupExportToFileParams exportParams, const std::string& version ) const;
 
-    bool Merge( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsMerge, CarbonResources::ResourceGroupExportToFileParams exportParams ) const;
+	bool Merge( const CarbonResources::ResourceGroupImportFromFileParams& importParamsBase, const CarbonResources::ResourceGroupImportFromFileParams& importParamsMerge, CarbonResources::ResourceGroupExportToFileParams exportParams ) const;
 
 	std::string m_baseResourceGroupPathArgumentId;
 	std::string m_mergeResourceGroupPathArgumentId;
 	std::string m_mergedResourceGroupOutputArgumentId;
 	std::string m_mergedResourceGroupDocumentVersionArgumentId;
-	
 };
-

--- a/cli/src/RemoveResourcesCliOperation.cpp
+++ b/cli/src/RemoveResourcesCliOperation.cpp
@@ -9,7 +9,7 @@
 #include <fstream>
 
 RemoveResourcesCliOperation::RemoveResourcesCliOperation() :
-	CliOperation("remove-resources", "Remove resources from a ResourceGroup identified by supplied text file containing a list of RelativePaths to remove."),
+	CliOperation( "remove-resources", "Remove resources from a ResourceGroup identified by supplied text file containing a list of RelativePaths to remove." ),
 	m_resourceGroupPathArgumentId( "resource-group-path" ),
 	m_resourceListPath( "resource-list-path" ),
 	m_outputResourceGroupDocumentVersionArgumentId( "--document-version" ),
@@ -20,13 +20,13 @@ RemoveResourcesCliOperation::RemoveResourcesCliOperation() :
 
 	AddRequiredPositionalArgument( m_resourceListPath, "Path to text file containing list of RelativePaths of resources to remove, separated by newlines." );
 
-    CarbonResources::ResourceGroupExportToFileParams defaultParams;
+	CarbonResources::ResourceGroupExportToFileParams defaultParams;
 
-    AddArgument( m_outputResourceGroupDocumentVersionArgumentId, "Document version for created resource group.", false, false, VersionToString( defaultParams.outputDocumentVersion ) );
+	AddArgument( m_outputResourceGroupDocumentVersionArgumentId, "Document version for created resource group.", false, false, VersionToString( defaultParams.outputDocumentVersion ) );
 
-    AddArgument( m_outputResourceGroupPath, "Filename for created resource group.", false, false, defaultParams.filename.string() );
+	AddArgument( m_outputResourceGroupPath, "Filename for created resource group.", false, false, defaultParams.filename.string() );
 
-    AddArgumentFlag( m_ignoreMissingResources, "Set to ignore 'resource not found' errors caused by supplying a list with Resources not present in ResourceGroup." );
+	AddArgumentFlag( m_ignoreMissingResources, "Set to ignore 'resource not found' errors caused by supplying a list with Resources not present in ResourceGroup." );
 }
 
 bool RemoveResourcesCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -51,28 +51,28 @@ bool RemoveResourcesCliOperation::Execute( std::string& returnErrorMessage ) con
 	}
 	std::filesystem::path resourcesToRemovePath = resourceListFilepath.value();
 
-    CarbonResources::ResourceGroupExportToFileParams exportParams;
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    std::string outResourceGroupFilename = m_argumentParser->get<std::string>( m_outputResourceGroupPath );
+	std::string outResourceGroupFilename = m_argumentParser->get<std::string>( m_outputResourceGroupPath );
 
 	exportParams.filename = outResourceGroupFilename;
 
-    std::string version = m_argumentParser->get( m_outputResourceGroupDocumentVersionArgumentId );
+	std::string version = m_argumentParser->get( m_outputResourceGroupDocumentVersionArgumentId );
 
-    CarbonResources::Version documentVersion;
+	CarbonResources::Version documentVersion;
 
 	bool versionIsValid = ParseDocumentVersion( version, documentVersion );
 
-    if( !versionIsValid )
+	if( !versionIsValid )
 	{
 		returnErrorMessage = "Invalid document version";
 
 		return false;
 	}
 
-    exportParams.outputDocumentVersion = documentVersion;
+	exportParams.outputDocumentVersion = documentVersion;
 
-    bool ignoreMissingResources =  m_argumentParser->get<bool>( m_ignoreMissingResources );
+	bool ignoreMissingResources = m_argumentParser->get<bool>( m_ignoreMissingResources );
 
 	PrintStartBanner( importParams, resourcesToRemovePath, exportParams, ignoreMissingResources, version );
 
@@ -88,92 +88,93 @@ void RemoveResourcesCliOperation::PrintStartBanner( const CarbonResources::Resou
 
 	std::cout << "---Removing Resources---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Resource Group: " << importParams.filename << std::endl;
 	std::cout << "Resources to remove Path: " << resourcesToRemoveFile << std::endl;
 	std::cout << "Output Resource Group Path: " << exportParams.filename << std::endl;
 	std::cout << "Output Document Version: " << version << std::endl;
-    if (ignoreMissingResources)
-    {
-	    std::cout << "Ignore missing Resources: On" << exportParams.filename << std::endl;
-    }
-    else
-    {
+	if( ignoreMissingResources )
+	{
+		std::cout << "Ignore missing Resources: On" << exportParams.filename << std::endl;
+	}
+	else
+	{
 		std::cout << "Ignore missing Resources: Off" << exportParams.filename << std::endl;
-    }
+	}
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool RemoveResourcesCliOperation::ReadResourcesToRemoveFile( std::filesystem::path& pathToResourcesToRemoveFile, std::vector<std::filesystem::path>& resourcesToRemoveOut ) const
 {
 	std::ifstream removeListFile( pathToResourcesToRemoveFile );
 
-    if( !removeListFile )
+	if( !removeListFile )
 	{
 		return false;
 	}
 
-    std::string line;
-    while (std::getline(removeListFile, line))
-    {
+	std::string line;
+	while( std::getline( removeListFile, line ) )
+	{
 		resourcesToRemoveOut.push_back( line );
-    }
+	}
 
-    removeListFile.close();
+	removeListFile.close();
 
-    return true;
+	return true;
 }
 
 bool RemoveResourcesCliOperation::RemoveResources( const CarbonResources::ResourceGroupImportFromFileParams& importParams, std::filesystem::path& resourcesToRemoveFile, CarbonResources::ResourceGroupExportToFileParams& exportParams, bool ignoreMissingResources ) const
 {
-    // Import base Resource Group
+	// Import base Resource Group
 	CarbonResources::ResourceGroup resourceGroup;
 
-    CarbonResources::Result importResourceGroupResult = resourceGroup.ImportFromFile( importParams );
+	CarbonResources::Result importResourceGroupResult = resourceGroup.ImportFromFile( importParams );
 
-    if (importResourceGroupResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( importResourceGroupResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( importResourceGroupResult );
 
 		return false;
-    }
+	}
 
-    // Get resources to remove
+	// Get resources to remove
 	std::vector<std::filesystem::path> resourcesToRemove;
 
-    if (!ReadResourcesToRemoveFile(resourcesToRemoveFile, resourcesToRemove))
-    {
+	if( !ReadResourcesToRemoveFile( resourcesToRemoveFile, resourcesToRemove ) )
+	{
 		std::cerr << "Failed to read resources to remove file." << std::endl;
 
 		return false;
-    }
+	}
 
-    CarbonResources::ResourceGroupRemoveResourcesParams removeParams;
+	CarbonResources::ResourceGroupRemoveResourcesParams removeParams;
 
-    removeParams.resourcesToRemove = &resourcesToRemove;
+	removeParams.resourcesToRemove = &resourcesToRemove;
 
-    removeParams.errorIfResourceNotFound = !ignoreMissingResources; 
+	removeParams.errorIfResourceNotFound = !ignoreMissingResources;
 
 
-    CarbonResources::Result removeResult = resourceGroup.RemoveResources( removeParams );
+	CarbonResources::Result removeResult = resourceGroup.RemoveResources( removeParams );
 
-    if (removeResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( removeResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( removeResult );
 
-        return false;
-    }
+		return false;
+	}
 
-    CarbonResources::Result exportResult = resourceGroup.ExportToFile( exportParams );
+	CarbonResources::Result exportResult = resourceGroup.ExportToFile( exportParams );
 
-    if (exportResult.type != CarbonResources::ResultType::SUCCESS)
-    {
+	if( exportResult.type != CarbonResources::ResultType::SUCCESS )
+	{
 		PrintCarbonResourcesError( exportResult );
 
-        return false;
-    }
+		return false;
+	}
 
-    return true;
+	return true;
 }

--- a/cli/src/RemoveResourcesCliOperation.h
+++ b/cli/src/RemoveResourcesCliOperation.h
@@ -13,19 +13,15 @@ public:
 	bool Execute( std::string& returnErrorMessage ) const final;
 
 private:
-
 	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& importParams, std::filesystem::path& resourcesToRemoveFile, CarbonResources::ResourceGroupExportToFileParams& exportParams, bool ignoreMissingResources, const std::string& version ) const;
 
-    bool RemoveResources( const CarbonResources::ResourceGroupImportFromFileParams& importParams, std::filesystem::path& resourcesToRemoveFile, CarbonResources::ResourceGroupExportToFileParams& exportParams, bool ignoreMissingResources ) const;
+	bool RemoveResources( const CarbonResources::ResourceGroupImportFromFileParams& importParams, std::filesystem::path& resourcesToRemoveFile, CarbonResources::ResourceGroupExportToFileParams& exportParams, bool ignoreMissingResources ) const;
 
-    bool ReadResourcesToRemoveFile( std::filesystem::path& pathToResourcesToRemoveFile, std::vector<std::filesystem::path>& resourcesToRemoveOut ) const;
+	bool ReadResourcesToRemoveFile( std::filesystem::path& pathToResourcesToRemoveFile, std::vector<std::filesystem::path>& resourcesToRemoveOut ) const;
 
-    std::string m_resourceGroupPathArgumentId;
+	std::string m_resourceGroupPathArgumentId;
 	std::string m_resourceListPath;
 	std::string m_outputResourceGroupPath;
 	std::string m_outputResourceGroupDocumentVersionArgumentId;
 	std::string m_ignoreMissingResources;
-
-	
 };
-

--- a/cli/src/UnpackBundleCliOperation.cpp
+++ b/cli/src/UnpackBundleCliOperation.cpp
@@ -6,22 +6,22 @@
 #include <argparse/argparse.hpp>
 
 UnpackBundleCliOperation::UnpackBundleCliOperation() :
-	CliOperation("unpack-bundle", "Extracts a bundle to original files given a Bundle Resource Group and a source for chunks [Only available in extended feature development build]"),
-	m_bundleResourceGroupPathArgumentId("bundle-resource-group-path"),
-	m_chunkSourceBasePathsArgumentId("--chunk-source-base-path"),
-	m_chunkSourceTypeArgumentId("--chunk-source-type"),
-	m_resourceDestinationBasePathArgumentId("--resource-destination-base-path"),
-	m_resourceDestinationTypeArgumentId("--resource-destination-type")
+	CliOperation( "unpack-bundle", "Extracts a bundle to original files given a Bundle Resource Group and a source for chunks [Only available in extended feature development build]" ),
+	m_bundleResourceGroupPathArgumentId( "bundle-resource-group-path" ),
+	m_chunkSourceBasePathsArgumentId( "--chunk-source-base-path" ),
+	m_chunkSourceTypeArgumentId( "--chunk-source-type" ),
+	m_resourceDestinationBasePathArgumentId( "--resource-destination-base-path" ),
+	m_resourceDestinationTypeArgumentId( "--resource-destination-type" )
 {
-    AddRequiredPositionalArgument( m_bundleResourceGroupPathArgumentId, "The path to the BundleResourceGroup.yaml file" );
+	AddRequiredPositionalArgument( m_bundleResourceGroupPathArgumentId, "The path to the BundleResourceGroup.yaml file" );
 
-    CarbonResources::BundleUnpackParams defaultParams;
+	CarbonResources::BundleUnpackParams defaultParams;
 
 	AddArgument( m_chunkSourceBasePathsArgumentId, "The path to the directory containing the bundled files.", true, true, PathsToString( defaultParams.chunkSourceSettings.basePaths ) );
 
-	AddArgument( m_chunkSourceTypeArgumentId, "The type of repository from which to retrieve the bundle files.", false, false, SourceTypeToString( defaultParams.chunkSourceSettings.sourceType ), ResourceSourceTypeChoicesAsString());
+	AddArgument( m_chunkSourceTypeArgumentId, "The type of repository from which to retrieve the bundle files.", false, false, SourceTypeToString( defaultParams.chunkSourceSettings.sourceType ), ResourceSourceTypeChoicesAsString() );
 
-	AddArgument( m_resourceDestinationBasePathArgumentId,"The path to the directory in which to place the unbundled files.", false, false, "UnpackBundleOut");
+	AddArgument( m_resourceDestinationBasePathArgumentId, "The path to the directory in which to place the unbundled files.", false, false, "UnpackBundleOut" );
 
 	AddArgument( m_resourceDestinationTypeArgumentId, "The type of repository in which to place the bundle files.", false, false, DestinationTypeToString( defaultParams.resourceDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
 }
@@ -40,7 +40,7 @@ bool UnpackBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 	}
 	importParams.filename = name.value();
 
-    // Unpack the bundle
+	// Unpack the bundle
 	CarbonResources::BundleUnpackParams unpackParams;
 
 	std::string chunkSourceType = m_argumentParser->get( m_chunkSourceTypeArgumentId );
@@ -90,7 +90,7 @@ void UnpackBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
 
 	std::cout << "---Unpacking Bundle---" << std::endl;
 
-    PrintCommonOperationHeaderInformation();
+	PrintCommonOperationHeaderInformation();
 
 	std::cout << "Bundle Resource Group Path:" << importParams.filename << std::endl;
 	std::cout << "Chunk Source Base Paths: " << PathsToString( unpackParams.chunkSourceSettings.basePaths ) << std::endl;
@@ -98,14 +98,15 @@ void UnpackBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
 	std::cout << "Resource Destination Base Path: " << unpackParams.resourceDestinationSettings.basePath << std::endl;
 	std::cout << "Resource Destination Type: " << DestinationTypeToString( unpackParams.resourceDestinationSettings.destinationType ) << std::endl;
 
-	std::cout << "----------------------------\n" << std::endl;
+	std::cout << "----------------------------\n"
+			  << std::endl;
 }
 
 bool UnpackBundleCliOperation::Unpack( CarbonResources::ResourceGroupImportFromFileParams& importParams, CarbonResources::BundleUnpackParams& unpackParams ) const
 {
 	CarbonResources::StatusCallback statusCallback = GetStatusCallback();
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Unpacking Bundle." );
 	}
@@ -113,35 +114,35 @@ bool UnpackBundleCliOperation::Unpack( CarbonResources::ResourceGroupImportFromF
 	// Load the bundle file
 	CarbonResources::BundleResourceGroup bundleResourceGroup;
 
-    importParams.statusCallback = statusCallback;
+	importParams.statusCallback = statusCallback;
 
-	if( bundleResourceGroup.ImportFromFile( importParams).type != CarbonResources::ResultType::SUCCESS )
+	if( bundleResourceGroup.ImportFromFile( importParams ).type != CarbonResources::ResultType::SUCCESS )
 	{
 		return false;
 	}
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 50, "Unpacking" );
 	}
 
-    unpackParams.statusCallback = statusCallback;
+	unpackParams.statusCallback = statusCallback;
 
 	auto unpackResult = bundleResourceGroup.Unpack( unpackParams );
 
-    if( unpackResult.type != CarbonResources::ResultType::SUCCESS)
+	if( unpackResult.type != CarbonResources::ResultType::SUCCESS )
 	{
-    	std::string out;
-    	CarbonResources::ResultTypeToString( unpackResult.type, out );
-    	std::cerr << "Failed to unpack bundle: " << out << std::endl;
-    	if( s_verbosityLevel >= CarbonResources::StatusLevel::DETAIL && !unpackResult.info.empty() )
-    	{
-    		std::cerr << unpackResult.info;
-    	}
-    	exit(1);
+		std::string out;
+		CarbonResources::ResultTypeToString( unpackResult.type, out );
+		std::cerr << "Failed to unpack bundle: " << out << std::endl;
+		if( s_verbosityLevel >= CarbonResources::StatusLevel::DETAIL && !unpackResult.info.empty() )
+		{
+			std::cerr << unpackResult.info;
+		}
+		exit( 1 );
 	}
 
-    if( statusCallback )
+	if( statusCallback )
 	{
 		statusCallback( CarbonResources::StatusLevel::OVERVIEW, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Successfully unpacked Bundle." );
 	}

--- a/cli/src/UnpackBundleCliOperation.h
+++ b/cli/src/UnpackBundleCliOperation.h
@@ -23,4 +23,3 @@ private:
 	std::string m_resourceDestinationBasePathArgumentId;
 	std::string m_resourceDestinationTypeArgumentId;
 };
-

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -28,34 +28,34 @@ std::string CalculateVersionString()
 	ss << " [EXTENDED FEATURE DEVELOPMENT BUILD]";
 #endif
 
-    return ss.str();
+	return ss.str();
 }
 
 int main( int argc, char** argv )
 {
-    Cli cli( "resources", CalculateVersionString() );
+	Cli cli( "resources", CalculateVersionString() );
 
-    CreateResourceGroupCliOperation createResourceGroupOperation;
+	CreateResourceGroupCliOperation createResourceGroupOperation;
 
-    cli.AddOperation( &createResourceGroupOperation );
+	cli.AddOperation( &createResourceGroupOperation );
 
-    CreatePatchCliOperation createPatchOperation;
+	CreatePatchCliOperation createPatchOperation;
 
-    cli.AddOperation( &createPatchOperation );
+	cli.AddOperation( &createPatchOperation );
 
-    CreateBundleCliOperation createBundleOperation;
+	CreateBundleCliOperation createBundleOperation;
 
-    cli.AddOperation( &createBundleOperation );
+	cli.AddOperation( &createBundleOperation );
 
-    MergeResourceGroupCliOperation mergeResourceGroupOperation;
+	MergeResourceGroupCliOperation mergeResourceGroupOperation;
 
 	cli.AddOperation( &mergeResourceGroupOperation );
 
-    DiffResourceGroupCliOperation diffResourceGroupOperation;
+	DiffResourceGroupCliOperation diffResourceGroupOperation;
 
 	cli.AddOperation( &diffResourceGroupOperation );
 
-    RemoveResourcesCliOperation removeResourcesOperation;
+	RemoveResourcesCliOperation removeResourcesOperation;
 
 	cli.AddOperation( &removeResourcesOperation );
 
@@ -69,23 +69,23 @@ int main( int argc, char** argv )
 	cli.AddOperation( &unpackBundleCliOperation );
 #endif
 
-    // Check no arguments
-    if (argc == 1)
-    {
-        // Prints help
+	// Check no arguments
+	if( argc == 1 )
+	{
+		// Prints help
 
 		cli.PrintError();
 
 		std::exit( FAILED_NO_OPERATION_SPECIFIED_RETURN );
-    }
+	}
 
-    // Process commandline
+	// Process commandline
 	int res = cli.ProcessCommandLine( argc, argv );
 
-    if (res != 0)
-    {
+	if( res != 0 )
+	{
 		std::exit( res );
-    }
+	}
 
-    return SUCCESSFUL_RETURN;
+	return SUCCESSFUL_RETURN;
 }

--- a/include/BundleResourceGroup.h
+++ b/include/BundleResourceGroup.h
@@ -13,7 +13,7 @@
 namespace CarbonResources
 {
 
-    /** @struct BundleUnpackParams
+/** @struct BundleUnpackParams
     *  @brief Function Parameters required for CarbonResources::BundleResourceGroup::Unpack
     *  @var BundleUnpackParams::chunkSourceSettings
     *  Location where chunks can be sourced.
@@ -22,41 +22,38 @@ namespace CarbonResources
     *  @var BundleUnpackParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-    struct BundleUnpackParams final
-    {
-		ResourceSourceSettings chunkSourceSettings;
+struct BundleUnpackParams final
+{
+	ResourceSourceSettings chunkSourceSettings;
 
-        ResourceDestinationSettings resourceDestinationSettings;
+	ResourceDestinationSettings resourceDestinationSettings;
 
-        StatusCallback statusCallback = nullptr;
-    };
+	StatusCallback statusCallback = nullptr;
+};
 
-    /** @class BundleResourceGroup
+/** @class BundleResourceGroup
     *  @brief Contains a collection of Chunk Resources
     */
-    class API BundleResourceGroup final: public ResourceGroup
-    {
-    public:
+class API BundleResourceGroup final : public ResourceGroup
+{
+public:
+	class BundleResourceGroupImpl;
 
-        class BundleResourceGroupImpl;
+	BundleResourceGroup();
 
-	    BundleResourceGroup( );
+	BundleResourceGroup( const BundleResourceGroup& ) = delete;
 
-        BundleResourceGroup( const BundleResourceGroup& ) = delete;
+	~BundleResourceGroup();
 
-	    ~BundleResourceGroup();
+	/// @brief Unpacks the Resoruces from the BundleResourceGroup.
+	/// @param params input parameters, See BundleUnpackParams for more details.
+	/// @see ResourceGroup::CreateBundle for information regarding bundle creation.
+	/// @return Result see CarbonResources::Result for more details.
+	Result Unpack( const BundleUnpackParams& params );
 
-        /// @brief Unpacks the Resoruces from the BundleResourceGroup.
-		/// @param params input parameters, See BundleUnpackParams for more details.
-		/// @see ResourceGroup::CreateBundle for information regarding bundle creation.
-		/// @return Result see CarbonResources::Result for more details.
-        Result Unpack( const BundleUnpackParams& params );
-
-    private:
-
-		BundleResourceGroupImpl* m_impl;
-
-    };
+private:
+	BundleResourceGroupImpl* m_impl;
+};
 
 }
 

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -15,7 +15,7 @@
 namespace CarbonResources
 {
 
-    /** @enum StatusLevel
+/** @enum StatusLevel
     *  @brief Reports the granularity level of the reported update.
     *  @var StatusLevel::OFF
     *  No status level specified.
@@ -26,15 +26,15 @@ namespace CarbonResources
     *  @var StatusLevel::DETAIL
     *  Low level status update
     */
-    enum class StatusLevel
-    {
-        OFF,
-	    OVERVIEW,
-	    PROCEDURE,
-	    DETAIL,
-    };
+enum class StatusLevel
+{
+	OFF,
+	OVERVIEW,
+	PROCEDURE,
+	DETAIL,
+};
 
-    /** @enum StatusProgressType
+/** @enum StatusProgressType
     *  @brief Type of progress reported in callback
     *  @var StatusProgressType::UNBOUNDED
     *  Status update with unbounded progress. When set the progress integer doesn't report progress.
@@ -43,22 +43,22 @@ namespace CarbonResources
     *  @var StatusProgressType::WARNING
     *  Warning message. When set the progress integer doesn't report progress
     */
-	enum class StatusProgressType
-	{
-		UNBOUNDED,
-		PERCENTAGE,
-        WARNING
-	};
+enum class StatusProgressType
+{
+	UNBOUNDED,
+	PERCENTAGE,
+	WARNING
+};
 
-    /** Status Callback function signature.
+/** Status Callback function signature.
     * @param statusLevel The status granularity level for the update.
     * @param statusProgressType Type of progress update to expect in update. Affects how progress parameter may be interpreted.
     * @param progress Progress, format is inferred from statusProgressType.
     * @param info Update message string.
     */
-    using StatusCallback = std::function<void( StatusLevel statusLevel, StatusProgressType statusProgressType, unsigned int progress, const std::string& info )>;
+using StatusCallback = std::function<void( StatusLevel statusLevel, StatusProgressType statusProgressType, unsigned int progress, const std::string& info )>;
 
-    /**
+/**
     * @enum CarbonResources::ResultType
     * @brief Error return type codes.
     * @var SUCCESS
@@ -136,69 +136,69 @@ namespace CarbonResources
     * @var REQUIRED_INPUT_PARAMETER_NOT_SET
     * A required input parameter was not set
     */
-    enum class ResultType
-    {
-	    SUCCESS,
-	    FAIL,
-	    UNSUPPORTED_FILE_FORMAT,
-	    FAILED_TO_OPEN_FILE,
-	    MALFORMED_RESOURCE_INPUT,
-	    FILE_TYPE_MISMATCH,
-		DOCUMENT_VERSION_UNSUPPORTED,
-		REQUIRED_RESOURCE_PARAMETER_NOT_SET,
-		FAILED_TO_OPEN_FILE_STREAM,
-        FAILED_TO_READ_FROM_STREAM,
-		FAILED_TO_WRITE_TO_STREAM,
-	    FAILED_TO_DOWNLOAD_FILE,
-		FAILED_TO_CREATE_PATCH,
-		FAILED_TO_SAVE_FILE,
-		FAILED_TO_GENERATE_CHECKSUM,
-		FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM,
-		FAILED_TO_COMPRESS_DATA,
-		PATCH_RESOURCE_LIST_MISSMATCH,
-		FAILED_TO_APPLY_PATCH,
-		UNEXPECTED_PATCH_CHECKSUM_RESULT,
-		UNEXPECTED_PATCH_DIFF_ENCOUNTERED,
-		FILE_NOT_FOUND,
-		FAILED_TO_RETRIEVE_CHUNK_DATA,
-		RESOURCE_VALUE_NOT_SET,
-		UNEXPECTED_END_OF_CHUNKS,
-		UNEXPECTED_CHUNK_CHECKSUM_RESULT,
-		FAILED_TO_SAVE_TO_STREAM,
-		INPUT_DIRECTORY_DOESNT_EXIST,
-	    RESOURCE_TYPE_MISSMATCH,
-    	MALFORMED_RESOURCE_GROUP,
-		MALFORMED_RESOURCE,
-    	FAILED_TO_PARSE_YAML,
-		INVALID_CHUNK_SIZE,
-        RESOURCE_GROUP_NOT_SET,
-        RESOURCE_LIST_NOT_SET,
-        RESOURCE_NOT_FOUND,
-		REQUIRED_INPUT_PARAMETER_NOT_SET,
-        //NOTE: if adding to this enum, a complimentary entry must be added to resultToString.
-    };
+enum class ResultType
+{
+	SUCCESS,
+	FAIL,
+	UNSUPPORTED_FILE_FORMAT,
+	FAILED_TO_OPEN_FILE,
+	MALFORMED_RESOURCE_INPUT,
+	FILE_TYPE_MISMATCH,
+	DOCUMENT_VERSION_UNSUPPORTED,
+	REQUIRED_RESOURCE_PARAMETER_NOT_SET,
+	FAILED_TO_OPEN_FILE_STREAM,
+	FAILED_TO_READ_FROM_STREAM,
+	FAILED_TO_WRITE_TO_STREAM,
+	FAILED_TO_DOWNLOAD_FILE,
+	FAILED_TO_CREATE_PATCH,
+	FAILED_TO_SAVE_FILE,
+	FAILED_TO_GENERATE_CHECKSUM,
+	FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM,
+	FAILED_TO_COMPRESS_DATA,
+	PATCH_RESOURCE_LIST_MISSMATCH,
+	FAILED_TO_APPLY_PATCH,
+	UNEXPECTED_PATCH_CHECKSUM_RESULT,
+	UNEXPECTED_PATCH_DIFF_ENCOUNTERED,
+	FILE_NOT_FOUND,
+	FAILED_TO_RETRIEVE_CHUNK_DATA,
+	RESOURCE_VALUE_NOT_SET,
+	UNEXPECTED_END_OF_CHUNKS,
+	UNEXPECTED_CHUNK_CHECKSUM_RESULT,
+	FAILED_TO_SAVE_TO_STREAM,
+	INPUT_DIRECTORY_DOESNT_EXIST,
+	RESOURCE_TYPE_MISSMATCH,
+	MALFORMED_RESOURCE_GROUP,
+	MALFORMED_RESOURCE,
+	FAILED_TO_PARSE_YAML,
+	INVALID_CHUNK_SIZE,
+	RESOURCE_GROUP_NOT_SET,
+	RESOURCE_LIST_NOT_SET,
+	RESOURCE_NOT_FOUND,
+	REQUIRED_INPUT_PARAMETER_NOT_SET,
+	//NOTE: if adding to this enum, a complimentary entry must be added to resultToString.
+};
 
-    /** @struct Result
+/** @struct Result
     *  @brief Return structure for resources operations
     *  @var Result::type
     *  Type of result returned
     *  @var Result::info
     *  Optional further information on the return
     */
-    struct Result
-    {
-		ResultType type = ResultType::SUCCESS;
+struct Result
+{
+	ResultType type = ResultType::SUCCESS;
 
-		std::string info = "";
-    };
-	
-    /** Converts ResultType to string 
+	std::string info = "";
+};
+
+/** Converts ResultType to string 
     * @param resultType Result type to be converted.
     * @param output Output to string conversion.
     */
-	bool API ResultTypeToString( ResultType resultType, std::string& output );
+bool API ResultTypeToString( ResultType resultType, std::string& output );
 
-    /** @enum ResourceSourceType
+/** @enum ResourceSourceType
     *  @brief Parameters to represent resource source location type
     *  @var ResourceSourceType::LOCAL_RELATIVE
     *  Paths are sourced via plain paths. Resource locations will be constructed by contactenation of base path and the resources' relative path.
@@ -207,15 +207,15 @@ namespace CarbonResources
     *  @var ResourceSourceType::REMOTE_CDN
     *  Resources are downloaded. They will then be processed as ResourceSourceType::LOCAL_CDN.
     */
-	enum class ResourceSourceType
-	{
-		LOCAL_RELATIVE,
-		LOCAL_CDN,
-		REMOTE_CDN,
-		//Note: If altering this enum, ensure that Enums::resourceSourceTypeChoicesAsString reflects update.
-	};
+enum class ResourceSourceType
+{
+	LOCAL_RELATIVE,
+	LOCAL_CDN,
+	REMOTE_CDN,
+	//Note: If altering this enum, ensure that Enums::resourceSourceTypeChoicesAsString reflects update.
+};
 
-    /** @enum ResourceDestinationType
+/** @enum ResourceDestinationType
     *  @brief Parameters to represent resource destinationlocation type.
     *  @var ResourceDestinationType::LOCAL_RELATIVE
     *  Paths are sourced via plain paths. Resource locations will be constructed by contactenation of base path and the resources' relative path.
@@ -224,15 +224,15 @@ namespace CarbonResources
     *  @var ResourceDestinationType::REMOTE_CDN
     *  Resources are compressed. They will then be processed as LOCAL_CDN. Note that the library does not upload the resources, this functionality is external.
     */
-	enum class ResourceDestinationType
-	{
-		LOCAL_RELATIVE,
-		LOCAL_CDN,
-		REMOTE_CDN,
-		//Note: If altering this enum, ensure that Enums::resourceDestinationTypeChoicesAsString reflects update.
-	};
+enum class ResourceDestinationType
+{
+	LOCAL_RELATIVE,
+	LOCAL_CDN,
+	REMOTE_CDN,
+	//Note: If altering this enum, ensure that Enums::resourceDestinationTypeChoicesAsString reflects update.
+};
 
-    /** @struct Version
+/** @struct Version
     *  @brief Represents Version information. Version follows semantic versioning paradigm.
     *  @var Version::major
     *  Major version.
@@ -241,21 +241,21 @@ namespace CarbonResources
     *  @var Version::patch
     *  Patch version
     */
-    struct Version
-    {
-		unsigned int major;
-		unsigned int minor;
-		unsigned int patch;
-    };
+struct Version
+{
+	unsigned int major;
+	unsigned int minor;
+	unsigned int patch;
+};
 
-    static const Version S_LIBRARY_VERSION = { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH }; /*!< Current version of the resources */
+static const Version S_LIBRARY_VERSION = { VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH }; /*!< Current version of the resources */
 
-    static const Version S_DOCUMENT_VERSION = { 0, 1, 0 }; /*!< Maximum document version supported by resources */
+static const Version S_DOCUMENT_VERSION = { 0, 1, 0 }; /*!< Maximum document version supported by resources */
 
-    static const std::vector S_VALID_DOCUMENT_VERSIONS = { 
-                                                            Version{ 0, 0, 0 },
-														    Version{ 0, 1, 0 }
-                                                         }; /*!< List of valid document version supported by resources */
+static const std::vector S_VALID_DOCUMENT_VERSIONS = {
+	Version{ 0, 0, 0 },
+	Version{ 0, 1, 0 }
+}; /*!< List of valid document version supported by resources */
 
 }
 

--- a/include/Exports.h
+++ b/include/Exports.h
@@ -5,21 +5,21 @@
 #define Exports_H
 
 #ifdef CARBON_RESOURCES_STATIC
-#    define API
+#define API
 #else
-#    ifdef _WIN32
-#       ifdef EXPORT_LIBRARY
-#           define API __declspec(dllexport)
-#       else
-#           define API __declspec(dllimport)
-#       endif
-#    else
-#        ifdef EXPORT_LIBRARY
-#            define API __attribute((visibility("default")))
-#        else
-#            define API
-#        endif
-#    endif
+#ifdef _WIN32
+#ifdef EXPORT_LIBRARY
+#define API __declspec( dllexport )
+#else
+#define API __declspec( dllimport )
+#endif
+#else
+#ifdef EXPORT_LIBRARY
+#define API __attribute( ( visibility( "default" ) ) )
+#else
+#define API
+#endif
+#endif
 #endif
 
 #endif // Exports_H

--- a/include/PatchResourceGroup.h
+++ b/include/PatchResourceGroup.h
@@ -14,7 +14,7 @@
 namespace CarbonResources
 {
 
-    /** @struct PatchApplyParams
+/** @struct PatchApplyParams
     *  @brief Function Parameters required for CarbonResources::PatchResourceGroup::Apply
     *  @var PatchApplyParams::newBuildResourcesSourceSettings
     *  Location where new resources can be sourced. Resources will be sourced from here if there are no patches related to them, indicating they are completely new files.
@@ -29,47 +29,45 @@ namespace CarbonResources
     *  @var PatchApplyParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-    struct PatchApplyParams final
-    {
-		ResourceSourceSettings nextBuildResourcesSourceSettings{ ResourceSourceType::LOCAL_RELATIVE };
+struct PatchApplyParams final
+{
+	ResourceSourceSettings nextBuildResourcesSourceSettings{ ResourceSourceType::LOCAL_RELATIVE };
 
-		ResourceSourceSettings patchBinarySourceSettings{};
+	ResourceSourceSettings patchBinarySourceSettings{};
 
-        ResourceSourceSettings resourcesToPatchSourceSettings{ ResourceSourceType::LOCAL_RELATIVE };
+	ResourceSourceSettings resourcesToPatchSourceSettings{ ResourceSourceType::LOCAL_RELATIVE };
 
-        ResourceDestinationSettings resourcesToPatchDestinationSettings{ ResourceDestinationType::LOCAL_RELATIVE };
+	ResourceDestinationSettings resourcesToPatchDestinationSettings{ ResourceDestinationType::LOCAL_RELATIVE };
 
-        std::filesystem::path temporaryFilePath = "tempFile.resource";
+	std::filesystem::path temporaryFilePath = "tempFile.resource";
 
-        StatusCallback statusCallback = nullptr;
-    };
+	StatusCallback statusCallback = nullptr;
+};
 
-    /** @class PatchResourceGroup
+/** @class PatchResourceGroup
     *  @brief Contains a collection of Patch Resources
     */
-    class API PatchResourceGroup final: public ResourceGroup
-    {
+class API PatchResourceGroup final : public ResourceGroup
+{
 
-    public:
-		class PatchResourceGroupImpl;
+public:
+	class PatchResourceGroupImpl;
 
-		PatchResourceGroup( );
+	PatchResourceGroup();
 
-        PatchResourceGroup( const PatchResourceGroup& ) = delete;
+	PatchResourceGroup( const PatchResourceGroup& ) = delete;
 
-	    ~PatchResourceGroup();
+	~PatchResourceGroup();
 
-        /// @brief Applies the Patches from the BundleResourceGroup.
-		/// @param params input parameters, See PatchApplyParams for more details.
-        /// @see ResourceGroup::CreatePatch for information regarding patch creation.
-		/// @return Result see CarbonResources::Result for more details.
-        Result Apply( const PatchApplyParams& params );
+	/// @brief Applies the Patches from the BundleResourceGroup.
+	/// @param params input parameters, See PatchApplyParams for more details.
+	/// @see ResourceGroup::CreatePatch for information regarding patch creation.
+	/// @return Result see CarbonResources::Result for more details.
+	Result Apply( const PatchApplyParams& params );
 
-    private:
-
-		PatchResourceGroupImpl* m_impl;
-
-    };
+private:
+	PatchResourceGroupImpl* m_impl;
+};
 
 }
 

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -12,45 +12,43 @@
 #include <functional>
 
 
-
-
 namespace CarbonResources
 {
-    
-    class ResourceGroup;
-    class PatchResourceGroup;
-    class BundleResourceGroup;
-	struct Result;
-    
-    /** @struct ResourceSourceSettings
+
+class ResourceGroup;
+class PatchResourceGroup;
+class BundleResourceGroup;
+struct Result;
+
+/** @struct ResourceSourceSettings
     *  @brief Parameters to represent where and how a resource is sourced.
     *  @var ResourceSourceSettings::sourceType
     *  Specifies the type of resource location. See ResourceSourceType for more info.
     *  @var ResourceSourceSettings::basePaths
     *  The base paths to locate resources.
     */
-    struct ResourceSourceSettings
-	{
-		ResourceSourceType sourceType = ResourceSourceType::LOCAL_CDN;
+struct ResourceSourceSettings
+{
+	ResourceSourceType sourceType = ResourceSourceType::LOCAL_CDN;
 
-        std::vector<std::filesystem::path> basePaths;
-	};
+	std::vector<std::filesystem::path> basePaths;
+};
 
-    /** @struct ResourceDestinationSettings
+/** @struct ResourceDestinationSettings
     *  @brief Parameters to represent where and how a resource is saved.
     *  @var ResourceDestinationSettings::destinationType
     *  Specifies the type of resource location. See ResourceDestinationType for more info.
     *  @var ResourceDestinationSettings::basePath
     *  The base path to save resources.
     */
-	struct ResourceDestinationSettings
-	{
-		ResourceDestinationType destinationType = ResourceDestinationType::LOCAL_CDN;
+struct ResourceDestinationSettings
+{
+	ResourceDestinationType destinationType = ResourceDestinationType::LOCAL_CDN;
 
-        std::filesystem::path basePath = "";
-	};
+	std::filesystem::path basePath = "";
+};
 
-    /** @struct BundleCreateParams
+/** @struct BundleCreateParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::CreatePatch
     *  @var BundleCreateParams::resourceSourceSettings
     *  Where resources related to ResourceGroup are to be be sourced.
@@ -69,28 +67,28 @@ namespace CarbonResources
     *  @var BundleCreateParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-    struct BundleCreateParams
-	{
-		ResourceSourceSettings resourceSourceSettings = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE };
+struct BundleCreateParams
+{
+	ResourceSourceSettings resourceSourceSettings = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE };
 
-        ResourceDestinationSettings chunkDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "BundleOut/Chunks/" };
+	ResourceDestinationSettings chunkDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "BundleOut/Chunks/" };
 
-        std::filesystem::path resourceGroupRelativePath = "ResourceGroup.yaml";
+	std::filesystem::path resourceGroupRelativePath = "ResourceGroup.yaml";
 
-		std::filesystem::path resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
+	std::filesystem::path resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
 
-        uintmax_t chunkSize = 50000000;
+	uintmax_t chunkSize = 50000000;
 
-        uintmax_t fileReadChunkSize = 10000000;
+	uintmax_t fileReadChunkSize = 10000000;
 
-        ResourceDestinationSettings resourceBundleResourceGroupDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_RELATIVE, "BundleOut/" };
-		
-        StatusCallback statusCallback = nullptr;
+	ResourceDestinationSettings resourceBundleResourceGroupDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_RELATIVE, "BundleOut/" };
 
-    	std::chrono::seconds downloadRetrySeconds{120};
-	};
+	StatusCallback statusCallback = nullptr;
 
-    /** @struct PatchCreateParams
+	std::chrono::seconds downloadRetrySeconds{ 120 };
+};
+
+/** @struct PatchCreateParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::CreatePatch
     *  @var PatchCreateParams::maxInputFileChunkSize
     *  Files are processed in chunks, maxInputFileChunkSize indicate the size of this chunk. Files smaller than chunk will be processed in one pass.
@@ -113,48 +111,48 @@ namespace CarbonResources
     *  @var PatchCreateParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-    struct PatchCreateParams
-	{
-        uint32_t maxInputFileChunkSize = 50000000;
+struct PatchCreateParams
+{
+	uint32_t maxInputFileChunkSize = 50000000;
 
-		ResourceGroup* previousResourceGroup = nullptr;
+	ResourceGroup* previousResourceGroup = nullptr;
 
-        std::filesystem::path resourceGroupRelativePath = "ResourceGroup.yaml";
+	std::filesystem::path resourceGroupRelativePath = "ResourceGroup.yaml";
 
-        std::filesystem::path resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
+	std::filesystem::path resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
 
-        std::filesystem::path patchFileRelativePathPrefix = "Patches/Patch";
+	std::filesystem::path patchFileRelativePathPrefix = "Patches/Patch";
 
-		ResourceSourceSettings resourceSourceSettingsPrevious = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE };
+	ResourceSourceSettings resourceSourceSettingsPrevious = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE };
 
-		ResourceSourceSettings resourceSourceSettingsNext = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE }; 
+	ResourceSourceSettings resourceSourceSettingsNext = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE };
 
-        ResourceDestinationSettings resourcePatchBinaryDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "PatchOut/Patches/" };
-;
-        ResourceDestinationSettings resourcePatchResourceGroupDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_RELATIVE, "PatchOut/" };
-	
-        StatusCallback statusCallback = nullptr;
+	ResourceDestinationSettings resourcePatchBinaryDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "PatchOut/Patches/" };
+	;
+	ResourceDestinationSettings resourcePatchResourceGroupDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_RELATIVE, "PatchOut/" };
 
-    	std::chrono::seconds downloadRetrySeconds{120};
+	StatusCallback statusCallback = nullptr;
 
-    	std::filesystem::path indexFolder = std::filesystem::temp_directory_path() / "carbonResources" / "chunkIndexes";
-    };
+	std::chrono::seconds downloadRetrySeconds{ 120 };
 
-    /** @struct ResourceGroupImportFromFileParams
+	std::filesystem::path indexFolder = std::filesystem::temp_directory_path() / "carbonResources" / "chunkIndexes";
+};
+
+/** @struct ResourceGroupImportFromFileParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::ImportFromFile
     *  @var ResourceGroupImportFromFileParams::filename
     *  Full filename of input file.
     *  @var ResourceGroupImportFromFileParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-    struct ResourceGroupImportFromFileParams
-	{
-		std::filesystem::path filename;
+struct ResourceGroupImportFromFileParams
+{
+	std::filesystem::path filename;
 
-        StatusCallback statusCallback = nullptr;
-	};
+	StatusCallback statusCallback = nullptr;
+};
 
-    /** @struct ResourceGroupExportToFileParams
+/** @struct ResourceGroupExportToFileParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::ExportToFile
     *  @var ResourceGroupExportToFileParams::filename
     *  Full filename of output file. If directory doesn't exist it will be created.
@@ -163,16 +161,16 @@ namespace CarbonResources
     *  @var ResourceGroupExportToFileParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-	struct ResourceGroupExportToFileParams
-	{
-		std::filesystem::path filename = "ResourceGroup.yaml";
+struct ResourceGroupExportToFileParams
+{
+	std::filesystem::path filename = "ResourceGroup.yaml";
 
-		Version outputDocumentVersion = S_DOCUMENT_VERSION;
+	Version outputDocumentVersion = S_DOCUMENT_VERSION;
 
-        StatusCallback statusCallback = nullptr;
-	};
+	StatusCallback statusCallback = nullptr;
+};
 
-	/** @struct CreateResourceGroupFromDirectoryParams
+/** @struct CreateResourceGroupFromDirectoryParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::CreateFromDirectory
     *  @var CreateResourceGroupFromDirectoryParams::directory
     *  Input directory for which to find files.
@@ -183,48 +181,48 @@ namespace CarbonResources
     *  @var CreateResourceGroupFromDirectoryParams::statusCallback
     *  Optional status function callback. Callback is triggered at key status update events.
     */
-	struct CreateResourceGroupFromDirectoryParams
-	{
-		std::filesystem::path directory = "";
+struct CreateResourceGroupFromDirectoryParams
+{
+	std::filesystem::path directory = "";
 
-		uintmax_t resourceStreamThreshold = 10000000;
+	uintmax_t resourceStreamThreshold = 10000000;
 
-		Version outputDocumentVersion = S_DOCUMENT_VERSION;
+	Version outputDocumentVersion = S_DOCUMENT_VERSION;
 
-        StatusCallback statusCallback = nullptr;
+	StatusCallback statusCallback = nullptr;
 
-		std::string resourcePrefix;
-	};
+	std::string resourcePrefix;
+};
 
-    /** @struct ResourceGroupMergeParams
+/** @struct ResourceGroupMergeParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::Merge
     *  @var ResourceGroupMergeParams::resourceGroupToMerge
     *  ResourceGroup to merge
     *  @var ResourceGroupMergeParams::mergedResourceGroup
     *  Resulting ResourceGroup after merge
     */
-	struct ResourceGroupMergeParams
-	{
-		ResourceGroup* resourceGroupToMerge = nullptr;
+struct ResourceGroupMergeParams
+{
+	ResourceGroup* resourceGroupToMerge = nullptr;
 
-        ResourceGroup* mergedResourceGroup = nullptr;
-	};
+	ResourceGroup* mergedResourceGroup = nullptr;
+};
 
-    /** @struct ResourceGroupRemoveResourcesParams
+/** @struct ResourceGroupRemoveResourcesParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::RemoveResources
     *  @var ResourceGroupRemoveResourcesParams::resourcesToRemove
     *  List of Resources to remove identified by RelativePath.
     *  @var ResourceGroupRemoveResourcesParams::errorIfResourceNotFound
     *  If true the function will return an error state if supplied Resource is not present in ResourceGroup
     */
-	struct ResourceGroupRemoveResourcesParams
-	{
-		std::vector<std::filesystem::path>* resourcesToRemove = nullptr;
+struct ResourceGroupRemoveResourcesParams
+{
+	std::vector<std::filesystem::path>* resourcesToRemove = nullptr;
 
-        bool errorIfResourceNotFound = true;
-	};
+	bool errorIfResourceNotFound = true;
+};
 
-    /** @struct ResourceGroupDiffAgainstGroupParams
+/** @struct ResourceGroupDiffAgainstGroupParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::DiffAgainstGroup
     *  @var ResourceGroupDiffAgainstGroupParams::resourceGroupToDiffAgainst
     *  Resource group to diff against
@@ -233,82 +231,80 @@ namespace CarbonResources
     *  @var ResourceGroupDiffAgainstGroupParams::subtractions
     *  Output list of relative paths that have been removed on second group.
     */
-	struct ResourceGroupDiffAgainstGroupParams
-	{
-		ResourceGroup* resourceGroupToDiffAgainst = nullptr;
+struct ResourceGroupDiffAgainstGroupParams
+{
+	ResourceGroup* resourceGroupToDiffAgainst = nullptr;
 
-		std::vector<std::filesystem::path>* additions = nullptr;
+	std::vector<std::filesystem::path>* additions = nullptr;
 
-        std::vector<std::filesystem::path>* subtractions = nullptr;
-	};
+	std::vector<std::filesystem::path>* subtractions = nullptr;
+};
 
-    /** @class ResourceGroup
+/** @class ResourceGroup
     *  @brief Contains a collection of Resources
     */
-    class API ResourceGroup
-    {
-	public:
-		class ResourceGroupImpl;
+class API ResourceGroup
+{
+public:
+	class ResourceGroupImpl;
 
-	protected:
-		
-        ResourceGroup( ResourceGroupImpl* impl );
+protected:
+	ResourceGroup( ResourceGroupImpl* impl );
 
-        ResourceGroup( const ResourceGroup& ) = delete;
+	ResourceGroup( const ResourceGroup& ) = delete;
 
-		ResourceGroupImpl* m_impl;
+	ResourceGroupImpl* m_impl;
 
-    public:
-	    ResourceGroup();
+public:
+	ResourceGroup();
 
-	    virtual ~ResourceGroup();
+	virtual ~ResourceGroup();
 
-        /// @brief Creates a Bundle from the ResourceGroup.
-		/// @param params input parameters, See BundleCreateParams for more details.
-        /// @see BundleResourceGroup::Unpack for information regarding bundle unpacking.
-		/// @return Result see CarbonResources::Result for more details.
-        Result CreateBundle( const BundleCreateParams& params ) const;
+	/// @brief Creates a Bundle from the ResourceGroup.
+	/// @param params input parameters, See BundleCreateParams for more details.
+	/// @see BundleResourceGroup::Unpack for information regarding bundle unpacking.
+	/// @return Result see CarbonResources::Result for more details.
+	Result CreateBundle( const BundleCreateParams& params ) const;
 
-        /// @brief Creates a Patch from the ResourceGroup. This ResourceGroup is expected to be latest.
-		/// @param params input parameters, See PatchCreateParams for more details.
-        /// @see PatchResourceGroup::Apply for information regarding patch application.
-		/// @return Result see CarbonResources::Result for more details.
-        Result CreatePatch( const PatchCreateParams& params ) const;
+	/// @brief Creates a Patch from the ResourceGroup. This ResourceGroup is expected to be latest.
+	/// @param params input parameters, See PatchCreateParams for more details.
+	/// @see PatchResourceGroup::Apply for information regarding patch application.
+	/// @return Result see CarbonResources::Result for more details.
+	Result CreatePatch( const PatchCreateParams& params ) const;
 
-        /// @brief Imports resource data from file.
-		/// @param params input parameters, See ResourceGroupImportFromFileParams for more details.
-		/// @return Result see CarbonResources::Result for more details.
-        /// @note Legacy support for importing from resfileindex CSV files is included.
-        Result ImportFromFile( const ResourceGroupImportFromFileParams& params ) const;
+	/// @brief Imports resource data from file.
+	/// @param params input parameters, See ResourceGroupImportFromFileParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	/// @note Legacy support for importing from resfileindex CSV files is included.
+	Result ImportFromFile( const ResourceGroupImportFromFileParams& params ) const;
 
-        /// @brief Exports ResourceGroup to file.
-		/// @param params input parameters, See ResourceGroupExportToFileParams for more details.
-		/// @return Result see CarbonResources::Result for more details.
-        Result ExportToFile( const ResourceGroupExportToFileParams& params ) const;
+	/// @brief Exports ResourceGroup to file.
+	/// @param params input parameters, See ResourceGroupExportToFileParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	Result ExportToFile( const ResourceGroupExportToFileParams& params ) const;
 
-        /// @brief Creates a ResourceGroup from a supplied directory.
-		/// @param params input parameters, See CreateResourceGroupFromDirectoryParams for more details.
-		/// @return Result see CarbonResources::Result for more details.
-		/// @note No file filtering supported
-        Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params );
+	/// @brief Creates a ResourceGroup from a supplied directory.
+	/// @param params input parameters, See CreateResourceGroupFromDirectoryParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	/// @note No file filtering supported
+	Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params );
 
-        /// @brief Merges a supplied ResourceGroup with this one. Merge performed on RelativePath, merge ResourceGroup takes precedent.
-		/// @param params input parameters, See ResourceGroupMergeParams for more details.
-		/// @return Result see CarbonResources::Result for more details.
-		Result Merge( const ResourceGroupMergeParams& params ) const;
+	/// @brief Merges a supplied ResourceGroup with this one. Merge performed on RelativePath, merge ResourceGroup takes precedent.
+	/// @param params input parameters, See ResourceGroupMergeParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	Result Merge( const ResourceGroupMergeParams& params ) const;
 
-        /// @brief Diffs two supplied ResourceGroups.
-		/// @param params input parameters, See ResourceGroupDiffAgainstGroupParams for more details.
-		/// @return Result see CarbonResources::Result for more details.
-		Result DiffAgainstGroup( const ResourceGroupDiffAgainstGroupParams& params ) const;
+	/// @brief Diffs two supplied ResourceGroups.
+	/// @param params input parameters, See ResourceGroupDiffAgainstGroupParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	Result DiffAgainstGroup( const ResourceGroupDiffAgainstGroupParams& params ) const;
 
-        /// @brief Removes Resources from ResourceGroup. Resources to remove are supplied are identified from a vector of RelativePaths.
-		/// @param params input parameters, See CreateResourceGroupFromDirectoryParams for more details.
-		/// @return Result see CarbonResources::Result for more details.
-		/// @note No file filtering supported
-		Result RemoveResources( const ResourceGroupRemoveResourcesParams& params ) const;
-
-    };
+	/// @brief Removes Resources from ResourceGroup. Resources to remove are supplied are identified from a vector of RelativePaths.
+	/// @param params input parameters, See CreateResourceGroupFromDirectoryParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	/// @note No file filtering supported
+	Result RemoveResources( const ResourceGroupRemoveResourcesParams& params ) const;
+};
 
 }
 

--- a/src/BundleResourceGroup.cpp
+++ b/src/BundleResourceGroup.cpp
@@ -6,21 +6,19 @@
 namespace CarbonResources
 {
 
-    BundleResourceGroup::BundleResourceGroup(  ) :
-	    ResourceGroup( new BundleResourceGroupImpl( )),
-		m_impl( reinterpret_cast<BundleResourceGroupImpl*>( ResourceGroup::m_impl ) )
-    {
+BundleResourceGroup::BundleResourceGroup() :
+	ResourceGroup( new BundleResourceGroupImpl() ),
+	m_impl( reinterpret_cast<BundleResourceGroupImpl*>( ResourceGroup::m_impl ) )
+{
+}
 
-    }
+BundleResourceGroup::~BundleResourceGroup()
+{
+}
 
-    BundleResourceGroup::~BundleResourceGroup()
-    {
-
-    }
-
-	Result BundleResourceGroup::Unpack( const BundleUnpackParams& params )
-    {
-		return m_impl->Unpack(params);
-    }
+Result BundleResourceGroup::Unpack( const BundleUnpackParams& params )
+{
+	return m_impl->Unpack( params );
+}
 
 }

--- a/src/BundleResourceGroupImpl.cpp
+++ b/src/BundleResourceGroupImpl.cpp
@@ -19,399 +19,394 @@
 namespace CarbonResources
 {
 
-    BundleResourceGroup::BundleResourceGroupImpl::BundleResourceGroupImpl() :
-	    ResourceGroup::ResourceGroupImpl()
-    {
-		m_chunkSize = 1000;
+BundleResourceGroup::BundleResourceGroupImpl::BundleResourceGroupImpl() :
+	ResourceGroup::ResourceGroupImpl()
+{
+	m_chunkSize = 1000;
 
-        m_resourceGroupParameter = new ResourceGroupInfo( {} );
+	m_resourceGroupParameter = new ResourceGroupInfo( {} );
 
-		m_type = TypeId();
-    }
+	m_type = TypeId();
+}
 
-    BundleResourceGroup::BundleResourceGroupImpl::~BundleResourceGroupImpl()
-    {
-		delete m_resourceGroupParameter.GetValue();
-    }
+BundleResourceGroup::BundleResourceGroupImpl::~BundleResourceGroupImpl()
+{
+	delete m_resourceGroupParameter.GetValue();
+}
 
-    Result BundleResourceGroup::BundleResourceGroupImpl::SetChunkSize( uintmax_t size )
-    {
-        if (size <= 0)
-        {
-			return Result{ ResultType::INVALID_CHUNK_SIZE };
-        }
+Result BundleResourceGroup::BundleResourceGroupImpl::SetChunkSize( uintmax_t size )
+{
+	if( size <= 0 )
+	{
+		return Result{ ResultType::INVALID_CHUNK_SIZE };
+	}
 
-		m_chunkSize = size;
+	m_chunkSize = size;
 
-        return Result{ ResultType::SUCCESS };
-    }
+	return Result{ ResultType::SUCCESS };
+}
 
-    Result BundleResourceGroup::BundleResourceGroupImpl::SetResourceGroup( const ResourceGroupInfo& resourceGroup )
-    {
-		// Creates a deep copy
-		return m_resourceGroupParameter.GetValue()->SetParametersFromResource( &resourceGroup, m_versionParameter.GetValue() );
-    }
+Result BundleResourceGroup::BundleResourceGroupImpl::SetResourceGroup( const ResourceGroupInfo& resourceGroup )
+{
+	// Creates a deep copy
+	return m_resourceGroupParameter.GetValue()->SetParametersFromResource( &resourceGroup, m_versionParameter.GetValue() );
+}
 
-    Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackParams& params )
-    {
-		if( params.statusCallback )
+Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackParams& params )
+{
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Unpacking" );
+	}
+
+	ResourceGroupInfo* resourceGroupResource = m_resourceGroupParameter.GetValue();
+
+
+	// Load the resourceGroup from the resourceGroupResource
+	std::string resourceGroupData;
+
+	ResourceGetDataParams resourceGroupDataParams;
+
+	resourceGroupDataParams.resourceSourceSettings = params.chunkSourceSettings;
+
+	resourceGroupDataParams.data = &resourceGroupData;
+
+	Result getChecksumResult = resourceGroupResource->GetChecksum( resourceGroupDataParams.expectedChecksum );
+
+	if( getChecksumResult.type != ResultType::SUCCESS )
+	{
+		return getChecksumResult;
+	}
+
+	Result resourceGroupGetDataResult = m_resourceGroupParameter.GetValue()->GetData( resourceGroupDataParams );
+
+	if( resourceGroupGetDataResult.type != ResultType::SUCCESS )
+	{
+		return resourceGroupGetDataResult;
+	}
+
+	std::shared_ptr<ResourceGroupImpl> resourceGroup;
+	Result createResult = CreateResourceGroupFromYamlString( resourceGroupData, resourceGroup );
+	if( createResult.type != ResultType::SUCCESS )
+	{
+		std::stringstream ss;
+		ss << "Failed to import resource group data from the following paths:";
+		for( auto path : resourceGroupDataParams.resourceSourceSettings.basePaths )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Unpacking" );
+			ss << " \"" << path.string() << "\"";
+		}
+		createResult.info = ss.str();
+		return createResult;
+	}
+
+	// Create stream
+	ResourceTools::BundleStreamIn bundleStream( m_chunkSize.GetValue() );
+
+	auto chunkIterator = m_resourcesParameter.begin();
+
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 20, "Rebuilding resources." );
+	}
+
+	// Reconstitute the resources in the bundle
+	auto numResources = resourceGroup->GetSize();
+	int numProcessed = 0;
+
+	std::vector<ResourceInfo*> toBundle;
+
+	std::copy( resourceGroup->begin(), resourceGroup->end(), std::back_inserter( toBundle ) );
+
+	Result getGroupSpecificResourcesToBundleResult = resourceGroup->GetGroupSpecificResourcesToBundle( toBundle );
+
+	if( getGroupSpecificResourcesToBundleResult.type != ResultType::SUCCESS )
+	{
+		return getGroupSpecificResourcesToBundleResult;
+	}
+
+	for( ResourceInfo* resource : toBundle )
+	{
+		std::string location;
+
+		Result getLocationResult = resource->GetLocation( location );
+
+		if( getLocationResult.type != ResultType::SUCCESS )
+		{
+			return getLocationResult;
 		}
 
-		ResourceGroupInfo* resourceGroupResource = m_resourceGroupParameter.GetValue();
+		if( params.statusCallback )
+		{
+			std::filesystem::path relativePath;
+
+			if( resource->GetRelativePath( relativePath ).type != ResultType::SUCCESS )
+			{
+				return Result{ ResultType::FAIL };
+			}
+
+			std::string message;
+
+			if( location.empty() )
+			{
+				message = "Nothing to rebuild: " + relativePath.string();
+			}
+			else
+			{
+				message = "Rebuilding: " + relativePath.string();
+			}
+
+			auto percentage = static_cast<unsigned int>( ( 100 * numProcessed ) / numResources );
+
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, message );
+
+			numProcessed++;
+		}
+
+		if( location.empty() )
+		{
+			continue;
+		}
+
+		uintmax_t resourceFileUncompressedSize;
+
+		Result getUncompressedDataSizeResult = resource->GetUncompressedSize( resourceFileUncompressedSize );
+
+		if( getUncompressedDataSizeResult.type != ResultType::SUCCESS )
+		{
+			return getUncompressedDataSizeResult;
+		}
 
 
-		// Load the resourceGroup from the resourceGroupResource
-		std::string resourceGroupData;
+		ResourceTools::FileDataStreamOut resourceDataStreamOut;
 
-		ResourceGetDataParams resourceGroupDataParams;
+		ResourcePutDataStreamParams resourcePutDataStreamParams;
 
-		resourceGroupDataParams.resourceSourceSettings = params.chunkSourceSettings;
+		resourcePutDataStreamParams.resourceDestinationSettings = params.resourceDestinationSettings;
 
-		resourceGroupDataParams.data = &resourceGroupData;
+		resourcePutDataStreamParams.dataStream = &resourceDataStreamOut;
 
-		Result getChecksumResult = resourceGroupResource->GetChecksum( resourceGroupDataParams.expectedChecksum );
+		Result resourcePutDataStreamResult = resource->PutDataStream( resourcePutDataStreamParams );
+
+		if( resourcePutDataStreamResult.type != ResultType::SUCCESS )
+		{
+			return resourcePutDataStreamResult;
+		}
+
+		ResourceTools::GetFile file;
+
+		file.fileSize = resourceFileUncompressedSize;
+
+		// Calculate checksum while processing chunks
+		ResourceTools::Md5ChecksumStream resourceChecksumStream;
+
+		while( resourceDataStreamOut.GetFileSize() < resourceFileUncompressedSize )
+		{
+			if( chunkIterator != m_resourcesParameter.end() )
+			{
+				ResourceInfo* chunk = ( *chunkIterator );
+
+				// Get chunk data
+				std::string chunkData;
+
+				ResourceGetDataParams resourceGetDataParams;
+
+				resourceGetDataParams.resourceSourceSettings = params.chunkSourceSettings;
+
+				resourceGetDataParams.data = &chunkData;
+
+				Result getChunkChecksumResult = chunk->GetChecksum( resourceGetDataParams.expectedChecksum );
+
+				if( getChunkChecksumResult.type != ResultType::SUCCESS )
+				{
+					return getChunkChecksumResult;
+				}
+
+				Result getChunkDataResult = chunk->GetData( resourceGetDataParams );
+
+				if( getChunkDataResult.type != ResultType::SUCCESS )
+				{
+					return getChunkDataResult;
+				}
+
+				// Add to chunk stream
+				if( !( bundleStream << chunkData ) )
+				{
+					return Result{ ResultType::FAIL };
+				}
+			}
+			else
+			{
+				if( bundleStream.GetCacheSize() == 0 )
+				{
+					return Result{ ResultType::UNEXPECTED_END_OF_CHUNKS };
+				}
+			}
+
+
+			std::string resourceChunkData;
+
+			file.data = &resourceChunkData;
+
+			// Retreive chunk from stream
+			// This ensures that we only get the data expected
+			// for this resource, extra is cached for next resource
+			if( !( bundleStream >> file ) )
+			{
+				return Result{ ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA };
+			}
+
+			if( !( resourceChecksumStream << resourceChunkData ) )
+			{
+				return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+			}
+
+			if( !( resourceDataStreamOut << resourceChunkData ) )
+			{
+				return Result{ ResultType::FAILED_TO_SAVE_TO_STREAM };
+			}
+
+			if( chunkIterator != m_resourcesParameter.end() )
+			{
+				chunkIterator++;
+			}
+		}
+
+		// Validate the resource data
+		std::string recreatedResourceChecksum;
+
+		if( !resourceChecksumStream.FinishAndRetrieve( recreatedResourceChecksum ) )
+		{
+			return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+		}
+
+
+		std::string resourceChecksum;
+
+		Result getChecksumResult = resource->GetChecksum( resourceChecksum );
 
 		if( getChecksumResult.type != ResultType::SUCCESS )
 		{
 			return getChecksumResult;
 		}
 
-		Result resourceGroupGetDataResult = m_resourceGroupParameter.GetValue()->GetData( resourceGroupDataParams );
-
-		if( resourceGroupGetDataResult.type != ResultType::SUCCESS )
+		if( recreatedResourceChecksum != resourceChecksum )
 		{
-			return resourceGroupGetDataResult;
+			return Result{ ResultType::UNEXPECTED_CHUNK_CHECKSUM_RESULT };
 		}
-
-    	std::shared_ptr<ResourceGroupImpl> resourceGroup;
-    	Result createResult = CreateResourceGroupFromYamlString( resourceGroupData, resourceGroup );
-    	if( createResult.type != ResultType::SUCCESS )
-    	{
-			std::stringstream ss;
-			ss << "Failed to import resource group data from the following paths:";
-			for( auto path : resourceGroupDataParams.resourceSourceSettings.basePaths )
-			{
-				ss << " \"" << path.string() << "\"";
-			}
-			createResult.info = ss.str();
-			return createResult;
-		}
-
-        // Create stream
-		ResourceTools::BundleStreamIn bundleStream(m_chunkSize.GetValue());
-
-        auto chunkIterator = m_resourcesParameter.begin();
-
-        if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 20, "Rebuilding resources." );
-		}
-
-        // Reconstitute the resources in the bundle
-		auto numResources = resourceGroup->GetSize();
-		int numProcessed = 0;
-
-		std::vector<ResourceInfo*> toBundle;
-
-		std::copy( resourceGroup->begin(), resourceGroup->end(), std::back_inserter( toBundle ) );
-
-		Result getGroupSpecificResourcesToBundleResult = resourceGroup->GetGroupSpecificResourcesToBundle( toBundle );
-
-		if( getGroupSpecificResourcesToBundleResult.type != ResultType::SUCCESS )
-		{
-			return getGroupSpecificResourcesToBundleResult;
-		}
-
-		for( ResourceInfo* resource : toBundle )
-		{
-			std::string location;
-
-			Result getLocationResult = resource->GetLocation( location );
-
-			if( getLocationResult.type != ResultType::SUCCESS )
-			{
-				return getLocationResult;
-			}
-
-			if( params.statusCallback )
-			{
-				std::filesystem::path relativePath;
-
-                if (resource->GetRelativePath(relativePath).type != ResultType::SUCCESS)
-                {
-					return Result{ ResultType::FAIL };
-                }
-
-				std::string message;
-
-				if( location.empty() )
-				{
-					message = "Nothing to rebuild: " + relativePath.string();
-				}
-				else
-				{
-					message = "Rebuilding: " + relativePath.string();
-				}
-
-				auto percentage = static_cast<unsigned int>( ( 100 * numProcessed ) / numResources );
-
-				params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, message );
-
-                numProcessed++;
-			}
-
-			if( location.empty() )
-			{
-				continue;
-			}
-
-            uintmax_t resourceFileUncompressedSize;
-
-            Result getUncompressedDataSizeResult = resource->GetUncompressedSize( resourceFileUncompressedSize );
-
-            if (getUncompressedDataSizeResult.type != ResultType::SUCCESS)
-            {
-				return getUncompressedDataSizeResult;
-            }
-
-
-            ResourceTools::FileDataStreamOut resourceDataStreamOut;
-
-            ResourcePutDataStreamParams resourcePutDataStreamParams;
-
-            resourcePutDataStreamParams.resourceDestinationSettings = params.resourceDestinationSettings;
-
-            resourcePutDataStreamParams.dataStream = &resourceDataStreamOut;
-
-            Result resourcePutDataStreamResult = resource->PutDataStream( resourcePutDataStreamParams );
-
-            if (resourcePutDataStreamResult.type != ResultType::SUCCESS)
-            {
-				return resourcePutDataStreamResult;
-            }
-
-			ResourceTools::GetFile file;
-
-            file.fileSize = resourceFileUncompressedSize;
-
-            // Calculate checksum while processing chunks
-			ResourceTools::Md5ChecksumStream resourceChecksumStream;
-
-            while( resourceDataStreamOut.GetFileSize() < resourceFileUncompressedSize )
-            {
-                if (chunkIterator != m_resourcesParameter.end())
-                {
-					ResourceInfo* chunk = ( *chunkIterator );
-
-					// Get chunk data
-					std::string chunkData;
-
-					ResourceGetDataParams resourceGetDataParams;
-
-					resourceGetDataParams.resourceSourceSettings = params.chunkSourceSettings;
-
-					resourceGetDataParams.data = &chunkData;
-
-					Result getChunkChecksumResult = chunk->GetChecksum( resourceGetDataParams.expectedChecksum );
-
-					if( getChunkChecksumResult.type != ResultType::SUCCESS )
-					{
-						return getChunkChecksumResult;
-					}
-
-					Result getChunkDataResult = chunk->GetData( resourceGetDataParams );
-
-					if( getChunkDataResult.type != ResultType::SUCCESS )
-					{
-						return getChunkDataResult;
-					}
-
-					// Add to chunk stream
-					if( !( bundleStream << chunkData ) )
-					{
-						return Result{ ResultType::FAIL };
-					}
-                }
-                else
-                {
-                    if (bundleStream.GetCacheSize() == 0)
-                    {
-						return Result{ ResultType::UNEXPECTED_END_OF_CHUNKS };
-                    }
-                }
-
-				
-                std::string resourceChunkData;
-
-                file.data = &resourceChunkData;
-             
-                // Retreive chunk from stream
-                // This ensures that we only get the data expected
-                // for this resource, extra is cached for next resource
-                if (!(bundleStream >> file))
-                {
-					return Result{ ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA };
-                }
-
-                if( !( resourceChecksumStream << resourceChunkData ) )
-                {
-					return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                }
-
-                if( !( resourceDataStreamOut << resourceChunkData ) )
-                {
-					return Result{ ResultType::FAILED_TO_SAVE_TO_STREAM };
-                }
-
-                if( chunkIterator != m_resourcesParameter.end() )
-				{
-					chunkIterator++;
-				}
-            }
-
-            // Validate the resource data
-			std::string recreatedResourceChecksum;
-
-            if (!resourceChecksumStream.FinishAndRetrieve(recreatedResourceChecksum))
-            {
-				return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-            }
-
-           
-            std::string resourceChecksum;
-
-            Result getChecksumResult = resource->GetChecksum( resourceChecksum );
-
-            if (getChecksumResult.type != ResultType::SUCCESS)
-            {
-				return getChecksumResult;
-            }
-
-            if (recreatedResourceChecksum != resourceChecksum)
-            {
-				return Result{ ResultType::UNEXPECTED_CHUNK_CHECKSUM_RESULT };
-            }
-
-		}
-
-    	// Export the resource group file.
-    	ResourceGroupExportToFileParams exportParams;
-    	std::filesystem::path resourceGroupRelativePath;
-    	Result getResourceGroupRelativePathResult = resourceGroupResource->GetRelativePath( resourceGroupRelativePath );
-    	if( getResourceGroupRelativePathResult.type != ResultType::SUCCESS )
-    	{
-    		return getResourceGroupRelativePathResult;
-    	}
-    	exportParams.filename = params.resourceDestinationSettings.basePath / resourceGroupRelativePath;
-    	exportParams.statusCallback = params.statusCallback;
-    	Result exportResult = resourceGroup->ExportToFile( exportParams );
-    	if( exportResult.type != ResultType::SUCCESS )
-    	{
-    		return exportResult;
-    	}
-
-        return Result{ ResultType::SUCCESS };
-
-    }
-
-    std::string BundleResourceGroup::BundleResourceGroupImpl::GetType() const
-	{
-		return TypeId();
 	}
 
-    std::string BundleResourceGroup::BundleResourceGroupImpl::TypeId()
+	// Export the resource group file.
+	ResourceGroupExportToFileParams exportParams;
+	std::filesystem::path resourceGroupRelativePath;
+	Result getResourceGroupRelativePathResult = resourceGroupResource->GetRelativePath( resourceGroupRelativePath );
+	if( getResourceGroupRelativePathResult.type != ResultType::SUCCESS )
 	{
-		return "BundleGroup";
+		return getResourceGroupRelativePathResult;
+	}
+	exportParams.filename = params.resourceDestinationSettings.basePath / resourceGroupRelativePath;
+	exportParams.statusCallback = params.statusCallback;
+	Result exportResult = resourceGroup->ExportToFile( exportParams );
+	if( exportResult.type != ResultType::SUCCESS )
+	{
+		return exportResult;
 	}
 
-    Result BundleResourceGroup::BundleResourceGroupImpl::CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut )
+	return Result{ ResultType::SUCCESS };
+}
+
+std::string BundleResourceGroup::BundleResourceGroupImpl::GetType() const
+{
+	return TypeId();
+}
+
+std::string BundleResourceGroup::BundleResourceGroupImpl::TypeId()
+{
+	return "BundleGroup";
+}
+
+Result BundleResourceGroup::BundleResourceGroupImpl::CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut )
+{
+	BundleResourceInfo* bundleResourceInfo = new BundleResourceInfo( BundleResourceInfoParams{} );
+
+	Result importFromYamlResult = bundleResourceInfo->ImportFromYaml( resource, m_versionParameter.GetValue() );
+
+	if( importFromYamlResult.type != ResultType::SUCCESS )
 	{
-		BundleResourceInfo* bundleResourceInfo = new BundleResourceInfo( BundleResourceInfoParams{} );
+		delete bundleResourceInfo;
 
-		Result importFromYamlResult = bundleResourceInfo->ImportFromYaml( resource, m_versionParameter.GetValue() );
+		return importFromYamlResult;
+	}
+	else
+	{
+		resourceOut = bundleResourceInfo;
 
-		if( importFromYamlResult.type != ResultType::SUCCESS )
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result BundleResourceGroup::BundleResourceGroupImpl::ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile )
+{
+	if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
+	{
+		YAML::Node resourceGroupNode = resourceGroupFile[m_resourceGroupParameter.GetTag()];
+
+		ResourceInfo* resource = nullptr;
+
+		Result createResourceFromYaml = ResourceGroupImpl::CreateResourceFromYaml( resourceGroupNode, resource );
+
+		if( createResourceFromYaml.type != ResultType::SUCCESS )
 		{
-			delete bundleResourceInfo;
+			return createResourceFromYaml;
+		}
 
-			return importFromYamlResult;
+		// Ensure that resource is of base type ResourceGroup
+		ResourceGroupInfo* resourceGroupInfo = dynamic_cast<ResourceGroupInfo*>( resource );
+
+		if( !resourceGroupInfo )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+		}
+
+		m_resourceGroupParameter = reinterpret_cast<ResourceGroupInfo*>( resource );
+	}
+
+	if( m_chunkSize.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
+	{
+
+		if( YAML::Node chunkSize = resourceGroupFile[m_chunkSize.GetTag()] )
+		{
+			m_chunkSize = chunkSize.as<uintmax_t>();
 		}
 		else
 		{
-			resourceOut = bundleResourceInfo;
-
-			return Result{ ResultType::SUCCESS };
+			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
 		}
-
 	}
 
-    Result BundleResourceGroup::BundleResourceGroupImpl::ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile )
-    {
-		if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
-		{
-			YAML::Node resourceGroupNode = resourceGroupFile[m_resourceGroupParameter.GetTag()];
+	return Result{ ResultType::SUCCESS };
+}
 
-			ResourceInfo* resource = nullptr;
+Result BundleResourceGroup::BundleResourceGroupImpl::ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const
+{
+	if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
+	{
+		out << YAML::Key << m_resourceGroupParameter.GetTag();
 
-			Result createResourceFromYaml = ResourceGroupImpl::CreateResourceFromYaml( resourceGroupNode, resource );
+		out << YAML::Value << YAML::BeginMap;
 
-			if( createResourceFromYaml.type != ResultType::SUCCESS )
-			{
-				return createResourceFromYaml;
-			}
+		m_resourceGroupParameter.GetValue()->ExportToYaml( out, outputDocumentVersion );
 
-			// Ensure that resource is of base type ResourceGroup
-			ResourceGroupInfo* resourceGroupInfo = dynamic_cast<ResourceGroupInfo*>( resource );
+		out << YAML::EndMap;
+	}
 
-            if( !resourceGroupInfo )
-            {
-				return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-            }
+	if( m_chunkSize.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
+	{
+		out << YAML::Key << m_chunkSize.GetTag();
 
-			m_resourceGroupParameter = reinterpret_cast<ResourceGroupInfo*>( resource );
-		}
+		out << YAML::Value << m_chunkSize.GetValue();
+	}
 
-        if (m_chunkSize.IsParameterExpectedInDocumentVersion(m_versionParameter.GetValue()))
-        {
-
-			if( YAML::Node chunkSize = resourceGroupFile[m_chunkSize.GetTag()] )
-			{
-				m_chunkSize = chunkSize.as<uintmax_t>();
-			}
-            else
-            {
-				return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-            }
-			
-			
-        }
-
-		return Result{ ResultType::SUCCESS };
-    }
-
-    Result BundleResourceGroup::BundleResourceGroupImpl::ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const
-    {
-		if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
-		{
-			out << YAML::Key << m_resourceGroupParameter.GetTag();
-
-			out << YAML::Value << YAML::BeginMap;
-
-			m_resourceGroupParameter.GetValue()->ExportToYaml( out, outputDocumentVersion );
-
-			out << YAML::EndMap;
-		}
-
-        if( m_chunkSize.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
-		{
-			out << YAML::Key << m_chunkSize.GetTag();
-
-			out << YAML::Value << m_chunkSize.GetValue();
-		}
-
-		return Result{ ResultType::SUCCESS };
-    }
+	return Result{ ResultType::SUCCESS };
+}
 
 }

--- a/src/BundleResourceGroupImpl.h
+++ b/src/BundleResourceGroupImpl.h
@@ -17,39 +17,35 @@
 namespace CarbonResources
 {
 
-    class BundleResourceGroup::BundleResourceGroupImpl : public ResourceGroup::ResourceGroupImpl
-    {
-    public:
+class BundleResourceGroup::BundleResourceGroupImpl : public ResourceGroup::ResourceGroupImpl
+{
+public:
+	BundleResourceGroupImpl();
 
-	    BundleResourceGroupImpl();
+	~BundleResourceGroupImpl();
 
-        ~BundleResourceGroupImpl();
+	Result SetResourceGroup( const ResourceGroupInfo& resourceGroup );
 
-        Result SetResourceGroup( const ResourceGroupInfo& resourceGroup );
+	Result Unpack( const BundleUnpackParams& params );
 
-        Result Unpack( const BundleUnpackParams& params );
+	virtual std::string GetType() const override;
 
-        virtual std::string GetType() const override;
+	static std::string TypeId();
 
-        static std::string TypeId();
+	Result SetChunkSize( uintmax_t size );
 
-        Result SetChunkSize( uintmax_t size );
+private:
+	virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut ) override;
 
-    private:
+	virtual Result ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile ) override;
 
-        virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut ) override;
+	virtual Result ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const override;
 
-        virtual Result ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile ) override;
+protected:
+	DocumentParameter<uintmax_t> m_chunkSize = DocumentParameter<uintmax_t>( CHUNK_SIZE, TypeId() );
 
-        virtual Result ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const override;
-
-    protected:
-
-        DocumentParameter<uintmax_t> m_chunkSize = DocumentParameter<uintmax_t>( CHUNK_SIZE, TypeId() );
-
-		DocumentParameter<ResourceGroupInfo*> m_resourceGroupParameter = DocumentParameter<ResourceGroupInfo*>( RESOURCE_GROUP_RESOURCE, TypeId() );
-
-    };
+	DocumentParameter<ResourceGroupInfo*> m_resourceGroupParameter = DocumentParameter<ResourceGroupInfo*>( RESOURCE_GROUP_RESOURCE, TypeId() );
+};
 
 }
 

--- a/src/Enums.cpp
+++ b/src/Enums.cpp
@@ -4,163 +4,162 @@
 
 namespace CarbonResources
 {
-    bool ResultTypeToString( ResultType resultType, std::string& output )
-    {
+bool ResultTypeToString( ResultType resultType, std::string& output )
+{
 
-	    switch( resultType )
-	    {
-	    case ResultType::SUCCESS:
-		    output = "Operation was successful.";
-		    return true;
+	switch( resultType )
+	{
+	case ResultType::SUCCESS:
+		output = "Operation was successful.";
+		return true;
 
-	    case ResultType::FAIL:
-		    output = "Operation failed. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
-		    return true;
+	case ResultType::FAIL:
+		output = "Operation failed. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
+		return true;
 
-	    case ResultType::UNSUPPORTED_FILE_FORMAT:
-		    output = "Operation encounted an unsupported file format. It is likely that supplied file format is unsupported.";
-		    return true;
+	case ResultType::UNSUPPORTED_FILE_FORMAT:
+		output = "Operation encounted an unsupported file format. It is likely that supplied file format is unsupported.";
+		return true;
 
-	    case ResultType::FAILED_TO_OPEN_FILE:
-		    output = "A file failed to open during operation. Perhaps the file was not found, or is locked.";
-		    return true;
+	case ResultType::FAILED_TO_OPEN_FILE:
+		output = "A file failed to open during operation. Perhaps the file was not found, or is locked.";
+		return true;
 
-	    case ResultType::MALFORMED_RESOURCE_INPUT:
-		    output = "A malformed resource was encountered. This may be related to required missing fields required for document version.";
-		    return true;
+	case ResultType::MALFORMED_RESOURCE_INPUT:
+		output = "A malformed resource was encountered. This may be related to required missing fields required for document version.";
+		return true;
 
-	    case ResultType::FILE_TYPE_MISMATCH:
-		    output = "The document type being imported didn't match expected type for operation.";
-		    return true;
+	case ResultType::FILE_TYPE_MISMATCH:
+		output = "The document type being imported didn't match expected type for operation.";
+		return true;
 
-	    case ResultType::DOCUMENT_VERSION_UNSUPPORTED:
-		    output = "Document version supplied is not supported.";
-		    return true;
+	case ResultType::DOCUMENT_VERSION_UNSUPPORTED:
+		output = "Document version supplied is not supported.";
+		return true;
 
-	    case ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET:
-		    output = "Resource parameter that is required for the document version has not been set.";
-		    return true;
+	case ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET:
+		output = "Resource parameter that is required for the document version has not been set.";
+		return true;
 
-	    case ResultType::FAILED_TO_OPEN_FILE_STREAM:
-			output = "Failed to open file stream during operation.Perhaps the file was not found, or is locked.";
-		    return true;
+	case ResultType::FAILED_TO_OPEN_FILE_STREAM:
+		output = "Failed to open file stream during operation.Perhaps the file was not found, or is locked.";
+		return true;
 
-	    case ResultType::FAILED_TO_READ_FROM_STREAM:
-			output = "An error was encountered while attempting to read from stream.";
-		    return true;
+	case ResultType::FAILED_TO_READ_FROM_STREAM:
+		output = "An error was encountered while attempting to read from stream.";
+		return true;
 
-	    case ResultType::FAILED_TO_WRITE_TO_STREAM:
-			output = "An error was encountered while attempting to write to a stream.";
-		    return true;
+	case ResultType::FAILED_TO_WRITE_TO_STREAM:
+		output = "An error was encountered while attempting to write to a stream.";
+		return true;
 
-		case ResultType::FAILED_TO_DOWNLOAD_FILE:
-			output = "A file failed to download during operation. Check supplied URLS are correct.";
-		    return true;
+	case ResultType::FAILED_TO_DOWNLOAD_FILE:
+		output = "A file failed to download during operation. Check supplied URLS are correct.";
+		return true;
 
-	    case ResultType::FAILED_TO_CREATE_PATCH:
-			output = "An error occurred during generation of a binary patch.";
-		    return true;
+	case ResultType::FAILED_TO_CREATE_PATCH:
+		output = "An error occurred during generation of a binary patch.";
+		return true;
 
-	    case ResultType::FAILED_TO_SAVE_FILE:
-			output = "Operation failed to save a file.";
-		    return true;
+	case ResultType::FAILED_TO_SAVE_FILE:
+		output = "Operation failed to save a file.";
+		return true;
 
-	    case ResultType::FAILED_TO_GENERATE_CHECKSUM:
-			output = "An error occurred during generation of a data checksum.";
-		    return true;
+	case ResultType::FAILED_TO_GENERATE_CHECKSUM:
+		output = "An error occurred during generation of a data checksum.";
+		return true;
 
-	    case ResultType::FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM:
-			output = "An error occurred during generation of a relative path checksum.";
-		    return true;
+	case ResultType::FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM:
+		output = "An error occurred during generation of a relative path checksum.";
+		return true;
 
-	    case ResultType::FAILED_TO_COMPRESS_DATA:
-			output = "An error occurred during data compression.";
-		    return true;
+	case ResultType::FAILED_TO_COMPRESS_DATA:
+		output = "An error occurred during data compression.";
+		return true;
 
-	    case ResultType::PATCH_RESOURCE_LIST_MISSMATCH:
-		    output = "ResourceGroups provided to create patch do not match in type. Validate ResourceGroup inputs are correct.";
-		    return true;
+	case ResultType::PATCH_RESOURCE_LIST_MISSMATCH:
+		output = "ResourceGroups provided to create patch do not match in type. Validate ResourceGroup inputs are correct.";
+		return true;
 
-	    case ResultType::FAILED_TO_APPLY_PATCH:
-			output = "An error occurred during application of a binary patch.";
-		    return true;
+	case ResultType::FAILED_TO_APPLY_PATCH:
+		output = "An error occurred during application of a binary patch.";
+		return true;
 
-	    case ResultType::UNEXPECTED_PATCH_CHECKSUM_RESULT:
-		    output = "Patched resource doesn't match expected checksum upon patch completion.";
-		    return true;
+	case ResultType::UNEXPECTED_PATCH_CHECKSUM_RESULT:
+		output = "Patched resource doesn't match expected checksum upon patch completion.";
+		return true;
 
-	    case ResultType::UNEXPECTED_PATCH_DIFF_ENCOUNTERED:
-		    output = "ResourceGroup diff operation produced unexpected result. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
-		    return true;
+	case ResultType::UNEXPECTED_PATCH_DIFF_ENCOUNTERED:
+		output = "ResourceGroup diff operation produced unexpected result. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
+		return true;
 
-	    case ResultType::FILE_NOT_FOUND:
-		    output = "Required file not found. Validate parameter inputs.";
-		    return true;
+	case ResultType::FILE_NOT_FOUND:
+		output = "Required file not found. Validate parameter inputs.";
+		return true;
 
-	    case ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA:
-		    output = "An error was encountered while attempting to read from a chunk data stream.";
-		    return true;
+	case ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA:
+		output = "An error was encountered while attempting to read from a chunk data stream.";
+		return true;
 
-	    case ResultType::RESOURCE_VALUE_NOT_SET:
-		    output = "A request was made for a parameter which was not set. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
-		    return true;
+	case ResultType::RESOURCE_VALUE_NOT_SET:
+		output = "A request was made for a parameter which was not set. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
+		return true;
 
-	    case ResultType::UNEXPECTED_END_OF_CHUNKS:
-		    output = "Chunk file finished before all expected chunks had reconstituted.";
-		    return true;
+	case ResultType::UNEXPECTED_END_OF_CHUNKS:
+		output = "Chunk file finished before all expected chunks had reconstituted.";
+		return true;
 
-	    case ResultType::UNEXPECTED_CHUNK_CHECKSUM_RESULT:
-		    output = "Generated checksum didn't match expected result.";
-		    return true;
+	case ResultType::UNEXPECTED_CHUNK_CHECKSUM_RESULT:
+		output = "Generated checksum didn't match expected result.";
+		return true;
 
-	    case ResultType::FAILED_TO_SAVE_TO_STREAM:
-			output = "An error was encountered while attempting to write to a stream.";
-		    return true;
+	case ResultType::FAILED_TO_SAVE_TO_STREAM:
+		output = "An error was encountered while attempting to write to a stream.";
+		return true;
 
-	    case ResultType::INPUT_DIRECTORY_DOESNT_EXIST:
-		    output = "Supplied input directory doesn't exist. Validate parameter inputs.";
-		    return true;
+	case ResultType::INPUT_DIRECTORY_DOESNT_EXIST:
+		output = "Supplied input directory doesn't exist. Validate parameter inputs.";
+		return true;
 
-        case ResultType::RESOURCE_TYPE_MISSMATCH:
-			output = "Resource parameters were attempted to be set by a resource of a different type. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
-			return true;
+	case ResultType::RESOURCE_TYPE_MISSMATCH:
+		output = "Resource parameters were attempted to be set by a resource of a different type. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
+		return true;
 
-	    case ResultType::MALFORMED_RESOURCE_GROUP:
-	    	output = "The resource group does not seem to contain the required parameters for this version.";
-	    	return true;
+	case ResultType::MALFORMED_RESOURCE_GROUP:
+		output = "The resource group does not seem to contain the required parameters for this version.";
+		return true;
 
-        case ResultType::MALFORMED_RESOURCE:
-			output = "The resource does not seem to contain the required parameters for this version.";
-			return true;
+	case ResultType::MALFORMED_RESOURCE:
+		output = "The resource does not seem to contain the required parameters for this version.";
+		return true;
 
-	    case ResultType::FAILED_TO_PARSE_YAML:
-	    	output = "Provided data is not valid YAML.";
-	    	return true;
+	case ResultType::FAILED_TO_PARSE_YAML:
+		output = "Provided data is not valid YAML.";
+		return true;
 
-        case ResultType::INVALID_CHUNK_SIZE:
-			output = "Chunk size specified is invalid, must be > 0.";
-			return true;
+	case ResultType::INVALID_CHUNK_SIZE:
+		output = "Chunk size specified is invalid, must be > 0.";
+		return true;
 
-        case ResultType::RESOURCE_GROUP_NOT_SET:
-			output = "Input Resource Group not set";
-			return true;
+	case ResultType::RESOURCE_GROUP_NOT_SET:
+		output = "Input Resource Group not set";
+		return true;
 
-        case ResultType::RESOURCE_LIST_NOT_SET:
-			output = "Resource list not set";
-			return true;
+	case ResultType::RESOURCE_LIST_NOT_SET:
+		output = "Resource list not set";
+		return true;
 
-        case ResultType::RESOURCE_NOT_FOUND:
-			output = "Resource not found";
-			return true;  
+	case ResultType::RESOURCE_NOT_FOUND:
+		output = "Resource not found";
+		return true;
 
-        case ResultType::REQUIRED_INPUT_PARAMETER_NOT_SET:
-			output = "A required parameter was not set";
-			return true;  
+	case ResultType::REQUIRED_INPUT_PARAMETER_NOT_SET:
+		output = "A required parameter was not set";
+		return true;
+	}
 
-	    }
+	output = "Error code unrecognised. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
 
-	    output = "Error code unrecognised. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";
-
-	    return false;
-    }
+	return false;
+}
 }

--- a/src/ParameterVersion.h
+++ b/src/ParameterVersion.h
@@ -54,14 +54,14 @@ public:
 class ParameterInfo
 {
 public:
-	ParameterInfo(CarbonResources::Parameter id, std::string tag, std::vector<ParameterContext> context, bool isOptional=false);
+	ParameterInfo( CarbonResources::Parameter id, std::string tag, std::vector<ParameterContext> context, bool isOptional = false );
 	Parameter m_id;
 	std::string m_tag;
 	std::vector<ParameterContext> m_context;
 	bool m_isOptional;
 };
 
-const ParameterInfo* GetParameterInfo(Parameter param);
+const ParameterInfo* GetParameterInfo( Parameter param );
 bool IsParameterExpected( Parameter parameter, const std::string& context, VersionInternal version );
 bool IsParameterRequired( Parameter parameter, const std::string& context, VersionInternal version );
 

--- a/src/PatchResourceGroup.cpp
+++ b/src/PatchResourceGroup.cpp
@@ -6,20 +6,19 @@
 namespace CarbonResources
 {
 
-    PatchResourceGroup::PatchResourceGroup( ):
-	    ResourceGroup(new PatchResourceGroupImpl()),
-	    m_impl( reinterpret_cast<PatchResourceGroupImpl*>( ResourceGroup::m_impl ) )
-    {
-        
-    }
+PatchResourceGroup::PatchResourceGroup() :
+	ResourceGroup( new PatchResourceGroupImpl() ),
+	m_impl( reinterpret_cast<PatchResourceGroupImpl*>( ResourceGroup::m_impl ) )
+{
+}
 
-    PatchResourceGroup::~PatchResourceGroup()
-    {
-    }
+PatchResourceGroup::~PatchResourceGroup()
+{
+}
 
-    Result PatchResourceGroup::Apply( const PatchApplyParams& params )
-    {
-		return m_impl->Apply( params );
-    }
+Result PatchResourceGroup::Apply( const PatchApplyParams& params )
+{
+	return m_impl->Apply( params );
+}
 
 }

--- a/src/PatchResourceGroupImpl.cpp
+++ b/src/PatchResourceGroupImpl.cpp
@@ -20,729 +20,720 @@
 
 namespace CarbonResources
 {
-    PatchResourceGroup::PatchResourceGroupImpl::PatchResourceGroupImpl() :
-	    ResourceGroupImpl()
-    {
-		m_resourceGroupParameter = new ResourceGroupInfo({});
+PatchResourceGroup::PatchResourceGroupImpl::PatchResourceGroupImpl() :
+	ResourceGroupImpl()
+{
+	m_resourceGroupParameter = new ResourceGroupInfo( {} );
 
-		m_type = TypeId();
-    }
+	m_type = TypeId();
+}
 
-    Result PatchResourceGroup::PatchResourceGroupImpl::SetResourceGroup( const ResourceGroupInfo& resourceGroup )
-    {
-        // Creates a deep copy
-    	ResourceGroupInfo* info = m_resourceGroupParameter.GetValue();
+Result PatchResourceGroup::PatchResourceGroupImpl::SetResourceGroup( const ResourceGroupInfo& resourceGroup )
+{
+	// Creates a deep copy
+	ResourceGroupInfo* info = m_resourceGroupParameter.GetValue();
 
-		Result result = info->SetParametersFromResource( &resourceGroup, m_versionParameter.GetValue() );
+	Result result = info->SetParametersFromResource( &resourceGroup, m_versionParameter.GetValue() );
 
-    	if( result.type != ResultType::SUCCESS )
-    	{
-    		return result;
-    	}
-
-    	// Change the relative path to include the checksum as part of the file name.
-    	// This should prevent issues with name collisions between files called "ResourceGroup.yaml"
-    	std::filesystem::path relativePath;
-
-    	result = info->GetRelativePath( relativePath );
-
-    	if( result.type != ResultType::SUCCESS )
-    	{
-    		return result;
-    	}
-
-    	std::string checksum;
-
-    	result = info->GetChecksum( checksum );
-
-    	if( result.type != ResultType::SUCCESS )
-    	{
-    		return result;
-    	}
-
-    	const std::string extension = relativePath.extension().string();
-
-    	relativePath.replace_filename( "DiffResourceGroup_" + checksum + extension );
-
-    	info->SetRelativePath( relativePath );
-
-    	return Result{ ResultType::SUCCESS };
-    }
-
-    Result PatchResourceGroup::PatchResourceGroupImpl::SetMaxInputChunkSize( uintmax_t maxInputChunkSize )
-    {
-        if (maxInputChunkSize <= 0)
-        {
-			return Result{ ResultType::INVALID_CHUNK_SIZE };
-        }
-
-		m_maxInputChunkSize = maxInputChunkSize;
-
-        return Result{ ResultType::SUCCESS };
-    }
-
-    PatchResourceGroup::PatchResourceGroupImpl::~PatchResourceGroupImpl()
-    {
-		delete m_resourceGroupParameter.GetValue();
-    }
-
-    std::string PatchResourceGroup::PatchResourceGroupImpl::GetType() const
+	if( result.type != ResultType::SUCCESS )
 	{
-		return TypeId();
+		return result;
 	}
 
-    std::string PatchResourceGroup::PatchResourceGroupImpl::TypeId()
-    {
-		return "PatchGroup";
-    }
+	// Change the relative path to include the checksum as part of the file name.
+	// This should prevent issues with name collisions between files called "ResourceGroup.yaml"
+	std::filesystem::path relativePath;
 
-	Result PatchResourceGroup::PatchResourceGroupImpl::CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut )
+	result = info->GetRelativePath( relativePath );
+
+	if( result.type != ResultType::SUCCESS )
 	{
-		PatchResourceInfo* patchResource = new PatchResourceInfo( PatchResourceInfoParams{} );
+		return result;
+	}
 
-		Result importFromYamlResult = patchResource->ImportFromYaml( resource, m_versionParameter.GetValue() );
+	std::string checksum;
 
-		if( importFromYamlResult.type != ResultType::SUCCESS )
+	result = info->GetChecksum( checksum );
+
+	if( result.type != ResultType::SUCCESS )
+	{
+		return result;
+	}
+
+	const std::string extension = relativePath.extension().string();
+
+	relativePath.replace_filename( "DiffResourceGroup_" + checksum + extension );
+
+	info->SetRelativePath( relativePath );
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result PatchResourceGroup::PatchResourceGroupImpl::SetMaxInputChunkSize( uintmax_t maxInputChunkSize )
+{
+	if( maxInputChunkSize <= 0 )
+	{
+		return Result{ ResultType::INVALID_CHUNK_SIZE };
+	}
+
+	m_maxInputChunkSize = maxInputChunkSize;
+
+	return Result{ ResultType::SUCCESS };
+}
+
+PatchResourceGroup::PatchResourceGroupImpl::~PatchResourceGroupImpl()
+{
+	delete m_resourceGroupParameter.GetValue();
+}
+
+std::string PatchResourceGroup::PatchResourceGroupImpl::GetType() const
+{
+	return TypeId();
+}
+
+std::string PatchResourceGroup::PatchResourceGroupImpl::TypeId()
+{
+	return "PatchGroup";
+}
+
+Result PatchResourceGroup::PatchResourceGroupImpl::CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut )
+{
+	PatchResourceInfo* patchResource = new PatchResourceInfo( PatchResourceInfoParams{} );
+
+	Result importFromYamlResult = patchResource->ImportFromYaml( resource, m_versionParameter.GetValue() );
+
+	if( importFromYamlResult.type != ResultType::SUCCESS )
+	{
+		delete patchResource;
+
+		return importFromYamlResult;
+	}
+	else
+	{
+		resourceOut = patchResource;
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result PatchResourceGroup::PatchResourceGroupImpl::ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile )
+{
+	if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
+	{
+		YAML::Node resourceGroupNode = resourceGroupFile[m_resourceGroupParameter.GetTag()];
+
+		ResourceInfo* resource = nullptr;
+
+		Result createResourceFromYaml = ResourceGroupImpl::CreateResourceFromYaml( resourceGroupNode, resource );
+
+		if( createResourceFromYaml.type != ResultType::SUCCESS )
 		{
-			delete patchResource;
+			return createResourceFromYaml;
+		}
 
-			return importFromYamlResult;
+		// Ensure that resource is of base type ResourceGroup
+		ResourceGroupInfo* resourceGroupInfo = dynamic_cast<ResourceGroupInfo*>( resource );
+
+		if( !resourceGroupInfo )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+		}
+
+		m_resourceGroupParameter = reinterpret_cast<ResourceGroupInfo*>( resource );
+	}
+
+
+	if( m_maxInputChunkSize.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
+	{
+		if( YAML::Node parameter = resourceGroupFile[m_maxInputChunkSize.GetTag()] )
+		{
+			m_maxInputChunkSize = parameter.as<uintmax_t>();
 		}
 		else
 		{
-			resourceOut = patchResource;
-
-			return Result{ ResultType::SUCCESS };
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
 		}
-
 	}
 
-    Result PatchResourceGroup::PatchResourceGroupImpl::ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile )
-    {
-		if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
+	if( m_removedResources.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
+	{
+		YAML::Node parameter = resourceGroupFile[m_removedResources.GetTag()];
+		if( parameter.IsDefined() && parameter.IsSequence() )
 		{
-			YAML::Node resourceGroupNode = resourceGroupFile[m_resourceGroupParameter.GetTag()];
-
-            ResourceInfo* resource = nullptr;
-
-            Result createResourceFromYaml = ResourceGroupImpl::CreateResourceFromYaml( resourceGroupNode, resource );
-
-            if (createResourceFromYaml.type != ResultType::SUCCESS)
-            {
-				return createResourceFromYaml;
-            }
-
-            // Ensure that resource is of base type ResourceGroup
-			ResourceGroupInfo* resourceGroupInfo = dynamic_cast<ResourceGroupInfo*>( resource );
-
-			if( !resourceGroupInfo )
+			for( size_t i = 0; i < parameter.size(); ++i )
 			{
-				return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-			}
-
-			m_resourceGroupParameter = reinterpret_cast<ResourceGroupInfo*>( resource );
-		}
-
-
-        if( m_maxInputChunkSize.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
-		{
-			if( YAML::Node parameter = resourceGroupFile[m_maxInputChunkSize.GetTag()] )
-			{
-				m_maxInputChunkSize = parameter.as<uintmax_t>();
-			}
-			else
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+				std::filesystem::path path = parameter[i].as<std::string>();
+				m_removedResources.PushBack( path );
 			}
 		}
+	}
 
-    	if( m_removedResources.IsParameterExpectedInDocumentVersion( m_versionParameter.GetValue() ) )
-    	{
-    		YAML::Node parameter = resourceGroupFile[m_removedResources.GetTag()];
-    		if( parameter.IsDefined() && parameter.IsSequence() )
-    		{
-    			for( size_t i = 0; i < parameter.size(); ++i )
-    			{
-    				std::filesystem::path path = parameter[i].as<std::string>();
-    				m_removedResources.PushBack( path );
-    			}
-    		}
-    	}
+	return Result{ ResultType::SUCCESS };
+}
 
-		return Result{ ResultType::SUCCESS };
-    }
+Result PatchResourceGroup::PatchResourceGroupImpl::ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const
+{
+	if( m_resourceGroupParameter.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
+	{
+		out << YAML::Key << m_resourceGroupParameter.GetTag();
 
-    Result PatchResourceGroup::PatchResourceGroupImpl::ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const
-    {
-        if (m_resourceGroupParameter.IsParameterExpectedInDocumentVersion(outputDocumentVersion))
-        {
-			out << YAML::Key << m_resourceGroupParameter.GetTag();
+		out << YAML::Value << YAML::BeginMap;
 
-			out << YAML::Value << YAML::BeginMap;
+		m_resourceGroupParameter.GetValue()->ExportToYaml( out, outputDocumentVersion );
 
-			m_resourceGroupParameter.GetValue()->ExportToYaml( out, outputDocumentVersion );
+		out << YAML::EndMap;
+	}
 
-			out << YAML::EndMap;
-
-        }
-
-        // Data offset
-		if( m_maxInputChunkSize.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
+	// Data offset
+	if( m_maxInputChunkSize.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
+	{
+		if( !m_maxInputChunkSize.HasValue() )
 		{
-			if( !m_maxInputChunkSize.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
-
-			out << YAML::Key << m_maxInputChunkSize.GetTag();
-			out << YAML::Value << m_maxInputChunkSize.GetValue();
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
 		}
 
-    	if( m_removedResources.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
-    	{
-    		out << YAML::Key << m_removedResources.GetTag();
-    		out << YAML::Value << YAML::BeginSeq;
-    		for( auto path : *m_removedResources.GetValue() )
-    		{
-    			out << path.string();
-    		}
-    		out << YAML::EndSeq;
-    	}
+		out << YAML::Key << m_maxInputChunkSize.GetTag();
+		out << YAML::Value << m_maxInputChunkSize.GetValue();
+	}
 
-		return Result{ ResultType::SUCCESS };
-    }
+	if( m_removedResources.IsParameterExpectedInDocumentVersion( outputDocumentVersion ) )
+	{
+		out << YAML::Key << m_removedResources.GetTag();
+		out << YAML::Value << YAML::BeginSeq;
+		for( auto path : *m_removedResources.GetValue() )
+		{
+			out << path.string();
+		}
+		out << YAML::EndSeq;
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
 
 
-    Result PatchResourceGroup::PatchResourceGroupImpl::GetTargetResourcePatches( const ResourceInfo* resource, std::vector<const PatchResourceInfo*>& patches ) const
-    {
-		std::filesystem::path resourceRelativePath;
+Result PatchResourceGroup::PatchResourceGroupImpl::GetTargetResourcePatches( const ResourceInfo* resource, std::vector<const PatchResourceInfo*>& patches ) const
+{
+	std::filesystem::path resourceRelativePath;
 
-		Result resourceRelativePathResult = resource->GetRelativePath( resourceRelativePath );
+	Result resourceRelativePathResult = resource->GetRelativePath( resourceRelativePath );
 
-        if( resourceRelativePathResult.type != ResultType::SUCCESS )
-        {
-			return resourceRelativePathResult;
-        }
+	if( resourceRelativePathResult.type != ResultType::SUCCESS )
+	{
+		return resourceRelativePathResult;
+	}
 
-        for (ResourceInfo* patchResource : m_resourcesParameter)
-        {
-			PatchResourceInfo* patch = reinterpret_cast<PatchResourceInfo*>( patchResource );
+	for( ResourceInfo* patchResource : m_resourcesParameter )
+	{
+		PatchResourceInfo* patch = reinterpret_cast<PatchResourceInfo*>( patchResource );
 
-			std::filesystem::path patchTargetResource;
+		std::filesystem::path patchTargetResource;
 
-			Result getPatchTargetResource = patch->GetTargetResourceRelativePath( patchTargetResource );
+		Result getPatchTargetResource = patch->GetTargetResourceRelativePath( patchTargetResource );
 
-			if( getPatchTargetResource.type != ResultType::SUCCESS )
-			{
-				return getPatchTargetResource;
-			}
+		if( getPatchTargetResource.type != ResultType::SUCCESS )
+		{
+			return getPatchTargetResource;
+		}
 
-            if (resourceRelativePath == patchTargetResource)
-            {
-				patches.push_back( patch );
-            }
-        }
+		if( resourceRelativePath == patchTargetResource )
+		{
+			patches.push_back( patch );
+		}
+	}
 
-        return Result{ ResultType::SUCCESS };
-    }
+	return Result{ ResultType::SUCCESS };
+}
 
-    Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams& params )
-    {
+Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams& params )
+{
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Applying Patch." );
+	}
+
+	// Will be removed when falls out of scope
+	ResourceTools::ScopedFile temporaryFileScope( params.temporaryFilePath );
+
+	ResourceGroupInfo* resourceGroupResource = m_resourceGroupParameter.GetValue();
+
+
+	// Load the resourceGroup from the resourceGroupResource
+	std::string resourceGroupData;
+
+	ResourceGetDataParams resourceGroupDataParams;
+
+	resourceGroupDataParams.resourceSourceSettings = params.patchBinarySourceSettings;
+
+	resourceGroupDataParams.data = &resourceGroupData;
+
+	Result resourceGroupGetDataResult = m_resourceGroupParameter.GetValue()->GetData( resourceGroupDataParams );
+
+	if( resourceGroupGetDataResult.type != ResultType::SUCCESS )
+	{
+		return resourceGroupGetDataResult;
+	}
+
+	ResourceGroupImpl resourceGroup;
+
+
+
+	Result resourceGroupImportFromDataResult = resourceGroup.ImportFromData( resourceGroupData );
+
+	if( resourceGroupImportFromDataResult.type != ResultType::SUCCESS )
+	{
+		return resourceGroupImportFromDataResult;
+	}
+
+	auto numResources = resourceGroup.GetSize();
+	int numProcessed = 0;
+
+	for( ResourceInfo* resource : resourceGroup )
+	{
 		if( params.statusCallback )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Applying Patch." );
+			std::filesystem::path relativePath;
+
+			if( resource->GetRelativePath( relativePath ).type != ResultType::SUCCESS )
+			{
+				return Result{ ResultType::FAIL };
+			}
+
+			auto percentage = static_cast<unsigned int>( ( 100 * numProcessed ) / numResources );
+
+			std::string message = "Patching: " + relativePath.string();
+
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, message );
+
+			numProcessed++;
 		}
 
-        // Will be removed when falls out of scope
-		ResourceTools::ScopedFile temporaryFileScope( params.temporaryFilePath );
+		// See if there is a patch available for resource
+		std::vector<const PatchResourceInfo*> patchesForResource;
 
-		ResourceGroupInfo* resourceGroupResource = m_resourceGroupParameter.GetValue();
+		Result getTargetResourcePatchesResult = GetTargetResourcePatches( resource, patchesForResource );
 
-        
-        // Load the resourceGroup from the resourceGroupResource
-		std::string resourceGroupData;
+		if( getTargetResourcePatchesResult.type != ResultType::SUCCESS )
+		{
+			return getTargetResourcePatchesResult;
+		}
 
-        ResourceGetDataParams resourceGroupDataParams;
 
-        resourceGroupDataParams.resourceSourceSettings = params.patchBinarySourceSettings;
+		// Open a stream to write a temp file of the patched resource
+		ResourceTools::FileDataStreamOut temporaryResourceDataStreamOut;
 
-        resourceGroupDataParams.data = &resourceGroupData;
+		if( !temporaryResourceDataStreamOut.StartWrite( params.temporaryFilePath ) )
+		{
+			return Result{ ResultType::FAILED_TO_OPEN_FILE };
+		}
 
-        Result resourceGroupGetDataResult = m_resourceGroupParameter.GetValue()->GetData( resourceGroupDataParams );
-
-        if (resourceGroupGetDataResult.type != ResultType::SUCCESS)
-        {
-			return resourceGroupGetDataResult;
-        }
-
-        ResourceGroupImpl resourceGroup;
+		// Incrementally calculate checksum for temporary patch file
+		ResourceTools::Md5ChecksumStream patchedFileChecksumStream;
 
 
 
-        Result resourceGroupImportFromDataResult = resourceGroup.ImportFromData( resourceGroupData );
+		if( patchesForResource.size() > 0 )
+		{
+			// Open stream for resource
+			auto resourceDataStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
 
-        if( resourceGroupImportFromDataResult.type != ResultType::SUCCESS )
-        {
-			return resourceGroupImportFromDataResult;
-        }
+			ResourceGetDataStreamParams resourceDataStreamParams;
 
-        auto numResources = resourceGroup.GetSize();
-		int numProcessed = 0;
-        
-        for( ResourceInfo* resource : resourceGroup )
-        {
-			if( params.statusCallback )
+			resourceDataStreamParams.resourceSourceSettings = params.resourcesToPatchSourceSettings;
+
+			resourceDataStreamParams.dataStream = resourceDataStreamIn;
+
+			Result getResourceDataStream = resource->GetDataStream( resourceDataStreamParams );
+
+			if( getResourceDataStream.type != ResultType::SUCCESS )
 			{
-				std::filesystem::path relativePath;
+				return getResourceDataStream;
+			}
 
-				if( resource->GetRelativePath( relativePath ).type != ResultType::SUCCESS )
+
+			for( auto patchIter = patchesForResource.begin(); patchIter != patchesForResource.end(); patchIter++ )
+			{
+
+				const PatchResourceInfo* patch = ( *patchIter );
+
+				// Patch found, Retreive and apply
+				std::string patchData;
+
+				ResourceGetDataParams patchGetDataParams;
+
+				patchGetDataParams.resourceSourceSettings = params.patchBinarySourceSettings;
+
+				patchGetDataParams.data = &patchData;
+
+				std::string location;
+				Result patchGetLocationResult = patch->GetLocation( location );
+				if( patchGetLocationResult.type != ResultType::SUCCESS )
 				{
-					return Result{ ResultType::FAIL };
+					return patchGetLocationResult;
+				}
+				bool hasPatchFile{ !location.empty() };
+
+				if( hasPatchFile )
+				{
+					Result getPatchDataResult = patch->GetData( patchGetDataParams );
+
+					if( getPatchDataResult.type != ResultType::SUCCESS )
+					{
+						return getPatchDataResult;
+					}
 				}
 
-				auto percentage = static_cast<unsigned int>( ( 100 * numProcessed ) / numResources );
+				// Get previous data
+				uintmax_t dataOffset;
+				uintmax_t sourceOffset;
+				Result getPatchDataOffset = patch->GetDataOffset( dataOffset );
 
-				std::string message = "Patching: " + relativePath.string();
+				if( getPatchDataOffset.type != ResultType::SUCCESS )
+				{
+					return getPatchDataOffset;
+				}
 
-				params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, message );
+				Result getPatchSourceOffset = patch->GetSourceOffset( sourceOffset );
+				if( getPatchSourceOffset.type != ResultType::SUCCESS )
+				{
+					return getPatchSourceOffset;
+				}
 
-				numProcessed++;
-			}
+				std::string previousResourceData;
 
-            // See if there is a patch available for resource
-            std::vector<const PatchResourceInfo*> patchesForResource; 
+				// Get previous size of resource
+				uintmax_t previousUncompressedSize;
 
-            Result getTargetResourcePatchesResult = GetTargetResourcePatches(resource, patchesForResource);
+				Result getPreviousUncompressedSize = resource->GetUncompressedSize( previousUncompressedSize );
 
-            if (getTargetResourcePatchesResult.type != ResultType::SUCCESS)
-            {
-				return getTargetResourcePatchesResult;
-            }
+				if( getPreviousUncompressedSize.type != ResultType::SUCCESS )
+				{
+					return getPreviousUncompressedSize;
+				}
 
-
-            // Open a stream to write a temp file of the patched resource
-			ResourceTools::FileDataStreamOut temporaryResourceDataStreamOut;
-
-			if( !temporaryResourceDataStreamOut.StartWrite( params.temporaryFilePath ) )
-			{
-				return Result{ ResultType::FAILED_TO_OPEN_FILE };
-			}
-
-			// Incrementally calculate checksum for temporary patch file
-			ResourceTools::Md5ChecksumStream patchedFileChecksumStream;
-
-
-
-			if( patchesForResource.size() > 0 )
-			{
-                // Open stream for resource
-				auto resourceDataStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
-
-				ResourceGetDataStreamParams resourceDataStreamParams;
-
-                resourceDataStreamParams.resourceSourceSettings = params.resourcesToPatchSourceSettings;
-
-                resourceDataStreamParams.dataStream = resourceDataStreamIn;
-
-				Result getResourceDataStream = resource->GetDataStream( resourceDataStreamParams );
-
-                if (getResourceDataStream.type != ResultType::SUCCESS)
-                {
-					return getResourceDataStream;
-                }
-
-
-				for( auto patchIter = patchesForResource.begin(); patchIter != patchesForResource.end(); patchIter++ )
-                {
-
-				    const PatchResourceInfo* patch = (*patchIter );
-
-				    // Patch found, Retreive and apply
-				    std::string patchData;
-
-				    ResourceGetDataParams patchGetDataParams;
-
-				    patchGetDataParams.resourceSourceSettings = params.patchBinarySourceSettings;
-
-                    patchGetDataParams.data = &patchData;
-
-					std::string location;
-					Result patchGetLocationResult = patch->GetLocation( location );
-					if( patchGetLocationResult.type != ResultType::SUCCESS )
+				if( dataOffset < previousUncompressedSize )
+				{
+					int64_t previousSourcePosition = resourceDataStreamIn->GetCurrentPosition();
+					// Get to location of patch
+					while( temporaryResourceDataStreamOut.GetFileSize() < dataOffset )
 					{
-						return patchGetLocationResult;
-					}
-					bool hasPatchFile{!location.empty()};
-
-					if( hasPatchFile )
-					{
-						Result getPatchDataResult = patch->GetData( patchGetDataParams );
-
-						if( getPatchDataResult.type != ResultType::SUCCESS )
+						std::string dataChunk;
+						uint64_t remaining = dataOffset - temporaryResourceDataStreamOut.GetFileSize();
+						if( remaining < m_maxInputChunkSize.GetValue() )
 						{
-							return getPatchDataResult;
-						}
-					}
-
-                    // Get previous data
-					uintmax_t dataOffset;
-					uintmax_t sourceOffset;
-					Result getPatchDataOffset = patch->GetDataOffset( dataOffset );
-
-                    if (getPatchDataOffset.type != ResultType::SUCCESS)
-                    {
-						return getPatchDataOffset;
-                    }
-
-					Result getPatchSourceOffset = patch->GetSourceOffset( sourceOffset );
-					if (getPatchSourceOffset.type != ResultType::SUCCESS)
-					{
-						return getPatchSourceOffset;
-					}
-
-				    std::string previousResourceData;
-
-                    // Get previous size of resource
-					uintmax_t previousUncompressedSize;
-
-					Result getPreviousUncompressedSize = resource->GetUncompressedSize( previousUncompressedSize );
-
-                    if (getPreviousUncompressedSize.type != ResultType::SUCCESS)
-                    {
-						return getPreviousUncompressedSize;
-                    }
-
-                    if (dataOffset < previousUncompressedSize)
-                    {
-                    	int64_t previousSourcePosition = resourceDataStreamIn->GetCurrentPosition();
-                        // Get to location of patch
-                        while (temporaryResourceDataStreamOut.GetFileSize() < dataOffset)
-                        {
-							std::string dataChunk;
-							uint64_t remaining = dataOffset - temporaryResourceDataStreamOut.GetFileSize();
-							if( remaining < m_maxInputChunkSize.GetValue() )
+							if( !resourceDataStreamIn->ReadBytes( remaining, dataChunk ) )
 							{
-								if( !resourceDataStreamIn->ReadBytes( remaining, dataChunk ) )
-								{
-									return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-								}
+								return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
 							}
-                            else if (!(*resourceDataStreamIn >> dataChunk))
-                            {
-								return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                            }
+						}
+						else if( !( *resourceDataStreamIn >> dataChunk ) )
+						{
+							return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+						}
 
-                            if( !( temporaryResourceDataStreamOut << dataChunk ) )
-                            {
-								return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-                            }
-
-                            // Add to incremental checksum calculation
-							if( !( patchedFileChecksumStream << dataChunk ) )
-                            {
-								return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                            }
-                        	previousSourcePosition += dataChunk.size();
-                        }
-                    	if( resourceDataStreamIn->IsFinished() )
-                    	{
-                    		resourceDataStreamIn->StartRead( resourceDataStreamIn->GetPath() );
-                    	}
-                    	resourceDataStreamIn->Seek( previousSourcePosition );
-
-
-						// Apply the patch to the previous data
-						std::string patchedResourceData;
-
-                    	if( hasPatchFile )
-                    	{
-                    		// Apply patch to data
-                    		resourceDataStreamIn->Seek(sourceOffset);
-                    		if( !( *resourceDataStreamIn >> previousResourceData ) )
-                    		{
-								return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                    		}
-                    		if( !ResourceTools::ApplyPatch( previousResourceData, patchData, patchedResourceData ) )
-                    		{
-								return Result{ ResultType::FAILED_TO_APPLY_PATCH };
-                    		}
-                    		// Write the patch result to file
-                    		if( !( temporaryResourceDataStreamOut << patchedResourceData ) )
-                    		{
-								return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-                    		}
-
-                    		// Add to incremental checksum calculation
-                    		if( !( patchedFileChecksumStream << patchedResourceData ) )
-                    		{
-								return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                    		}
-                    	}
-                    	else
-                    	{
-
-                            auto sourceDataStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
-
-                            ResourceGetDataStreamParams getDataStreamParams;
-
-                            getDataStreamParams.dataStream = sourceDataStreamIn;
-
-                            getDataStreamParams.resourceSourceSettings = params.resourcesToPatchSourceSettings;
-
-							Result getDataStreamResult = resource->GetDataStream( getDataStreamParams );
-
-                            if (getDataStreamResult.type != ResultType::SUCCESS)
-                            {
-								return getDataStreamResult;
-                            }
-
-                    		uintmax_t sourceOffset{0};
-                    		Result getSourceOffsetResult = patch->GetSourceOffset( sourceOffset );
-                    		if( getSourceOffsetResult.type != ResultType::SUCCESS )
-                    		{
-								return getSourceOffsetResult;
-                    		}
-                    		uintmax_t unCompressedSize{0};
-                    		Result getUncompressedSizeResult = patch->GetUncompressedSize( unCompressedSize );
-                    		if( getUncompressedSizeResult.type != ResultType::SUCCESS )
-                    		{
-                    			return getUncompressedSizeResult;
-                    		}
-                    		sourceDataStreamIn->Seek( sourceOffset );
-                    		while( unCompressedSize )
-                    		{
-                    			std::string sourceData;
-                    			if(unCompressedSize >= m_maxInputChunkSize.GetValue())
-                    			{
-                    				*sourceDataStreamIn >> sourceData;
-                    			}
-                    			else
-                    			{
-                    				sourceDataStreamIn->ReadBytes( unCompressedSize, sourceData );
-                    			}
-
-                    			if( sourceData.empty() )
-                    			{
-									return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                    			}
-                    			*resourceDataStreamIn >> previousResourceData;
-                    			if( sourceData.size() > unCompressedSize )
-                    			{
-                    				sourceData = sourceData.substr( unCompressedSize );
-                    			}
-                    			unCompressedSize -= std::min( sourceData.size(), unCompressedSize );
-
-                    			// Write the data from the source file
-                    			if( !( temporaryResourceDataStreamOut << sourceData ) )
-                    			{
-									return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-                    			}
-
-                    			// Add to incremental checksum calculation
-                    			if( !( patchedFileChecksumStream << sourceData ) )
-                    			{
-									return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                    			}
-                    		}
-
-                    	}
-                    }
-                    else
-                    {
-                        // New data, append on to end
-						if( !( temporaryResourceDataStreamOut << previousResourceData ) )
+						if( !( temporaryResourceDataStreamOut << dataChunk ) )
 						{
 							return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
 						}
 
-                        // Add to incremental checksum calculation
-						if( !( patchedFileChecksumStream << previousResourceData ) )
+						// Add to incremental checksum calculation
+						if( !( patchedFileChecksumStream << dataChunk ) )
 						{
 							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
 						}
+						previousSourcePosition += dataChunk.size();
+					}
+					if( resourceDataStreamIn->IsFinished() )
+					{
+						resourceDataStreamIn->StartRead( resourceDataStreamIn->GetPath() );
+					}
+					resourceDataStreamIn->Seek( previousSourcePosition );
 
-                    }
 
+					// Apply the patch to the previous data
+					std::string patchedResourceData;
+
+					if( hasPatchFile )
+					{
+						// Apply patch to data
+						resourceDataStreamIn->Seek( sourceOffset );
+						if( !( *resourceDataStreamIn >> previousResourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+						}
+						if( !ResourceTools::ApplyPatch( previousResourceData, patchData, patchedResourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_APPLY_PATCH };
+						}
+						// Write the patch result to file
+						if( !( temporaryResourceDataStreamOut << patchedResourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+						}
+
+						// Add to incremental checksum calculation
+						if( !( patchedFileChecksumStream << patchedResourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+						}
+					}
+					else
+					{
+
+						auto sourceDataStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
+
+						ResourceGetDataStreamParams getDataStreamParams;
+
+						getDataStreamParams.dataStream = sourceDataStreamIn;
+
+						getDataStreamParams.resourceSourceSettings = params.resourcesToPatchSourceSettings;
+
+						Result getDataStreamResult = resource->GetDataStream( getDataStreamParams );
+
+						if( getDataStreamResult.type != ResultType::SUCCESS )
+						{
+							return getDataStreamResult;
+						}
+
+						uintmax_t sourceOffset{ 0 };
+						Result getSourceOffsetResult = patch->GetSourceOffset( sourceOffset );
+						if( getSourceOffsetResult.type != ResultType::SUCCESS )
+						{
+							return getSourceOffsetResult;
+						}
+						uintmax_t unCompressedSize{ 0 };
+						Result getUncompressedSizeResult = patch->GetUncompressedSize( unCompressedSize );
+						if( getUncompressedSizeResult.type != ResultType::SUCCESS )
+						{
+							return getUncompressedSizeResult;
+						}
+						sourceDataStreamIn->Seek( sourceOffset );
+						while( unCompressedSize )
+						{
+							std::string sourceData;
+							if( unCompressedSize >= m_maxInputChunkSize.GetValue() )
+							{
+								*sourceDataStreamIn >> sourceData;
+							}
+							else
+							{
+								sourceDataStreamIn->ReadBytes( unCompressedSize, sourceData );
+							}
+
+							if( sourceData.empty() )
+							{
+								return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+							}
+							*resourceDataStreamIn >> previousResourceData;
+							if( sourceData.size() > unCompressedSize )
+							{
+								sourceData = sourceData.substr( unCompressedSize );
+							}
+							unCompressedSize -= std::min( sourceData.size(), unCompressedSize );
+
+							// Write the data from the source file
+							if( !( temporaryResourceDataStreamOut << sourceData ) )
+							{
+								return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+							}
+
+							// Add to incremental checksum calculation
+							if( !( patchedFileChecksumStream << sourceData ) )
+							{
+								return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+							}
+						}
+					}
 				}
-
-                // Stream out the remaining expected data
-                uintmax_t expectedResourceSize = 0;
-
-                Result getResourceUncompressedSizeResult = resource->GetUncompressedSize( expectedResourceSize );
-
-                if (getResourceUncompressedSizeResult.type != ResultType::SUCCESS)
-                {
-					return getResourceUncompressedSizeResult;
-                }
-
-                temporaryResourceDataStreamOut.Finish();
-
-			}
-            else
-            {
-                // No Patch found, indicates this is just a new file
-                // Just replace file directly
-                auto resourceStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>(m_maxInputChunkSize.GetValue());
-
-				ResourceGetDataStreamParams resourceGetDataParams;
-
-                resourceGetDataParams.resourceSourceSettings = params.nextBuildResourcesSourceSettings;
-
-                resourceGetDataParams.dataStream = resourceStreamIn;
-
-				Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
-
-                if (resourceGetDataResult.type != ResultType::SUCCESS)
-                {
-					return resourceGetDataResult;
-                }
-
-                while (!resourceStreamIn->IsFinished())
-                {
-					std::string resourceData;
-
-                    if (!(*resourceStreamIn >> resourceData))
-                    {
-						return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                    }
-
-                    if (!(temporaryResourceDataStreamOut << resourceData))
-                    {
+				else
+				{
+					// New data, append on to end
+					if( !( temporaryResourceDataStreamOut << previousResourceData ) )
+					{
 						return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-                    }
+					}
 
-                    // Add to incremental checksum calculation
-					if( !( patchedFileChecksumStream << resourceData ) )
+					// Add to incremental checksum calculation
+					if( !( patchedFileChecksumStream << previousResourceData ) )
 					{
 						return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
 					}
-                }
-
-                temporaryResourceDataStreamOut.Finish();
-
-            }
-
-
-            // Test checksum against expected
-			std::string destinationExpectedChecksum;
-
-			Result getChecksumResult = resource->GetChecksum( destinationExpectedChecksum );
-
-			if( getChecksumResult.type != ResultType::SUCCESS )
-			{
-				return getChecksumResult;
+				}
 			}
 
-			std::string patchedFileChecksum;
+			// Stream out the remaining expected data
+			uintmax_t expectedResourceSize = 0;
 
-			if( !patchedFileChecksumStream.FinishAndRetrieve( patchedFileChecksum ) )
+			Result getResourceUncompressedSizeResult = resource->GetUncompressedSize( expectedResourceSize );
+
+			if( getResourceUncompressedSizeResult.type != ResultType::SUCCESS )
 			{
-				return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+				return getResourceUncompressedSizeResult;
 			}
 
-			if( patchedFileChecksum != destinationExpectedChecksum )
+			temporaryResourceDataStreamOut.Finish();
+		}
+		else
+		{
+			// No Patch found, indicates this is just a new file
+			// Just replace file directly
+			auto resourceStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
+
+			ResourceGetDataStreamParams resourceGetDataParams;
+
+			resourceGetDataParams.resourceSourceSettings = params.nextBuildResourcesSourceSettings;
+
+			resourceGetDataParams.dataStream = resourceStreamIn;
+
+			Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
+
+			if( resourceGetDataResult.type != ResultType::SUCCESS )
 			{
-				return Result{ ResultType::UNEXPECTED_PATCH_CHECKSUM_RESULT };
+				return resourceGetDataResult;
 			}
 
-
-			// Copy temp file to replace the old resource file
-
-            // Open output stream
-			ResourceTools::FileDataStreamOut resourceStreamOut;
-
-			ResourcePutDataStreamParams patchedResourceResourcePutDataStreamParams;
-
-			patchedResourceResourcePutDataStreamParams.resourceDestinationSettings = params.resourcesToPatchDestinationSettings;
-
-			patchedResourceResourcePutDataStreamParams.dataStream = &resourceStreamOut;
-
-			Result putResourceDataStreamResult = resource->PutDataStream( patchedResourceResourcePutDataStreamParams );
-
-			if( putResourceDataStreamResult.type != ResultType::SUCCESS )
+			while( !resourceStreamIn->IsFinished() )
 			{
-				return putResourceDataStreamResult;
-			}
+				std::string resourceData;
 
-
-			// Open input stream
-			ResourceTools::FileDataStreamIn tempPatchedResourceIn(m_maxInputChunkSize.GetValue());
-
-            if (!tempPatchedResourceIn.StartRead(params.temporaryFilePath))
-            {
-				return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-            }
-
-            while (!tempPatchedResourceIn.IsFinished())
-            {
-				std::string data;
-
-                if (!(tempPatchedResourceIn >> data))
-                {
+				if( !( *resourceStreamIn >> resourceData ) )
+				{
 					return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                }
+				}
 
-                if (!(resourceStreamOut << data))
-                {
+				if( !( temporaryResourceDataStreamOut << resourceData ) )
+				{
 					return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-                }
-            }
+				}
 
-            resourceStreamOut.Finish();
-        }
+				// Add to incremental checksum calculation
+				if( !( patchedFileChecksumStream << resourceData ) )
+				{
+					return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+				}
+			}
 
-    	for( const auto& path : *m_removedResources.GetValue() )
-    	{
-    		auto toRemove = std::filesystem::absolute( params.resourcesToPatchDestinationSettings.basePath / path );
-    		std::error_code ec;
-    		if( std::filesystem::exists( toRemove ) )
-    		{
-    			bool removed = std::filesystem::remove( toRemove, ec );
-    			if( !removed && params.statusCallback )
-    			{
-    				params.statusCallback(StatusLevel::DETAIL, StatusProgressType::UNBOUNDED, 0, "Failed to remove file " + toRemove.string());
-    			}
-    		}
-
-    		// Remove any empty directories left over
-    		toRemove = toRemove.parent_path();
-    		while( std::filesystem::is_directory( toRemove ) && std::filesystem::is_empty( toRemove ) )
-    		{
-    			bool removed = std::filesystem::remove( toRemove, ec );
-    			if( !removed && params.statusCallback )
-    			{
-    				params.statusCallback(StatusLevel::DETAIL, StatusProgressType::UNBOUNDED, 0, "Failed to remove empty directory " + toRemove.string());
-    			}
-    		}
-    	}
-
-        if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Patches applied" );
+			temporaryResourceDataStreamOut.Finish();
 		}
 
-        return Result{ ResultType::SUCCESS };
 
+		// Test checksum against expected
+		std::string destinationExpectedChecksum;
 
-    }
+		Result getChecksumResult = resource->GetChecksum( destinationExpectedChecksum );
 
-    Result PatchResourceGroup::PatchResourceGroupImpl::SetRemovedResourceRelativePaths( const std::vector<std::filesystem::path>& paths )
-	{
-		for( auto path : paths )
+		if( getChecksumResult.type != ResultType::SUCCESS )
 		{
-			m_removedResources.PushBack( path );
+			return getChecksumResult;
 		}
-		return Result{ ResultType::SUCCESS };
+
+		std::string patchedFileChecksum;
+
+		if( !patchedFileChecksumStream.FinishAndRetrieve( patchedFileChecksum ) )
+		{
+			return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+		}
+
+		if( patchedFileChecksum != destinationExpectedChecksum )
+		{
+			return Result{ ResultType::UNEXPECTED_PATCH_CHECKSUM_RESULT };
+		}
+
+
+		// Copy temp file to replace the old resource file
+
+		// Open output stream
+		ResourceTools::FileDataStreamOut resourceStreamOut;
+
+		ResourcePutDataStreamParams patchedResourceResourcePutDataStreamParams;
+
+		patchedResourceResourcePutDataStreamParams.resourceDestinationSettings = params.resourcesToPatchDestinationSettings;
+
+		patchedResourceResourcePutDataStreamParams.dataStream = &resourceStreamOut;
+
+		Result putResourceDataStreamResult = resource->PutDataStream( patchedResourceResourcePutDataStreamParams );
+
+		if( putResourceDataStreamResult.type != ResultType::SUCCESS )
+		{
+			return putResourceDataStreamResult;
+		}
+
+
+		// Open input stream
+		ResourceTools::FileDataStreamIn tempPatchedResourceIn( m_maxInputChunkSize.GetValue() );
+
+		if( !tempPatchedResourceIn.StartRead( params.temporaryFilePath ) )
+		{
+			return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+		}
+
+		while( !tempPatchedResourceIn.IsFinished() )
+		{
+			std::string data;
+
+			if( !( tempPatchedResourceIn >> data ) )
+			{
+				return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+			}
+
+			if( !( resourceStreamOut << data ) )
+			{
+				return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+			}
+		}
+
+		resourceStreamOut.Finish();
 	}
 
-	Result PatchResourceGroup::PatchResourceGroupImpl::GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const
+	for( const auto& path : *m_removedResources.GetValue() )
 	{
-		if( m_resourceGroupParameter.HasValue() )
+		auto toRemove = std::filesystem::absolute( params.resourcesToPatchDestinationSettings.basePath / path );
+		std::error_code ec;
+		if( std::filesystem::exists( toRemove ) )
 		{
-			toBundle.emplace_back( m_resourceGroupParameter.GetValue() );
+			bool removed = std::filesystem::remove( toRemove, ec );
+			if( !removed && params.statusCallback )
+			{
+				params.statusCallback( StatusLevel::DETAIL, StatusProgressType::UNBOUNDED, 0, "Failed to remove file " + toRemove.string() );
+			}
 		}
 
-		return Result{ ResultType::SUCCESS };
+		// Remove any empty directories left over
+		toRemove = toRemove.parent_path();
+		while( std::filesystem::is_directory( toRemove ) && std::filesystem::is_empty( toRemove ) )
+		{
+			bool removed = std::filesystem::remove( toRemove, ec );
+			if( !removed && params.statusCallback )
+			{
+				params.statusCallback( StatusLevel::DETAIL, StatusProgressType::UNBOUNDED, 0, "Failed to remove empty directory " + toRemove.string() );
+			}
+		}
 	}
+
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Patches applied" );
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result PatchResourceGroup::PatchResourceGroupImpl::SetRemovedResourceRelativePaths( const std::vector<std::filesystem::path>& paths )
+{
+	for( auto path : paths )
+	{
+		m_removedResources.PushBack( path );
+	}
+	return Result{ ResultType::SUCCESS };
+}
+
+Result PatchResourceGroup::PatchResourceGroupImpl::GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const
+{
+	if( m_resourceGroupParameter.HasValue() )
+	{
+		toBundle.emplace_back( m_resourceGroupParameter.GetValue() );
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
 
 }

--- a/src/PatchResourceGroupImpl.h
+++ b/src/PatchResourceGroupImpl.h
@@ -15,46 +15,43 @@
 namespace CarbonResources
 {
 
-    class PatchResourceGroup::PatchResourceGroupImpl : public ResourceGroup::ResourceGroupImpl
-    {
-    public:
+class PatchResourceGroup::PatchResourceGroupImpl : public ResourceGroup::ResourceGroupImpl
+{
+public:
+	PatchResourceGroupImpl();
 
-        PatchResourceGroupImpl( );
+	~PatchResourceGroupImpl();
 
-        ~PatchResourceGroupImpl();
+	Result SetResourceGroup( const ResourceGroupInfo& resourceGroup );
 
-        Result SetResourceGroup( const ResourceGroupInfo& resourceGroup );
+	Result SetMaxInputChunkSize( uintmax_t maxInputChunkSize );
 
-        Result SetMaxInputChunkSize( uintmax_t maxInputChunkSize );
+	Result Apply( const PatchApplyParams& params );
 
-        Result Apply( const PatchApplyParams& params );
+	virtual std::string GetType() const override;
 
-        virtual std::string GetType() const override;
+	static std::string TypeId();
 
-        static std::string TypeId();
+	Result SetRemovedResourceRelativePaths( const std::vector<std::filesystem::path>& paths );
 
-    	Result SetRemovedResourceRelativePaths( const std::vector<std::filesystem::path>& paths );
+	virtual Result GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const final;
 
-		virtual Result GetGroupSpecificResourcesToBundle(std::vector<ResourceInfo*>& toBundle) const final;
+private:
+	virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut ) override;
 
-    private:
+	virtual Result ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile ) override;
 
-        virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut ) override;
+	virtual Result ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const override;
 
-        virtual Result ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile ) override;
+	Result GetTargetResourcePatches( const ResourceInfo* targetResource, std::vector<const PatchResourceInfo*>& patches ) const;
 
-        virtual Result ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const override;
+protected:
+	DocumentParameter<uintmax_t> m_maxInputChunkSize = DocumentParameter<uintmax_t>( MAX_INPUT_CHUNK_SIZE, TypeId() );
 
-        Result GetTargetResourcePatches( const ResourceInfo* targetResource, std::vector<const PatchResourceInfo*>& patches ) const;
+	DocumentParameter<ResourceGroupInfo*> m_resourceGroupParameter = DocumentParameter<ResourceGroupInfo*>( RESOURCE_GROUP_RESOURCE, TypeId() );
 
-    protected:
-
-        DocumentParameter<uintmax_t> m_maxInputChunkSize = DocumentParameter<uintmax_t>( MAX_INPUT_CHUNK_SIZE, TypeId() );
-
-        DocumentParameter<ResourceGroupInfo*> m_resourceGroupParameter = DocumentParameter<ResourceGroupInfo*>( RESOURCE_GROUP_RESOURCE, TypeId() );
-
-    	DocumentParameterCollection<std::filesystem::path> m_removedResources = DocumentParameterCollection<std::filesystem::path>( REMOVED_RESOURCE_RELATIVE_PATHS, TypeId() );
-    };
+	DocumentParameterCollection<std::filesystem::path> m_removedResources = DocumentParameterCollection<std::filesystem::path>( REMOVED_RESOURCE_RELATIVE_PATHS, TypeId() );
+};
 
 }
 

--- a/src/ResourceGroup.cpp
+++ b/src/ResourceGroup.cpp
@@ -7,59 +7,59 @@
 namespace CarbonResources
 {
 
-    ResourceGroup::ResourceGroup( ResourceGroupImpl* impl ) :
-	    m_impl( impl )
-    {
-    }
+ResourceGroup::ResourceGroup( ResourceGroupImpl* impl ) :
+	m_impl( impl )
+{
+}
 
-    ResourceGroup::ResourceGroup(  ) :
-		m_impl( new ResourceGroupImpl( ) )
-    {
-    }
+ResourceGroup::ResourceGroup() :
+	m_impl( new ResourceGroupImpl() )
+{
+}
 
-    ResourceGroup::~ResourceGroup()
-    {
-	    delete m_impl;
-    }
+ResourceGroup::~ResourceGroup()
+{
+	delete m_impl;
+}
 
-    Result ResourceGroup::CreateBundle( const BundleCreateParams& params ) const
-    {
-		return m_impl->CreateBundle( params );
-    }
+Result ResourceGroup::CreateBundle( const BundleCreateParams& params ) const
+{
+	return m_impl->CreateBundle( params );
+}
 
-    Result ResourceGroup::CreatePatch( const PatchCreateParams& params ) const
-    {
-	    return m_impl->CreatePatch( params );
-    }
+Result ResourceGroup::CreatePatch( const PatchCreateParams& params ) const
+{
+	return m_impl->CreatePatch( params );
+}
 
-    Result ResourceGroup::ImportFromFile( const ResourceGroupImportFromFileParams& params ) const
-    {
-	    return m_impl->ImportFromFile( params );
-    }
+Result ResourceGroup::ImportFromFile( const ResourceGroupImportFromFileParams& params ) const
+{
+	return m_impl->ImportFromFile( params );
+}
 
-    Result ResourceGroup::ExportToFile( const ResourceGroupExportToFileParams& params ) const
-    {
-	    return m_impl->ExportToFile( params );
-    }
+Result ResourceGroup::ExportToFile( const ResourceGroupExportToFileParams& params ) const
+{
+	return m_impl->ExportToFile( params );
+}
 
-    Result ResourceGroup::CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params )
-    {
-		return m_impl->CreateFromDirectory( params );
-    }
+Result ResourceGroup::CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params )
+{
+	return m_impl->CreateFromDirectory( params );
+}
 
-    Result ResourceGroup::Merge( const ResourceGroupMergeParams& params ) const
-    {
-		return m_impl->Merge( params );
-    }
+Result ResourceGroup::Merge( const ResourceGroupMergeParams& params ) const
+{
+	return m_impl->Merge( params );
+}
 
-    Result ResourceGroup::DiffAgainstGroup( const ResourceGroupDiffAgainstGroupParams& params ) const
-    {
-		return m_impl->DiffChangesAsLists( params );
-    }
+Result ResourceGroup::DiffAgainstGroup( const ResourceGroupDiffAgainstGroupParams& params ) const
+{
+	return m_impl->DiffChangesAsLists( params );
+}
 
-    Result ResourceGroup::RemoveResources(const ResourceGroupRemoveResourcesParams& params) const
-    {
-		return m_impl->RemoveResources( params );
-    }
+Result ResourceGroup::RemoveResources( const ResourceGroupRemoveResourcesParams& params ) const
+{
+	return m_impl->RemoveResources( params );
+}
 
 }

--- a/src/ResourceGroupFactory.cpp
+++ b/src/ResourceGroupFactory.cpp
@@ -18,111 +18,111 @@
 
 namespace CarbonResources
 {
-    Result CreateResourceGroupFromYamlString( const std::string& yamlString, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out )
+Result CreateResourceGroupFromYamlString( const std::string& yamlString, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out )
+{
+	YAML::Node root;
+	try
 	{
-	    YAML::Node root;
-    	try
-    	{
-    		root = YAML::Load( yamlString );
-    	}
-    	catch( YAML::ParserException& )
-    	{
-    		return Result{ ResultType::FAILED_TO_PARSE_YAML };
-    	}
-		YAML::Node type = root["Type"];
-		if( !type.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP, "Tried to load a resource group without a 'Type' attribute." };
-		}
-		auto resourceGroupTypeString = type.as<std::string>();
-
-        Result createFromStringResult = CreateResourceGroupFromString( resourceGroupTypeString, out );
-
-        if( createFromStringResult.type != ResultType::SUCCESS )
-        {
-			return createFromStringResult;
-        }
-
-		return out->ImportFromYaml( root );
+		root = YAML::Load( yamlString );
 	}
-
-    Result CreateResourceGroupFromString( std::string& string, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out )
-    {
-		if( string == ResourceGroup::ResourceGroupImpl::TypeId() )
-		{
-			out = std::make_shared<ResourceGroup::ResourceGroupImpl>();
-		}
-		else if( string == PatchResourceGroup::PatchResourceGroupImpl::TypeId() )
-		{
-			out = std::make_shared<PatchResourceGroup::PatchResourceGroupImpl>();
-		}
-		else if( string == BundleResourceGroup::BundleResourceGroupImpl::TypeId() )
-		{
-			out = std::make_shared<BundleResourceGroup::BundleResourceGroupImpl>();
-		}
-		else
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP, "Unexpected Resource Group Type: '" + string + "'." };
-		}
-
-        return Result{ ResultType::SUCCESS };
-    }
-
-
-
-
-    Result CreateResourceInfoFromYamlNode( YAML::Node& resource, std::unique_ptr<ResourceInfo>& out, const VersionInternal& documentVersion )
+	catch( YAML::ParserException& )
 	{
-		YAML::Node type = resource["Type"];
-		if( !type.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE, "Tried to load a resource info without a 'Type' attribute." };
-		}
-		auto resourceGroupTypeString = type.as<std::string>();
-
-		Result createFromStringResult = CreateResourceInfoFromString( resourceGroupTypeString, out );
-
-		if( createFromStringResult.type != ResultType::SUCCESS )
-		{
-			return createFromStringResult;
-		}
-
-		return out->ImportFromYaml( resource, documentVersion );
+		return Result{ ResultType::FAILED_TO_PARSE_YAML };
 	}
-
-	Result CreateResourceInfoFromString( std::string& string, std::unique_ptr<ResourceInfo>& out )
+	YAML::Node type = root["Type"];
+	if( !type.IsDefined() )
 	{
-
-		if( string == BundleResourceGroupInfo::TypeId() )
-		{
-			out = std::make_unique<BundleResourceGroupInfo>( BundleResourceGroupInfoParams {});
-		}
-		else if( string == BundleResourceInfo::TypeId() )
-		{
-			out = std::make_unique<BundleResourceInfo>( BundleResourceInfoParams{} );
-		}
-		else if( string == PatchResourceGroupInfo::TypeId() )
-		{
-			out = std::make_unique<PatchResourceGroupInfo>( PatchResourceGroupInfoParams{} );
-		}
-		else if( string == PatchResourceInfo::TypeId() )
-		{
-			out = std::make_unique<PatchResourceInfo>( PatchResourceInfoParams{} );
-		}
-		else if( string == ResourceGroupInfo::TypeId() )
-		{
-			out = std::make_unique<ResourceGroupInfo>( ResourceGroupInfoParams{} );
-		}
-		else if( string == ResourceInfo::TypeId() )
-		{
-			out = std::make_unique<ResourceInfo>( ResourceInfoParams{} );
-		}
-		
-		else
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE, "Unexpected Resource Info Type: '" + string + "'." };
-		}
-
-		return Result{ ResultType::SUCCESS };
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP, "Tried to load a resource group without a 'Type' attribute." };
 	}
+	auto resourceGroupTypeString = type.as<std::string>();
+
+	Result createFromStringResult = CreateResourceGroupFromString( resourceGroupTypeString, out );
+
+	if( createFromStringResult.type != ResultType::SUCCESS )
+	{
+		return createFromStringResult;
 	}
+
+	return out->ImportFromYaml( root );
+}
+
+Result CreateResourceGroupFromString( std::string& string, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out )
+{
+	if( string == ResourceGroup::ResourceGroupImpl::TypeId() )
+	{
+		out = std::make_shared<ResourceGroup::ResourceGroupImpl>();
+	}
+	else if( string == PatchResourceGroup::PatchResourceGroupImpl::TypeId() )
+	{
+		out = std::make_shared<PatchResourceGroup::PatchResourceGroupImpl>();
+	}
+	else if( string == BundleResourceGroup::BundleResourceGroupImpl::TypeId() )
+	{
+		out = std::make_shared<BundleResourceGroup::BundleResourceGroupImpl>();
+	}
+	else
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP, "Unexpected Resource Group Type: '" + string + "'." };
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+
+
+
+Result CreateResourceInfoFromYamlNode( YAML::Node& resource, std::unique_ptr<ResourceInfo>& out, const VersionInternal& documentVersion )
+{
+	YAML::Node type = resource["Type"];
+	if( !type.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE, "Tried to load a resource info without a 'Type' attribute." };
+	}
+	auto resourceGroupTypeString = type.as<std::string>();
+
+	Result createFromStringResult = CreateResourceInfoFromString( resourceGroupTypeString, out );
+
+	if( createFromStringResult.type != ResultType::SUCCESS )
+	{
+		return createFromStringResult;
+	}
+
+	return out->ImportFromYaml( resource, documentVersion );
+}
+
+Result CreateResourceInfoFromString( std::string& string, std::unique_ptr<ResourceInfo>& out )
+{
+
+	if( string == BundleResourceGroupInfo::TypeId() )
+	{
+		out = std::make_unique<BundleResourceGroupInfo>( BundleResourceGroupInfoParams{} );
+	}
+	else if( string == BundleResourceInfo::TypeId() )
+	{
+		out = std::make_unique<BundleResourceInfo>( BundleResourceInfoParams{} );
+	}
+	else if( string == PatchResourceGroupInfo::TypeId() )
+	{
+		out = std::make_unique<PatchResourceGroupInfo>( PatchResourceGroupInfoParams{} );
+	}
+	else if( string == PatchResourceInfo::TypeId() )
+	{
+		out = std::make_unique<PatchResourceInfo>( PatchResourceInfoParams{} );
+	}
+	else if( string == ResourceGroupInfo::TypeId() )
+	{
+		out = std::make_unique<ResourceGroupInfo>( ResourceGroupInfoParams{} );
+	}
+	else if( string == ResourceInfo::TypeId() )
+	{
+		out = std::make_unique<ResourceInfo>( ResourceInfoParams{} );
+	}
+
+	else
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE, "Unexpected Resource Info Type: '" + string + "'." };
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+}

--- a/src/ResourceGroupFactory.h
+++ b/src/ResourceGroupFactory.h
@@ -7,13 +7,13 @@
 
 namespace CarbonResources
 {
-	Result CreateResourceGroupFromYamlString( const std::string& yamlString, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out );
+Result CreateResourceGroupFromYamlString( const std::string& yamlString, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out );
 
-    Result CreateResourceGroupFromString( std::string& string, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out );
+Result CreateResourceGroupFromString( std::string& string, std::shared_ptr<ResourceGroup::ResourceGroupImpl>& out );
 
-    Result CreateResourceInfoFromYamlNode( YAML::Node& resource, std::unique_ptr<ResourceInfo>& out, const VersionInternal& documentVersion );
+Result CreateResourceInfoFromYamlNode( YAML::Node& resource, std::unique_ptr<ResourceInfo>& out, const VersionInternal& documentVersion );
 
-	Result CreateResourceInfoFromString( std::string& string, std::unique_ptr<ResourceInfo>& out );
+Result CreateResourceInfoFromString( std::string& string, std::unique_ptr<ResourceInfo>& out );
 
 }
 

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -1884,7 +1884,10 @@ Result ResourceGroup::ResourceGroupImpl::Merge( const ResourceGroupMergeParams& 
 
 	std::vector<ResourceInfo*> unionResources;
 	std::set_union(
-		sortedMergeResources.begin(), sortedMergeResources.end(), sortedResourcesParameter.begin(), sortedResourcesParameter.end(), std::back_inserter( unionResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+		sortedMergeResources.begin(), sortedMergeResources.end(),
+		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
+		std::back_inserter( unionResources ),
+		[]( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
 
 	// Add result to merge ResourceGroup output
 	for( auto resource : unionResources )
@@ -1981,15 +1984,24 @@ Result ResourceGroup::ResourceGroupImpl::Diff( ResourceGroupSubtractionParams& p
 
 	std::vector<ResourceInfo*> addedResources;
 	std::set_difference(
-		sortedResourcesParameter.begin(), sortedResourcesParameter.end(), sortedSubtractionResources.begin(), sortedSubtractionResources.end(), std::back_inserter( addedResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
+		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
+		std::back_inserter( addedResources ),
+		[]( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
 
 	std::vector<ResourceInfo*> removedResources;
 	std::set_difference(
-		sortedSubtractionResources.begin(), sortedSubtractionResources.end(), sortedResourcesParameter.begin(), sortedResourcesParameter.end(), std::back_inserter( removedResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
+		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
+		std::back_inserter( removedResources ),
+		[]( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
 
 	std::vector<ResourceInfo*> potentiallyModifiedResources;
 	std::set_intersection(
-		sortedResourcesParameter.begin(), sortedResourcesParameter.end(), sortedSubtractionResources.begin(), sortedSubtractionResources.end(), std::back_inserter( potentiallyModifiedResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
+		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
+		std::back_inserter( potentiallyModifiedResources ),
+		[]( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
 
 	for( ResourceInfo* resource : potentiallyModifiedResources )
 	{
@@ -2014,7 +2026,8 @@ Result ResourceGroup::ResourceGroupImpl::Diff( ResourceGroupSubtractionParams& p
 		}
 
 		ResourceInfo* resource2 = *std::lower_bound(
-			sortedSubtractionResources.begin(), sortedSubtractionResources.end(), resource, []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+			sortedSubtractionResources.begin(), sortedSubtractionResources.end(), resource,
+			[]( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
 
 		std::string resource1Checksum;
 

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -21,228 +21,226 @@
 
 namespace CarbonResources
 {
-    
 
-    ResourceGroup::ResourceGroupImpl::ResourceGroupImpl()
-    {
-		m_versionParameter = VersionInternal(S_DOCUMENT_VERSION);
 
-		m_type = TypeId();
+ResourceGroup::ResourceGroupImpl::ResourceGroupImpl()
+{
+	m_versionParameter = VersionInternal( S_DOCUMENT_VERSION );
 
-        m_numberOfResources = 0;
+	m_type = TypeId();
 
-        m_totalResourcesSizeCompressed = 0;
+	m_numberOfResources = 0;
 
-        m_totalResourcesSizeUncompressed = 0;
-    }
+	m_totalResourcesSizeCompressed = 0;
 
-    ResourceGroup::ResourceGroupImpl::~ResourceGroupImpl()
-    {
-        for (ResourceInfo* resourceInfo : m_resourcesParameter)
-        {
-			delete resourceInfo;
-        }
-    }
+	m_totalResourcesSizeUncompressed = 0;
+}
 
-    Result ResourceGroup::ResourceGroupImpl::CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params )
-    {
-		// Update status
-		if( params.statusCallback )
+ResourceGroup::ResourceGroupImpl::~ResourceGroupImpl()
+{
+	for( ResourceInfo* resourceInfo : m_resourcesParameter )
+	{
+		delete resourceInfo;
+	}
+}
+
+Result ResourceGroup::ResourceGroupImpl::CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params )
+{
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Processing Files: " + params.directory.string() );
+	}
+
+	if( !std::filesystem::exists( params.directory ) )
+	{
+		return Result{ ResultType::INPUT_DIRECTORY_DOESNT_EXIST };
+	}
+
+	// Ensure document version is valid
+	VersionInternal documentVersion( params.outputDocumentVersion );
+
+	if( !documentVersion.isVersionValid() )
+	{
+		return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
+	}
+
+	// Walk directory and create a resource from each file using data
+	auto recursiveDirectoryIter = std::filesystem::recursive_directory_iterator( params.directory );
+
+	for( const std::filesystem::directory_entry& entry : recursiveDirectoryIter )
+	{
+		if( entry.is_regular_file() )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Processing Files: " + params.directory.string() );
-		}
-
-        if (!std::filesystem::exists(params.directory))
-        {
-			return Result{ ResultType::INPUT_DIRECTORY_DOESNT_EXIST };
-        }
-
-        // Ensure document version is valid
-        VersionInternal documentVersion( params.outputDocumentVersion );
-
-        if (!documentVersion.isVersionValid())
-        {
-			return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
-        }
-
-        // Walk directory and create a resource from each file using data
-		auto recursiveDirectoryIter = std::filesystem::recursive_directory_iterator( params.directory );
-
-        for (const std::filesystem::directory_entry& entry : recursiveDirectoryIter)
-        {
-            if (entry.is_regular_file())
-            {
-                // Update status
-                if (params.statusCallback)
-                {
-					params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::UNBOUNDED, 0, "Processing File: " + entry.path().string() );
-                }
-
-                // Create resource
-			    auto fileSize = entry.file_size();
-
-                if( fileSize < params.resourceStreamThreshold )
-                {
-                    // Create resource from data
-				    ResourceInfoParams resourceParams;
-					
-                    resourceParams.relativePath = std::filesystem::relative( entry.path(), params.directory );
-
-                	resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entry.path() );
-
-                	resourceParams.prefix = params.resourcePrefix;
-
-				    ResourceInfo* resource = new ResourceInfo( resourceParams );
-
-                    std::string resourceData;
-
-                    ResourceGetDataParams resourceGetDataParams;
-
-                    resourceGetDataParams.resourceSourceSettings.basePaths = { params.directory };
-
-                    resourceGetDataParams.resourceSourceSettings.sourceType = ResourceSourceType::LOCAL_RELATIVE;
-
-                    resourceGetDataParams.data = &resourceData;
-
-                    Result getResourceDataResult = resource->GetData( resourceGetDataParams );
-
-                    if (getResourceDataResult.type != ResultType::SUCCESS)
-                    {
-					    return getResourceDataResult;
-                    }
-
-                    Result setParametersFromDataResult = resource->SetParametersFromData( resourceData );
-
-                    if (setParametersFromDataResult.type != ResultType::SUCCESS)
-                    {
-					    return setParametersFromDataResult;
-                    }
-
-                    Result addResourceResult = AddResource( resource );
-
-                    if (addResourceResult.type != ResultType::SUCCESS)
-                    {
-					    return addResourceResult;
-                    }
-                }
-                else
-                {
-                    // Process data via stream
-                    ResourceTools::Md5ChecksumStream checksumStream;
-                	std::string compressedData;
-
-                    ResourceTools::GzipCompressionStream compressionStream( &compressedData );
-
-                    ResourceTools::FileDataStreamIn fileStreamIn( params.resourceStreamThreshold );
-
-                    if (!compressionStream.Start())
-                    {
-						return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
-                    }
-
-                    if (!fileStreamIn.StartRead(entry.path()))
-                    {
-						return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
-                    }
-
-                    uintmax_t compressedDataSize = 0;
-
-                    while (!fileStreamIn.IsFinished())
-                    {
-						// Update status
-						if( params.statusCallback )
-						{
-							auto percentage = static_cast<unsigned int>( ( 100 * fileStreamIn.GetCurrentPosition() ) / fileStreamIn.Size() );
-							params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, "Percentage Update" );
-						}
-
-						std::string fileData;
-
-                        if (!(fileStreamIn >> fileData))
-                        {
-							return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                        }
-
-                        if (!(checksumStream << fileData))
-                        {
-							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                        }
-
-                        if( !( compressionStream << &fileData ) )
-                        {
-							return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
-                        }
-
-                        compressedDataSize += compressedData.size();
-                    	compressedData.clear();
-                    }
-
-                    if (!compressionStream.Finish())
-                    {
-						return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
-                    }
-
-                	compressedDataSize += compressedData.size();
-                	compressedData.clear();
-
-                    std::string checksum;
-
-                    if (!checksumStream.FinishAndRetrieve(checksum))
-                    {
-						return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                    }
-
-                    // Create resource from parameters
-                    ResourceInfoParams resourceParams;
-
-					resourceParams.relativePath = std::filesystem::relative( entry.path(), params.directory );
-
-					resourceParams.uncompressedSize = fileSize;
-
-                    resourceParams.compressedSize = compressedDataSize;
-
-                    resourceParams.checksum = checksum;
-
-                	resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entry.path() );
-
-                    Location l;
-
-					Result calculateLocationResult = l.SetFromRelativePathAndDataChecksum( resourceParams.relativePath, resourceParams.checksum );
-
-                    if (calculateLocationResult.type != ResultType::SUCCESS)
-                    {
-						return calculateLocationResult;
-                    }
-
-                    resourceParams.location = l.ToString();
-
-                    ResourceInfo* resource = new ResourceInfo( resourceParams );
-
-                    Result addResourceResult = AddResource( resource );
-
-					if( addResourceResult.type != ResultType::SUCCESS )
-					{
-						return addResourceResult;
-					}
-                    
-                }
+			// Update status
+			if( params.statusCallback )
+			{
+				params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::UNBOUNDED, 0, "Processing File: " + entry.path().string() );
 			}
-        }
 
-        if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Resource group successfully created from directory" );
+			// Create resource
+			auto fileSize = entry.file_size();
+
+			if( fileSize < params.resourceStreamThreshold )
+			{
+				// Create resource from data
+				ResourceInfoParams resourceParams;
+
+				resourceParams.relativePath = std::filesystem::relative( entry.path(), params.directory );
+
+				resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entry.path() );
+
+				resourceParams.prefix = params.resourcePrefix;
+
+				ResourceInfo* resource = new ResourceInfo( resourceParams );
+
+				std::string resourceData;
+
+				ResourceGetDataParams resourceGetDataParams;
+
+				resourceGetDataParams.resourceSourceSettings.basePaths = { params.directory };
+
+				resourceGetDataParams.resourceSourceSettings.sourceType = ResourceSourceType::LOCAL_RELATIVE;
+
+				resourceGetDataParams.data = &resourceData;
+
+				Result getResourceDataResult = resource->GetData( resourceGetDataParams );
+
+				if( getResourceDataResult.type != ResultType::SUCCESS )
+				{
+					return getResourceDataResult;
+				}
+
+				Result setParametersFromDataResult = resource->SetParametersFromData( resourceData );
+
+				if( setParametersFromDataResult.type != ResultType::SUCCESS )
+				{
+					return setParametersFromDataResult;
+				}
+
+				Result addResourceResult = AddResource( resource );
+
+				if( addResourceResult.type != ResultType::SUCCESS )
+				{
+					return addResourceResult;
+				}
+			}
+			else
+			{
+				// Process data via stream
+				ResourceTools::Md5ChecksumStream checksumStream;
+				std::string compressedData;
+
+				ResourceTools::GzipCompressionStream compressionStream( &compressedData );
+
+				ResourceTools::FileDataStreamIn fileStreamIn( params.resourceStreamThreshold );
+
+				if( !compressionStream.Start() )
+				{
+					return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+				}
+
+				if( !fileStreamIn.StartRead( entry.path() ) )
+				{
+					return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
+				}
+
+				uintmax_t compressedDataSize = 0;
+
+				while( !fileStreamIn.IsFinished() )
+				{
+					// Update status
+					if( params.statusCallback )
+					{
+						auto percentage = static_cast<unsigned int>( ( 100 * fileStreamIn.GetCurrentPosition() ) / fileStreamIn.Size() );
+						params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, "Percentage Update" );
+					}
+
+					std::string fileData;
+
+					if( !( fileStreamIn >> fileData ) )
+					{
+						return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+					}
+
+					if( !( checksumStream << fileData ) )
+					{
+						return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+					}
+
+					if( !( compressionStream << &fileData ) )
+					{
+						return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+					}
+
+					compressedDataSize += compressedData.size();
+					compressedData.clear();
+				}
+
+				if( !compressionStream.Finish() )
+				{
+					return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+				}
+
+				compressedDataSize += compressedData.size();
+				compressedData.clear();
+
+				std::string checksum;
+
+				if( !checksumStream.FinishAndRetrieve( checksum ) )
+				{
+					return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+				}
+
+				// Create resource from parameters
+				ResourceInfoParams resourceParams;
+
+				resourceParams.relativePath = std::filesystem::relative( entry.path(), params.directory );
+
+				resourceParams.uncompressedSize = fileSize;
+
+				resourceParams.compressedSize = compressedDataSize;
+
+				resourceParams.checksum = checksum;
+
+				resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entry.path() );
+
+				Location l;
+
+				Result calculateLocationResult = l.SetFromRelativePathAndDataChecksum( resourceParams.relativePath, resourceParams.checksum );
+
+				if( calculateLocationResult.type != ResultType::SUCCESS )
+				{
+					return calculateLocationResult;
+				}
+
+				resourceParams.location = l.ToString();
+
+				ResourceInfo* resource = new ResourceInfo( resourceParams );
+
+				Result addResourceResult = AddResource( resource );
+
+				if( addResourceResult.type != ResultType::SUCCESS )
+				{
+					return addResourceResult;
+				}
+			}
 		}
+	}
 
-        return Result{ ResultType::SUCCESS };
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Resource group successfully created from directory" );
+	}
 
-    }
+	return Result{ ResultType::SUCCESS };
+}
 
-    Result ResourceGroup::ResourceGroupImpl::ImportFromData( const std::string& data, DocumentType documentType /* = DocumentType::YAML */ )
-    {
-        switch (documentType)
-        {
-		case DocumentType::CSV:
+Result ResourceGroup::ResourceGroupImpl::ImportFromData( const std::string& data, DocumentType documentType /* = DocumentType::YAML */ )
+{
+	switch( documentType )
+	{
+	case DocumentType::CSV:
 #ifdef _MSC_VER
 #pragma warning( push )
 #pragma warning( disable : 4996 ) // Suppress deprecation warning.
@@ -250,204 +248,248 @@ namespace CarbonResources
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
-			return ImportFromCSV( data );
-#ifdef _MSC_VER
-#pragma warning ( pop )
-#elif __APPLE__
-#pragma clang diagnostic pop
-#endif
-		case DocumentType::YAML:
-			return ImportFromYamlString( data );
-		default:
-			return Result{ ResultType::UNSUPPORTED_FILE_FORMAT };
-        }
-
-        return Result{ ResultType::FAIL };
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ImportFromFile( const ResourceGroupImportFromFileParams& params )
-    {
-        // Status update
-        if (params.statusCallback)
-        {
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Importing Resource Group from file." );
-        }
-
-        if (params.filename.empty())
-        {
-			return Result{ ResultType::FILE_NOT_FOUND };
-        }
-
-        std::string data;
-
-		if( !ResourceTools::GetLocalFileData( params.filename, data ) )
-		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE };
-		}
-
-        // VERSION NEEDS TO BE CHECKED TO ENSURE ITS SUPPORTED ON IMPORT
-		std::filesystem::path filename = params.filename;
-
-        std::string extension = filename.extension().string();
-        
-        Result importResult;
-
-        if( extension == ".txt" )
-        {
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable : 4996 ) // Suppress deprecation warning.
-#elif __APPLE__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-			importResult = ImportFromCSV( data, params.statusCallback );
+		return ImportFromCSV( data );
 #ifdef _MSC_VER
 #pragma warning( pop )
 #elif __APPLE__
 #pragma clang diagnostic pop
 #endif
-        }
-		else if( extension == ".yml" || extension == ".yaml" || extension.empty() )
+	case DocumentType::YAML:
+		return ImportFromYamlString( data );
+	default:
+		return Result{ ResultType::UNSUPPORTED_FILE_FORMAT };
+	}
+
+	return Result{ ResultType::FAIL };
+}
+
+Result ResourceGroup::ResourceGroupImpl::ImportFromFile( const ResourceGroupImportFromFileParams& params )
+{
+	// Status update
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Importing Resource Group from file." );
+	}
+
+	if( params.filename.empty() )
+	{
+		return Result{ ResultType::FILE_NOT_FOUND };
+	}
+
+	std::string data;
+
+	if( !ResourceTools::GetLocalFileData( params.filename, data ) )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE };
+	}
+
+	// VERSION NEEDS TO BE CHECKED TO ENSURE ITS SUPPORTED ON IMPORT
+	std::filesystem::path filename = params.filename;
+
+	std::string extension = filename.extension().string();
+
+	Result importResult;
+
+	if( extension == ".txt" )
+	{
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4996 ) // Suppress deprecation warning.
+#elif __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+		importResult = ImportFromCSV( data, params.statusCallback );
+#ifdef _MSC_VER
+#pragma warning( pop )
+#elif __APPLE__
+#pragma clang diagnostic pop
+#endif
+	}
+	else if( extension == ".yml" || extension == ".yaml" || extension.empty() )
+	{
+		importResult = ImportFromYamlString( data, params.statusCallback );
+	}
+	else
+	{
+		return Result{ ResultType::UNSUPPORTED_FILE_FORMAT };
+	}
+
+	if( params.statusCallback )
+	{
+		if( importResult.type == ResultType::SUCCESS )
 		{
-			importResult = ImportFromYamlString( data, params.statusCallback );
+			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Successfully imported ResourceGroup" );
 		}
-        else
-        {
-			return Result{ ResultType::UNSUPPORTED_FILE_FORMAT };
-        }
+	}
 
-        if( params.statusCallback )
+	return importResult;
+}
+
+Result ResourceGroup::ResourceGroupImpl::ExportToFile( const ResourceGroupExportToFileParams& params ) const
+{
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Exporting Resource Group to file: " + params.filename.string() );
+	}
+
+	std::string data = "";
+
+	if( params.outputDocumentVersion.major == 0 && params.outputDocumentVersion.minor == 0 )
+	{
+		Result exportCsvResult = ExportCsv( params.outputDocumentVersion, data, params.statusCallback );
+		if( exportCsvResult.type != ResultType::SUCCESS )
 		{
-            if (importResult.type == ResultType::SUCCESS)
-			{
-				params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Successfully imported ResourceGroup" );
-            }
+			return exportCsvResult;
 		}
-
-        return importResult;
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ExportToFile( const ResourceGroupExportToFileParams& params ) const
-    {
-		// Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Exporting Resource Group to file: " + params.filename.string() );
-		}
-
-		std::string data = "";
-
-    	if( params.outputDocumentVersion.major == 0 && params.outputDocumentVersion.minor == 0 )
-    	{
-    		Result exportCsvResult = ExportCsv( params.outputDocumentVersion, data, params.statusCallback );
-    		if( exportCsvResult.type != ResultType::SUCCESS )
-    		{
-    			return exportCsvResult;
-    		}
-    	}
-    	else
-    	{
-    		Result exportYamlResult = ExportYaml( params.outputDocumentVersion, data, params.statusCallback );
-
-    		if (exportYamlResult.type != ResultType::SUCCESS)
-    		{
-    			return exportYamlResult;
-    		}
-    	}
-
-        if( !ResourceTools::SaveFile( params.filename, data ) )
-		{
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-
-        if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Resource group successfully exported." );
-		}
-
-		return Result{ ResultType::SUCCESS };
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ExportToData( std::string& data, VersionInternal outputDocumentVersion /* = S_DOCUMENT_VERSION*/ ) const
-    {
-		Result exportYamlResult = ExportYaml( outputDocumentVersion, data );
+	}
+	else
+	{
+		Result exportYamlResult = ExportYaml( params.outputDocumentVersion, data, params.statusCallback );
 
 		if( exportYamlResult.type != ResultType::SUCCESS )
 		{
 			return exportYamlResult;
 		}
+	}
 
-        return Result{ ResultType::SUCCESS };
-    }
+	if( !ResourceTools::SaveFile( params.filename, data ) )
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
 
-    Result ResourceGroup::ResourceGroupImpl::ImportFromCSV( const std::string& data, StatusCallback statusCallback /* = nullptr */ )
-    {
-		// Status update
-		if( statusCallback )
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Resource group successfully exported." );
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::ExportToData( std::string& data, VersionInternal outputDocumentVersion /* = S_DOCUMENT_VERSION*/ ) const
+{
+	Result exportYamlResult = ExportYaml( outputDocumentVersion, data );
+
+	if( exportYamlResult.type != ResultType::SUCCESS )
+	{
+		return exportYamlResult;
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::ImportFromCSV( const std::string& data, StatusCallback statusCallback /* = nullptr */ )
+{
+	// Status update
+	if( statusCallback )
+	{
+		statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 5, "Importing Resource Group from CSV file." );
+	}
+
+	std::stringstream inputStream;
+
+	inputStream << data;
+
+	std::string stringIn;
+
+	while( !inputStream.eof() )
+	{
+		std::getline( inputStream, stringIn );
+
+		if( stringIn == "" )
 		{
-			statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 5, "Importing Resource Group from CSV file." );
+			continue;
 		}
 
-        std::stringstream inputStream;
+		std::stringstream ss( stringIn );
 
-        inputStream << data;
+		std::string value;
 
-		std::string stringIn;
+		char delimiter = ',';
 
-		while( !inputStream.eof() )
+		ResourceInfoParams resourceParams;
+
+		if( !std::getline( ss, value, delimiter ) )
 		{
-			std::getline( inputStream, stringIn );
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
 
-            if (stringIn == "")
-            {
-				continue;
-            }
+		// Split filename and prefix
+		std::string resourcePrefixDelimiter = ":/";
+		std::string filename = value.substr( value.find( resourcePrefixDelimiter ) + resourcePrefixDelimiter.size() );
+		std::string resourcePrefix = value.substr( 0, value.find( ":" ) );
 
-            std::stringstream ss(stringIn);
+		resourceParams.relativePath = filename;
 
-            std::string value;
+		resourceParams.prefix = resourcePrefix;
 
-            char delimiter = ',';
+		if( !std::getline( ss, value, delimiter ) )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
 
-            ResourceInfoParams resourceParams;
+		resourceParams.location = value;
 
-            if( !std::getline( ss, value, delimiter ) )
-            {
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-            }
+		if( !std::getline( ss, value, delimiter ) )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
 
-            // Split filename and prefix
-			std::string resourcePrefixDelimiter = ":/";
-			std::string filename = value.substr( value.find(resourcePrefixDelimiter) + resourcePrefixDelimiter.size() );
-			std::string resourcePrefix = value.substr( 0, value.find( ":" ) );
+		resourceParams.checksum = value;
 
-			resourceParams.relativePath = filename;
+		if( !std::getline( ss, value, delimiter ) )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
 
-			resourceParams.prefix = resourcePrefix;
+		try
+		{
+			resourceParams.uncompressedSize = std::stoull( value.c_str() );
+		}
+		catch( std::invalid_argument& )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+		catch( std::out_of_range& )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
 
-			if( !std::getline( ss, value, delimiter ) )
+		if( !std::getline( ss, value, delimiter ) )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+
+		try
+		{
+			resourceParams.compressedSize = std::stoull( value.c_str() );
+		}
+		catch( std::invalid_argument& )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+		catch( std::out_of_range& )
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+
+		if( !std::getline( ss, value, delimiter ) )
+		{
+			resourceParams.binaryOperation = 0;
+		}
+		else
+		{
+			try
 			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
+				unsigned long long valueToULongLong = std::stoull( value.c_str() );
 
-			resourceParams.location = value;
+				if( valueToULongLong > std::numeric_limits<uint32_t>::max() )
+				{
+					return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+				}
 
-			if( !std::getline( ss, value, delimiter ) )
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
-
-			resourceParams.checksum = value;
-
-			if( !std::getline( ss, value, delimiter ) )
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
-
-            try
-			{
-				resourceParams.uncompressedSize = std::stoull( value.c_str() );
+				resourceParams.binaryOperation = static_cast<uint32_t>( valueToULongLong );
 			}
 			catch( std::invalid_argument& )
 			{
@@ -457,1512 +499,541 @@ namespace CarbonResources
 			{
 				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
 			}
-
-			if( !std::getline( ss, value, delimiter ) )
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
-
-            try
-			{
-				resourceParams.compressedSize = std::stoull( value.c_str() );
-			}
-			catch( std::invalid_argument& )
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
-			catch( std::out_of_range& )
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
-
-			if( !std::getline( ss, value, delimiter ) )
-			{
-				resourceParams.binaryOperation = 0;
-			}
-			else
-			{
-                try
-				{
-					unsigned long long valueToULongLong = std::stoull( value.c_str() );
-
-					if( valueToULongLong > std::numeric_limits<uint32_t>::max() )
-					{
-						return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-					}
-
-                    resourceParams.binaryOperation = static_cast<uint32_t>( valueToULongLong );
-				}
-				catch( std::invalid_argument& )
-				{
-					return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-				}
-				catch( std::out_of_range& )
-				{
-					return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-				}
-
-			}
-
-            // ResourceGroup gets upgraded to 0.1.0
-			m_versionParameter = VersionInternal{ 0, 1, 0 };
-
-			// Create a Resource
-			ResourceInfo* resource = new ResourceInfo( resourceParams );
-
-            Result addResourceResult = AddResource( resource );
-
-            if (addResourceResult.type != ResultType::SUCCESS)
-            {
-				return addResourceResult;
-            }
-
-            if( statusCallback )
-			{
-				statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::UNBOUNDED, 0, "Imported resource: " + resourceParams.relativePath.string() );
-			}
 		}
 
-		return Result{ ResultType::SUCCESS };
-    }
+		// ResourceGroup gets upgraded to 0.1.0
+		m_versionParameter = VersionInternal{ 0, 1, 0 };
 
-    Result ResourceGroup::ResourceGroupImpl::CreateResourceFromResource( const ResourceInfo& resourceIn, ResourceInfo*& resourceOut ) const
-    {
-		resourceOut = nullptr;
+		// Create a Resource
+		ResourceInfo* resource = new ResourceInfo( resourceParams );
 
-		std::string resourceType = "";
-
-		Result getResourceTypeResult = resourceIn.GetType( resourceType );
-
-        if (getResourceTypeResult.type != ResultType::SUCCESS)
-        {
-			return getResourceTypeResult;
-        }
-
-        if (resourceType == ResourceInfo::TypeId())
-        {
-			resourceOut = new ResourceInfo( {} );
-
-            Result setParametersFromResourceResult = resourceOut->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
-
-            if (setParametersFromResourceResult.type != ResultType::SUCCESS)
-            {
-				return setParametersFromResourceResult;
-            }
-        }
-        else if (resourceType == PatchResourceInfo::TypeId())
-        {
-			PatchResourceInfo* patchResourceInfo = new PatchResourceInfo( {} );
-
-            Result setParametersFromResourceResult = patchResourceInfo->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
-
-            if( setParametersFromResourceResult.type != ResultType::SUCCESS )
-			{
-				return setParametersFromResourceResult;
-			}
-
-            resourceOut = patchResourceInfo;
-        }
-		else if( resourceType == BundleResourceInfo::TypeId() )
-		{
-			BundleResourceInfo* bundleResourceInfo = new BundleResourceInfo( {} );
-
-			Result setParametersFromResourceResult = bundleResourceInfo->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
-            
-            if( setParametersFromResourceResult.type != ResultType::SUCCESS )
-			{
-				return setParametersFromResourceResult;
-			}
-
-			resourceOut = bundleResourceInfo;
-		}
-		else if( resourceType == BundleResourceInfo::TypeId() )
-		{
-			ResourceInfo* binaryResourceInfo = new ResourceInfo( {} );
-
-			Result setParametersFromResourceResult = binaryResourceInfo->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
-
-            if( setParametersFromResourceResult.type != ResultType::SUCCESS )
-			{
-				return setParametersFromResourceResult;
-			}
-
-			resourceOut = binaryResourceInfo;
-		}
-
-        return Result{ ResultType::SUCCESS };
-
-    }
-
-	Result ResourceGroup::ResourceGroupImpl::CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut )
-	{
-		std::unique_ptr<ResourceInfo> resourceInfo;
-      
-		Result createResourceInfoResult = CreateResourceInfoFromYamlNode( resource, resourceInfo, m_versionParameter.GetValue() );
-
-        if( createResourceInfoResult.type != ResultType::SUCCESS )
-		{
-
-			return createResourceInfoResult;
-		}
-        else
-        {
-			resourceOut = resourceInfo.release();
-
-			return Result{ ResultType::SUCCESS };
-        }
-
-	}
-
-    Result ResourceGroup::ResourceGroupImpl::ImportFromYamlString( const std::string& data, StatusCallback statusCallback /* = nullptr */ )
-    {
-	    YAML::Node resourceGroupFile;
-    	try
-    	{
-    		resourceGroupFile = YAML::Load( data );
-    	}
-    	catch( YAML::ParserException& )
-    	{
-    		return Result{ ResultType::FAILED_TO_PARSE_YAML };
-    	}
-    	return ImportFromYaml( resourceGroupFile, statusCallback );
-    }
-
-	Result ResourceGroup::ResourceGroupImpl::ImportFromYaml( YAML::Node& resourceGroupFile, StatusCallback statusCallback )
-	{
-		YAML::Node typeNode = resourceGroupFile[m_type.GetTag()];
-		if( !typeNode.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-		}
-		m_type = typeNode.as<std::string>();
-		if( m_type.GetValue() != GetType() )
-		{
-			return Result{ ResultType::FILE_TYPE_MISMATCH };
-		}
-
-    	YAML::Node resourceGroupVersionNode = resourceGroupFile[m_versionParameter.GetTag()];
-    	if( !resourceGroupVersionNode.IsDefined() )
-    	{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-    	}
-        std::string versionStr = resourceGroupVersionNode.as<std::string>(); //version stringID needs to be in one place
-		
-        VersionInternal version;
-		version.FromString( versionStr );
-        m_versionParameter = version;
-
-		if( m_versionParameter.GetValue().getMajor() > S_DOCUMENT_VERSION.major )
-        {
-			return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
-        }
-
-        // If version is greater than the max version supported at compile then ceil to that
-        if (version > S_DOCUMENT_VERSION)
-        {
-			if( statusCallback )
-            {
-				statusCallback( StatusLevel::OVERVIEW, StatusProgressType::WARNING, 0, "Supplied resource group version greater than resources build max version. Some data may be lost during import." );
-            }
-			version = S_DOCUMENT_VERSION;
-        }
-
-		YAML::Node numberOfResourcesNode = resourceGroupFile[m_numberOfResources.GetTag()];
-		if( !numberOfResourcesNode.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-		}
-
-		YAML::Node totalResourceSizeCompressedNode = resourceGroupFile[m_totalResourcesSizeCompressed.GetTag()];
-		if( !totalResourceSizeCompressedNode.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-		}
-
-    	YAML::Node totalResourceSizeUncompressedNode = resourceGroupFile[m_totalResourcesSizeUncompressed.GetTag()];
-		if( !totalResourceSizeUncompressedNode.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-		}
-
-        Result res = ImportGroupSpecialisedYaml( resourceGroupFile );
-
-        if( res.type != ResultType::SUCCESS )
-		{
-			return res;
-		}
-
-        YAML::Node resources = resourceGroupFile[m_resourcesParameter.GetTag()];
-    	if( !resources.IsDefined() )
-    	{
-			return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
-    	}
-
-        for (auto iter = resources.begin(); iter != resources.end(); iter++)
-        {
-            // This bit is a sequence
-			YAML::Node resourceNode = (*iter);
-            
-            ResourceInfo* resource = nullptr;
-
-            Result createResourceFromYamlResult = CreateResourceFromYaml( resourceNode, resource );
-
-            if (createResourceFromYamlResult.type != ResultType::SUCCESS)
-            {
-				return createResourceFromYamlResult;
-            }
-
-            Result addResourceResult = AddResource( resource );
-
-			if( addResourceResult.type != ResultType::SUCCESS )
-			{
-				return addResourceResult;
-			}
-
-        }
-
-		return Result{ ResultType::SUCCESS };
-    }
-
-    std::string ResourceGroup::ResourceGroupImpl::GetType() const
-	{
-		return TypeId();
-	}
-
-    std::string ResourceGroup::ResourceGroupImpl::TypeId() 
-    {
-		return "ResourceGroup";
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile )
-    {
-		return Result{ ResultType::SUCCESS };
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const
-    {
-		return Result{ ResultType::SUCCESS };
-    } 
-
-    Result ResourceGroup::ResourceGroupImpl::ExportYaml( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback /*= nullptr*/ ) const
-    {
-		
-        YAML::Emitter out;
-
-        // Output header information
-		out << YAML::BeginMap;
-
-        // It is possible to export a different version that the imported version
-        // The version must be less than the version of the document and also no higher than supported by the binary at compile
-		// Ensure document version is valid
-		if( !outputDocumentVersion.isVersionValid() )
-		{
-			return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
-		}
-
-		VersionInternal sanitisedOutputDocumentVersion = outputDocumentVersion;
-		const VersionInternal documentCurrentVersion = m_versionParameter.GetValue();
-
-        if( sanitisedOutputDocumentVersion > documentCurrentVersion )
-        {
-			sanitisedOutputDocumentVersion = documentCurrentVersion;
-        }
-
-        if (sanitisedOutputDocumentVersion > S_DOCUMENT_VERSION)
-        {
-			sanitisedOutputDocumentVersion = S_DOCUMENT_VERSION;
-        }
-
-        //Export document parameters
-	    out << YAML::Key << m_versionParameter.GetTag();
-		out << YAML::Value << sanitisedOutputDocumentVersion.ToString(); 
-
-        out << YAML::Key << m_type.GetTag();
-		out << YAML::Value << m_type.GetValue();
-
-        out << YAML::Key << m_numberOfResources.GetTag();
-		out << YAML::Value << m_numberOfResources.GetValue();
-
-        out << YAML::Key << m_totalResourcesSizeCompressed.GetTag();
-		out << YAML::Value << m_totalResourcesSizeCompressed.GetValue();
-
-        out << YAML::Key << m_totalResourcesSizeUncompressed.GetTag();
-		out << YAML::Value << m_totalResourcesSizeUncompressed.GetValue();
-
-        Result res = ExportGroupSpecialisedYaml( out, sanitisedOutputDocumentVersion );
-
-		if( res.type != ResultType::SUCCESS )
-        {
-			return res;
-        }
-
-        out << YAML::Key << m_resourcesParameter.GetTag();
-
-        out << YAML::Value << YAML::BeginSeq;
-
-        int i = 0;
-
-        for (ResourceInfo* r : m_resourcesParameter)
-        {
-			// Update status
-			if( statusCallback )
-			{
-				std::filesystem::path relativePath;
-
-				Result getRelativePathResult = r->GetRelativePath( relativePath );
-
-                if (getRelativePathResult.type != ResultType::SUCCESS)
-                {
-					return Result{ ResultType::FAIL };
-                }
-
-				auto percentage = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetValue()->size() );
-
-                std::string message = "Exporting: " + relativePath.string();
-
-				statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, message );
-
-				i++;
-			}
-
-			out << YAML::BeginMap;
-
-			Result resourceExportResult = r->ExportToYaml( out, sanitisedOutputDocumentVersion );
-
-            if( resourceExportResult.type != ResultType::SUCCESS )
-			{
-				return resourceExportResult;
-			}
-
-            out << YAML::EndMap;
-			
-        }
-
-        out << YAML::EndSeq;
-
-		out << YAML::EndMap;
-
-        data = out.c_str();
-
-        return Result{ ResultType::SUCCESS };
-      
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ExportCsv( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback /*= nullptr*/ ) const
-    {
-    	if( outputDocumentVersion.getMajor() > 0 || outputDocumentVersion.getMinor() > 0 || outputDocumentVersion.getPatch() > 0 )
-    	{
-    		return Result{ ResultType::UNSUPPORTED_FILE_FORMAT };
-    	}
-
-    	std::string out;
-
-
-    	auto resourceInfos = m_resourcesParameter.GetValue();
-    	std::sort(
-    		resourceInfos->begin(),
-    		resourceInfos->end(),
-    		[] (ResourceInfo* a, ResourceInfo* b) {
-    			std::filesystem::path ap;
-    			std::filesystem::path bp;
-    			a->GetRelativePath( ap );
-    			b->GetRelativePath( bp );
-    			return ap < bp;
-    		} );
-
-    	int i{0};
-		for (ResourceInfo* r : m_resourcesParameter)
-        {
-			// Update status
-			if( statusCallback )
-			{
-				auto percentage = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetValue()->size() );
-				statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, "Percentage Update" );
-				i++;
-			}
-
-			Result resourceExportResult = r->ExportToCsv( out, m_versionParameter.GetValue() );
-            if( resourceExportResult.type != ResultType::SUCCESS )
-			{
-				return resourceExportResult;
-			}
-			data += out + "\n";
-        }
-    	return Result{ ResultType::SUCCESS };
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::ProcessChunk( ResourceTools::GetChunk& chunkFile, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const
-    {
-		// Create resource from Patch Data
-		BundleResourceInfo* chunkResource = new BundleResourceInfo( { chunkRelativePath } );
-
-    	// md5 Checksum
-    	ResourceTools::Md5ChecksumStream checksumStream;
-
-    	std::string checksum;
-    	{
-    		std::string chunk;
-
-    		while( *chunkFile.uncompressedChunkIn >> chunk )
-    		{
-    			checksumStream << chunk;
-    		}
-    	}
-
-    	if( !checksumStream.FinishAndRetrieve( checksum ) )
-    	{
-    		return Result( { ResultType::FAILED_TO_GENERATE_CHECKSUM } );
-    	}
-
-    	chunkResource->SetDataChecksum( checksum );
-
-    	// Compressed Size
-    	chunkResource->SetCompressedSize( chunkFile.compressedChunkIn->Size() );
-
-    	// Uncompressed Size
-    	chunkResource->SetUncompressedSize( chunkFile.uncompressedChunkIn->Size() );
-
-		// Export chunk file
-    	std::filesystem::path sourceFile;
-
-    	if( chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
-    	{
-    		sourceFile = chunkFile.compressedChunkIn->GetPath();
-    	}
-    	else
-    	{
-    		sourceFile = chunkFile.uncompressedChunkIn->GetPath();
-    	}
-
-    	std::filesystem::path targetFile;
-
-    	if( chunkDestinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
-    	{
-    		std::filesystem::path relativePath;
-
-    		chunkResource->GetRelativePath( relativePath );
-
-    		targetFile = chunkDestinationSettings.basePath / relativePath;
-    	}
-    	else
-    	{
-    		std::string location;
-
-    		chunkResource->GetLocation( location );
-
-    		targetFile = chunkDestinationSettings.basePath / location;
-    	}
-
-    	if( std::filesystem::exists( targetFile ) )
-    	{
-    		std::filesystem::remove( targetFile );
-    	}
-
-		if( !std::filesystem::exists( targetFile.parent_path() ) )
-		{
-			std::filesystem::create_directories( targetFile.parent_path() );
-		}
-
-    	try
-    	{
-    		std::filesystem::copy_file( sourceFile, targetFile );
-    	}
-    	catch( std::filesystem::filesystem_error& e )
-    	{
-    		return Result( { ResultType::FAILED_TO_SAVE_FILE, e.what() } );
-    	}
-
-		// Add the chunk resource to the bundleResourceGroup
-		Result addResourceResult = bundleResourceGroup.AddResource( chunkResource );
+		Result addResourceResult = AddResource( resource );
 
 		if( addResourceResult.type != ResultType::SUCCESS )
 		{
-			delete chunkResource;
-
 			return addResourceResult;
 		}
 
-        return Result{ ResultType::SUCCESS };
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams& params ) const
-    {
-		// Update status
-		if( params.statusCallback )
+		if( statusCallback )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Creating Bundle" );
+			statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::UNBOUNDED, 0, "Imported resource: " + resourceParams.relativePath.string() );
 		}
-
-		uintmax_t numberOfChunks = 0;
-
-        std::string chunkBaseName = params.resourceGroupRelativePath.filename().replace_extension().string();
-
-		BundleResourceGroup::BundleResourceGroupImpl bundleResourceGroup;
-
-        Result setChunkSizeResult = bundleResourceGroup.SetChunkSize( params.chunkSize );
-
-        if (setChunkSizeResult.type != ResultType::SUCCESS)
-        {
-			return setChunkSizeResult;
-        }
-
-		ResourceTools::BundleStreamOut bundleStream( params.chunkSize, params.chunkDestinationSettings.basePath );
-
-
-        // Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 5, "Generating Chunks" );
-		}
-
-        int i = 0;
-
-		std::vector<ResourceInfo*> toBundle;
-
-		std::copy( m_resourcesParameter.begin(), m_resourcesParameter.end(), std::back_inserter( toBundle ) );
-
-		Result getGroupSpecificResourcesToBundleResult = GetGroupSpecificResourcesToBundle( toBundle );
-
-		if( getGroupSpecificResourcesToBundleResult.type != ResultType::SUCCESS )
-		{
-			return getGroupSpecificResourcesToBundleResult;
-		}
-
-        // Loop through all resources and send data for chunking
-		for ( ResourceInfo* resource : toBundle )
-        {
-			std::string location;
-
-			Result getLocationResult = resource->GetLocation( location );
-
-			if( getLocationResult.type != ResultType::SUCCESS )
-			{
-				return getLocationResult;
-			}
-
-			if( params.statusCallback )
-			{
-				std::filesystem::path relativePath;
-
-				Result getRelativePathResult = resource->GetRelativePath( relativePath );
-
-                if (getRelativePathResult.type != ResultType::SUCCESS)
-                {
-					return getRelativePathResult;
-                }
-
-				std::string message;
-
-				if( location.empty() )
-				{
-					message = "No file to process: " + relativePath.string();
-				}
-				else
-				{
-					message = "Processing: " + relativePath.string();
-				}
-
-				auto percentComplete = static_cast<unsigned int>( ( 100 * i ) / toBundle.size() );
-
-                i++;
-
-				params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
-			}
-			if( location.empty() )
-			{
-				continue;
-			}
-
-            auto resourceDataStream = std::make_shared<ResourceTools::FileDataStreamIn>( params.fileReadChunkSize );
-
-            ResourceGetDataStreamParams resourceGetDataParams;
-
-            resourceGetDataParams.resourceSourceSettings = params.resourceSourceSettings;
-
-            resourceGetDataParams.dataStream = resourceDataStream;
-
-        	resourceGetDataParams.downloadRetrySeconds = params.downloadRetrySeconds;
-
-			Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
-
-			bundleStream << resourceDataStream;
-
-            if (resourceGetDataResult.type != ResultType::SUCCESS)
-            {
-				return resourceGetDataResult;
-            }
-			
-            while (!resourceDataStream->IsFinished() )
-            {
-				std::string resourceDataChunk;
-
-                if (!(*resourceDataStream >> resourceDataChunk))
-                {
-					return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                }
-
-                // Loop through possible created chunks
-				ResourceTools::GetChunk chunkFile;
-
-				chunkFile.clearCache = false;
-
-            	bool bundleReadOk{true};
-
-                while( ( bundleReadOk = bundleStream >> chunkFile ) && !chunkFile.outOfChunks )
-				{
-					std::stringstream ss;
-					ss << chunkBaseName << numberOfChunks << ".chunk";
-					std::string chunkName = ss.str();
-
-					std::filesystem::path chunkPath = params.chunkDestinationSettings.basePath / ss.str();
-
-                    if( params.statusCallback )
-					{
-						std::stringstream ss;
-
-						ss << "Generating Chunk: " << chunkPath;
-
-						params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::UNBOUNDED, 0, ss.str() );
-					}
-
-					Result processChunkResult = ProcessChunk( chunkFile, chunkPath, bundleResourceGroup, params.chunkDestinationSettings );
-
-					if( processChunkResult.type != ResultType::SUCCESS )
-					{
-						return processChunkResult;
-					}
-
-					numberOfChunks++;
-				}
-            	if( !bundleReadOk )
-            	{
-            		return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
-            	}
-            }
-
-        }
-
-        
-		ResourceTools::GetChunk chunkFile;
-
-		chunkFile.clearCache = true;
-
-    	bundleStream.Flush();
-
-		if( !( bundleStream >> chunkFile ) )
-		{
-			return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
-		}
-
-		std::stringstream ss;
-		ss << chunkBaseName << numberOfChunks << ".chunk";
-		std::string chunkName = ss.str();
-
-		std::filesystem::path chunkPath = params.chunkDestinationSettings.basePath / ss.str();
-
-		Result processChunkResult = ProcessChunk( chunkFile, chunkPath, bundleResourceGroup, params.chunkDestinationSettings );
-
-		if( processChunkResult.type != ResultType::SUCCESS )
-		{
-			return processChunkResult;
-		}
-
-		// Export this resource list
-        // 
-		// Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 75, "Exporting ResourceGroups" );
-		}
-
-		std::string resourceGroupData;
-
-		Result exportToDataResult = ExportToData( resourceGroupData );
-
-        if (exportToDataResult.type != ResultType::SUCCESS)
-        {
-			return exportToDataResult;
-        }
-
-		ResourceGroupInfo resourceGroupInfo( { params.resourceGroupRelativePath } );
-
-		Result setParametersFromDataResult = resourceGroupInfo.SetParametersFromData( resourceGroupData );
-
-        if (setParametersFromDataResult.type != ResultType::SUCCESS)
-        {
-			return setParametersFromDataResult;
-        }
-
-		ResourcePutDataParams putDataParams;
-
-		putDataParams.resourceDestinationSettings = params.chunkDestinationSettings;
-
-		putDataParams.data = &resourceGroupData;
-
-		Result subtractionResourcePutResult = resourceGroupInfo.PutData( putDataParams );
-
-		if( subtractionResourcePutResult.type != ResultType::SUCCESS )
-		{
-			return subtractionResourcePutResult;
-		}
-
-		// Export the bundleGroup
-		Result setResourceGroupResult = bundleResourceGroup.SetResourceGroup( resourceGroupInfo );
-
-        if (setResourceGroupResult.type != ResultType::SUCCESS)
-        {
-			return setResourceGroupResult;
-        }
-
-		std::string patchResourceGroupData;
-
-		Result exportBundleResourceGroupToDataResult = bundleResourceGroup.ExportToData( patchResourceGroupData );
-
-        if (exportBundleResourceGroupToDataResult.type != ResultType::SUCCESS)
-        {
-			return exportBundleResourceGroupToDataResult;
-        }
-
-		BundleResourceGroupInfo patchResourceGroupInfo( { params.resourceGroupBundleRelativePath } );
-
-		Result setPatchParametersFromDataResult = patchResourceGroupInfo.SetParametersFromData( patchResourceGroupData );
-
-        if (setPatchParametersFromDataResult.type != ResultType::SUCCESS)
-        {
-			return setPatchParametersFromDataResult;
-        }
-
-		ResourcePutDataParams bundlePutDataParams;
-
-		bundlePutDataParams.resourceDestinationSettings = params.resourceBundleResourceGroupDestinationSettings;
-
-		bundlePutDataParams.data = &patchResourceGroupData;
-
-		Result patchResourceGroupPutResult = patchResourceGroupInfo.PutData( bundlePutDataParams );
-
-		if( patchResourceGroupPutResult.type != ResultType::SUCCESS )
-		{
-			return patchResourceGroupPutResult;
-		}
-
-        // Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Bundle Creation Complete." );
-		}
-
-        return Result{ ResultType::SUCCESS };
-    }
-
-	Result ResourceGroup::ResourceGroupImpl::ConstructPatchResourceInfo( const PatchCreateParams& params, int patchId, uintmax_t dataOffset, uint64_t patchSourceOffset, ResourceInfo* resourceNext, PatchResourceInfo*& patchResource ) const
-	{
-    	// Create a resource from patch data
-    	std::filesystem::path resourceLatestRelativePath;
-    	Result getResourceLatestRelativePathResult = resourceNext->GetRelativePath( resourceLatestRelativePath );
-    	if( getResourceLatestRelativePathResult.type != ResultType::SUCCESS )
-    	{
-    		return getResourceLatestRelativePathResult;
-    	}
-
-		PatchResourceInfoParams patchResourceInfoParams;
-		std::string patchFilename = params.patchFileRelativePathPrefix.string() + "." + std::to_string( patchId );
-		patchResourceInfoParams.relativePath = patchFilename;
-		patchResourceInfoParams.targetResourceRelativePath = resourceLatestRelativePath;
-		patchResourceInfoParams.dataOffset = dataOffset;
-		patchResourceInfoParams.sourceOffset = patchSourceOffset;
-		patchResource = new PatchResourceInfo( patchResourceInfoParams );
-
-    	return Result{ ResultType::SUCCESS };
 	}
 
-	Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& params ) const
-    {
-        // Update status
-		if( params.statusCallback )
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::CreateResourceFromResource( const ResourceInfo& resourceIn, ResourceInfo*& resourceOut ) const
+{
+	resourceOut = nullptr;
+
+	std::string resourceType = "";
+
+	Result getResourceTypeResult = resourceIn.GetType( resourceType );
+
+	if( getResourceTypeResult.type != ResultType::SUCCESS )
+	{
+		return getResourceTypeResult;
+	}
+
+	if( resourceType == ResourceInfo::TypeId() )
+	{
+		resourceOut = new ResourceInfo( {} );
+
+		Result setParametersFromResourceResult = resourceOut->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
+
+		if( setParametersFromResourceResult.type != ResultType::SUCCESS )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Creating Patch" );
+			return setParametersFromResourceResult;
+		}
+	}
+	else if( resourceType == PatchResourceInfo::TypeId() )
+	{
+		PatchResourceInfo* patchResourceInfo = new PatchResourceInfo( {} );
+
+		Result setParametersFromResourceResult = patchResourceInfo->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
+
+		if( setParametersFromResourceResult.type != ResultType::SUCCESS )
+		{
+			return setParametersFromResourceResult;
 		}
 
-        std::string previousGroupType = params.previousResourceGroup->m_impl->GetType();
+		resourceOut = patchResourceInfo;
+	}
+	else if( resourceType == BundleResourceInfo::TypeId() )
+	{
+		BundleResourceInfo* bundleResourceInfo = new BundleResourceInfo( {} );
 
-        std::string nextGroupType = GetType();
+		Result setParametersFromResourceResult = bundleResourceInfo->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
 
-        if (params.previousResourceGroup->m_impl->GetType() != GetType())
-        {
-			return Result{ ResultType::PATCH_RESOURCE_LIST_MISSMATCH };
-        }
-
-        PatchResourceGroup::PatchResourceGroupImpl patchResourceGroup;
-
-        Result setMaxInputChunkSizeResult = patchResourceGroup.SetMaxInputChunkSize( params.maxInputFileChunkSize );
-
-        if (setMaxInputChunkSizeResult.type != ResultType::SUCCESS)
-        {
-			return setMaxInputChunkSizeResult;
-        }
-        
-        // Created resource groups
-
-        std::shared_ptr<ResourceGroupImpl> resourceGroupSubtractionPrevious;
-
-		Result createPreviousResourceGroupResult = CreateResourceGroupFromString( previousGroupType, resourceGroupSubtractionPrevious );
-
-        if (createPreviousResourceGroupResult.type != ResultType::SUCCESS)
-        {
-			return createPreviousResourceGroupResult;
-        }
-
-        std::shared_ptr<ResourceGroupImpl> resourceGroupSubtractionNext;
-
-		Result createNextResourceGroupResult = CreateResourceGroupFromString( nextGroupType, resourceGroupSubtractionNext );
-
-		if( createNextResourceGroupResult.type != ResultType::SUCCESS )
+		if( setParametersFromResourceResult.type != ResultType::SUCCESS )
 		{
-			return createNextResourceGroupResult;
+			return setParametersFromResourceResult;
 		}
 
+		resourceOut = bundleResourceInfo;
+	}
+	else if( resourceType == BundleResourceInfo::TypeId() )
+	{
+		ResourceInfo* binaryResourceInfo = new ResourceInfo( {} );
 
-        ResourceGroupSubtractionParams resourceGroupSubtractionParams;
+		Result setParametersFromResourceResult = binaryResourceInfo->SetParametersFromResource( &resourceIn, m_versionParameter.GetValue() );
 
-		resourceGroupSubtractionParams.subtractResourceGroup = params.previousResourceGroup->m_impl;
-
-		resourceGroupSubtractionParams.result1 = resourceGroupSubtractionPrevious.get();
-
-        resourceGroupSubtractionParams.result2 = resourceGroupSubtractionNext.get();
-
-        resourceGroupSubtractionParams.statusCallback = params.statusCallback;
-
-        // Update status
-		if( params.statusCallback )
+		if( setParametersFromResourceResult.type != ResultType::SUCCESS )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 20, "Calculaing resourceGroups delta." );
+			return setParametersFromResourceResult;
 		}
 
-        Result subtractionResult = Diff( resourceGroupSubtractionParams );
+		resourceOut = binaryResourceInfo;
+	}
 
-        if (subtractionResult.type != ResultType::SUCCESS)
-        {
-			return subtractionResult;
-        }
+	return Result{ ResultType::SUCCESS };
+}
 
-        // Ensure that the diff results have the same number of members
-        if (resourceGroupSubtractionPrevious->m_resourcesParameter.GetSize() != resourceGroupSubtractionNext->m_resourcesParameter.GetSize())
-        {
-			return Result{ ResultType::UNEXPECTED_PATCH_DIFF_ENCOUNTERED };
-        }
+Result ResourceGroup::ResourceGroupImpl::CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut )
+{
+	std::unique_ptr<ResourceInfo> resourceInfo;
 
-        int patchId = 0;
+	Result createResourceInfoResult = CreateResourceInfoFromYamlNode( resource, resourceInfo, m_versionParameter.GetValue() );
 
-        // Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 40, "Generating Patches" );
-		}
+	if( createResourceInfoResult.type != ResultType::SUCCESS )
+	{
 
-        for (int i = 0; i < resourceGroupSubtractionNext->m_resourcesParameter.GetSize(); i++)
-        {
-			
-			ResourceInfo* resourcePrevious = resourceGroupSubtractionPrevious->m_resourcesParameter.At( i );
-
-			ResourceInfo* resourceNext = resourceGroupSubtractionNext->m_resourcesParameter.At( i );
-
-            if( params.statusCallback )
-			{
-				auto percentageComplete = static_cast<unsigned int>( ( 100 * i ) / resourceGroupSubtractionNext->m_resourcesParameter.GetSize() );
-
-                std::filesystem::path relativePath;
-
-                Result getRelativePathResult = resourcePrevious->GetRelativePath( relativePath );
-
-                if (getRelativePathResult.type != ResultType::SUCCESS)
-                {
-					return getRelativePathResult;
-                }
-
-                std::string message = "Creating patch for: " + relativePath.string();
-
-				params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentageComplete, message );
-			}
-
-        	size_t patchSourceOffset{0};
-        	uint64_t patchSourceOffsetDelta{0};
-
-            // Check to see if previous entry contains dummy information
-            // Suggesting that this is a new entry in latest
-            // In which case there is no reason to create a patch
-            // The new entry will be stored with the ResourceGroup related to the PatchResourceGroup
-			uintmax_t previousUncompressedSize;
-
-            Result getResourcePreviousCompressedSizeResult = resourcePrevious->GetUncompressedSize( previousUncompressedSize );
-
-            if (getResourcePreviousCompressedSizeResult.type != ResultType::SUCCESS)
-            {
-				return getResourcePreviousCompressedSizeResult;
-            }
-
-
-
-            uintmax_t nextUncompressedSize;
-
-			Result getResourceNextCompressedSizeResult = resourceNext->GetUncompressedSize( nextUncompressedSize );
-
-			if( getResourceNextCompressedSizeResult.type != ResultType::SUCCESS )
-			{
-				return getResourceNextCompressedSizeResult;
-			}
-
-
-            // If previous size is 0 this suggests that this is a new entry in latest
-			// In which case there is no reason to create a patch
-            if( previousUncompressedSize != 0 )
-            {
-				// Get resource data previous
-            	auto previousFileDataStream = std::make_shared<ResourceTools::FileDataStreamIn>( params.maxInputFileChunkSize );
-
-				ResourceGetDataStreamParams previousResourceGetDataStreamParams;
-
-				previousResourceGetDataStreamParams.resourceSourceSettings = params.resourceSourceSettingsPrevious;
-
-            	previousResourceGetDataStreamParams.downloadRetrySeconds = params.downloadRetrySeconds;
-
-				previousResourceGetDataStreamParams.dataStream = previousFileDataStream;
-
-                Result getPreviousDataStreamResult = resourcePrevious->GetDataStream( previousResourceGetDataStreamParams );
-
-                if (getPreviousDataStreamResult.type != ResultType::SUCCESS)
-                {
-					return getPreviousDataStreamResult;
-                }
-
-                // Get resource data next
-				auto nextFileDataStream = std::make_shared<ResourceTools::FileDataStreamIn>( params.maxInputFileChunkSize );
-
-				ResourceGetDataStreamParams nextResourceGetDataStreamParams;
-
-				nextResourceGetDataStreamParams.resourceSourceSettings = params.resourceSourceSettingsNext;
-
-				nextResourceGetDataStreamParams.dataStream = nextFileDataStream;
-
-                Result getNextDataStreamResult = resourceNext->GetDataStream( nextResourceGetDataStreamParams );
-
-				if( getNextDataStreamResult.type != ResultType::SUCCESS )
-				{
-					return getNextDataStreamResult;
-				}
-
-            	std::filesystem::path relativePath;
-				Result getRelativePathResult = resourcePrevious->GetRelativePath( relativePath );
-				if (getRelativePathResult.type != ResultType::SUCCESS)
-				{
-					return getRelativePathResult;
-            	}
-
-            	std::function<void(unsigned int, const std::string&)> callback = [params](unsigned int percent, const std::string& msg) {
-            	if( params.statusCallback )
-            		{
-            			params.statusCallback( StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, percent, msg );
-            		}
-            	};
-        		ResourceTools::ChunkIndex index(previousFileDataStream->GetPath(), params.maxInputFileChunkSize, params.indexFolder, callback );
-        		if( params.statusCallback )
-        		{
-        			std::string message = "Generating index for " + relativePath.string();
-        			params.statusCallback( StatusLevel::DETAIL , StatusProgressType::PERCENTAGE, 0, message );
-        		}
-            	index.GenerateChecksumFilter( nextFileDataStream->GetPath() );
-        		if( !index.Generate() )
-        		{
-					std::string message = "Index generation failed for " + relativePath.string();
-					params.statusCallback(StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, 0, message);
-        		}
-
-                // Process one chunk at a time
-				for( uintmax_t dataOffset = 0; dataOffset < nextUncompressedSize; dataOffset += params.maxInputFileChunkSize )
-                {
-					std::string previousFileData = "";
-
-					if( previousFileDataStream->IsFinished() )
-					{
-						if( previousFileDataStream->Size() > nextFileDataStream->GetCurrentPosition() )
-						{
-							// We ran out of data because we found a chunk match later in the file,
-							// but we can rewind back to where the read stream is in hopes
-							// of getting a good diff, rather than just treating it as new data.
-							previousFileDataStream->StartRead( previousFileDataStream->GetPath() );
-						}
-					}
-
-                    // Handling if previous file is smaller than next file
-                    // If so then previousFileData will be nothing and
-                    // All next data will be used for the patch
-                    if (!previousFileDataStream->IsFinished())
-                    {
-						if( !( *previousFileDataStream >> previousFileData ) )
-						{
-							return Result{ ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA };
-						}
-                    }
-
-					size_t nextStreamPosition = nextFileDataStream->GetCurrentPosition();
-                    // Note: in the case that the next file is smaller than previous
-                    // nothing is stored, application of the patch will chop off the extra file data
-                    std::string nextFileData;
-
-					if(!nextFileDataStream->IsFinished())
-					{
-						if(!(*nextFileDataStream >> nextFileData))
-						{
-							return Result{ ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA };
-						}
-					}
-
-                    // Create a patch
-					// Create a patch from the data
-					std::string patchData;
-
-					bool chunkMatchFound{false};
-					size_t matchCount{0};
-
-
-                    if (previousFileData != "")
-					{
-                    	// Here's how this should work:
-                    	// We find a matching chunk if it exists. If the chunk exists we make a patch with no data, because we'll get
-                    	// the data from the source file using the patch info. Consecutive patches should be collapsed into one big one.
-                    	// If we can't find a matching chunk, we will base the current diff off the chunk in the source starting after the final byte
-                    	// in the chunk from the source file that we last used.
-                    	// These should keep our patches pretty minimal, even if lots of data gets added early in the file causing offsets.
-                    	// It should also handle small changes in moved parts of the file pretty well.
-                    	if( params.statusCallback )
-                    	{
-                    		unsigned int progress = static_cast<uint32_t>( ( dataOffset * 100 ) / nextUncompressedSize );
-                    		std::stringstream ss;
-                    		ss << "Generating patch files: " << relativePath.string();
-                    		params.statusCallback( StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, progress, ss.str() );
-                    	}
-
-                    	chunkMatchFound = index.FindMatchingChunk( nextFileData, patchSourceOffset );
-
-                    	if( chunkMatchFound )
-                    	{
-                    		matchCount = 1;
-                    		matchCount += ResourceTools::CountMatchingChunks(
-                    			nextFileDataStream->GetPath(),
-                    			nextFileDataStream->GetCurrentPosition(),
-                    			previousFileDataStream->GetPath(),
-                    			patchSourceOffset + params.maxInputFileChunkSize,
-                    			params.maxInputFileChunkSize );
-
-                    		size_t matchSize = std::min(params.maxInputFileChunkSize * matchCount, previousFileDataStream->Size() - patchSourceOffset);
-
-                    		PatchResourceInfo* patchResource{nullptr};
-
-                    		ConstructPatchResourceInfo( params, patchId, dataOffset, patchSourceOffset, resourceNext, patchResource );
-
-                    		if( previousFileDataStream->IsFinished() )
-                    		{
-                    			previousFileDataStream->StartRead( previousFileDataStream->GetPath() );
-                    		}
-
-                    		previousFileDataStream->Seek( patchSourceOffset );
-
-                    		patchResource->SetParametersFromSourceStream( *previousFileDataStream, matchSize );
-
-                    		// Advance the first stream by the size of the matching data,
-                    		// but move the point we generate patches from for the previous
-                    		// file data stream to the end of the match.
-                    		// It's hard to tell if it would be smarter to simply advance
-                    		// the destination data by the same amount of the source data,
-                    		// or perhaps even not to move it at all.
-                    		nextFileDataStream->Seek( std::min( nextFileDataStream->Size(), nextStreamPosition + matchSize ) );
-
-                    		previousFileDataStream->Seek( std::min(previousFileDataStream->Size(), patchSourceOffset + matchSize ) );
-
-                    		dataOffset += matchSize - params.maxInputFileChunkSize;
-
-                    		patchSourceOffset += matchSize;
-
-                    		if( nextStreamPosition == 0 && patchSourceOffset == 0 )
-                    		{
-                    			// This is the beginning of the file and it matches.
-                    			// There is no need to write patch data.
-                    			continue;
-                    		}
-
-                    		// Add the patch resource to the patchResourceGroup
-                    		Result addResourceResult = patchResourceGroup.AddResource( patchResource );
-
-                    		if( addResourceResult.type != ResultType::SUCCESS )
-                    		{
-                    			delete patchResource;
-
-                    			return addResourceResult;
-                    		}
-
-                    		patchId++;
-
-                    		continue;
-                    	}
-						else
-						{
-							// Previous and next data chunk are different, create a patch
-							if( !ResourceTools::CreatePatch( previousFileData, nextFileData, patchData ) )
-							{
-								return Result{ ResultType::FAILED_TO_CREATE_PATCH };
-							}
-							patchSourceOffsetDelta = previousFileData.size();
-						}
-                    }
-                    else
-                    {
-                        // If there is no previous data then just store the data straight from the file
-                        // All this data is new
-                    	if( !ResourceTools::CreatePatch( "", nextFileData, patchData ) )
-                    	{
-							return Result{ ResultType::FAILED_TO_CREATE_PATCH };
-                    	}
-                    	patchSourceOffsetDelta = nextFileData.size();
-                    }
-
-					PatchResourceInfo* patchResource{nullptr};
-					ConstructPatchResourceInfo( params, patchId, dataOffset, patchSourceOffset, resourceNext, patchResource );
-					patchSourceOffset += patchSourceOffsetDelta;
-					if( !patchData.empty() )
-					{
-						Result setParametersFromDataResult = patchResource->SetParametersFromData( patchData );
-
-						if( setParametersFromDataResult.type != ResultType::SUCCESS )
-						{
-							return setParametersFromDataResult;
-						}
-
-						// Export patch file
-						ResourcePutDataParams resourcePutDataParams;
-
-						resourcePutDataParams.resourceDestinationSettings = params.resourcePatchBinaryDestinationSettings;
-
-						resourcePutDataParams.data = &patchData;
-
-						Result putPatchDataResult = patchResource->PutData( resourcePutDataParams );
-
-						if( putPatchDataResult.type != ResultType::SUCCESS )
-						{
-							delete patchResource;
-
-							return putPatchDataResult;
-						}
-					}
-
-					// Add the patch resource to the patchResourceGroup
-					Result addResourceResult = patchResourceGroup.AddResource( patchResource );
-
-					if( addResourceResult.type != ResultType::SUCCESS )
-					{
-						delete patchResource;
-
-						return addResourceResult;
-					}
-
-                    patchId++;
-
-
-                }
-
-            }
-
-        }
-
-    	patchResourceGroup.SetRemovedResourceRelativePaths( resourceGroupSubtractionParams.removedResources );
-
-        // Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 60, "Exporting ResourceGroups." );
-		}
-
-        // Export the subtraction ResourceGroup
-        std::string resourceGroupData;
-
-        Result exportResourceGroupSubtractionLatestResult = resourceGroupSubtractionNext->ExportToData( resourceGroupData );
-
-        if (exportResourceGroupSubtractionLatestResult.type != ResultType::SUCCESS)
-        {
-			return exportResourceGroupSubtractionLatestResult;
-        }
-
-		ResourceGroupInfo subtractionResourceGroupInfo( { params.resourceGroupRelativePath } );
-
-        Result setParametersFromDataResult = subtractionResourceGroupInfo.SetParametersFromData( resourceGroupData );
-
-        if (setParametersFromDataResult.type != ResultType::SUCCESS)
-        {
-			return setParametersFromDataResult;
-        }
-
-        ResourcePutDataParams putDataParams;
-
-        putDataParams.resourceDestinationSettings = params.resourcePatchBinaryDestinationSettings;
-
-        putDataParams.data = &resourceGroupData; 
-
-        Result subtractionResourcePutResult = subtractionResourceGroupInfo.PutData( putDataParams );
-
-        if (subtractionResourcePutResult.type != ResultType::SUCCESS)
-        {
-			return subtractionResourcePutResult;
-        }
-
-      
-
-        // Export the patchGroup
-		Result setResourceGroupResult = patchResourceGroup.SetResourceGroup( subtractionResourceGroupInfo );
-
-        if (setResourceGroupResult.type != ResultType::SUCCESS)
-        {
-			return setResourceGroupResult;
-        }
-
-        std::string patchResourceGroupData;
-
-        Result exportToDataResult = patchResourceGroup.ExportToData( patchResourceGroupData );
-
-        if (exportToDataResult.type != ResultType::SUCCESS)
-        {
-			return exportToDataResult;
-        }
-
-		PatchResourceGroupInfo patchResourceGroupInfo( { params.resourceGroupPatchRelativePath } );
-
-        Result setPatchParametersFromDataResult = patchResourceGroupInfo.SetParametersFromData( patchResourceGroupData );
-
-        if (setPatchParametersFromDataResult.type != ResultType::SUCCESS)
-        {
-			return setPatchParametersFromDataResult;
-        }
-
-        ResourcePutDataParams patchPutDataParams;
-
-		patchPutDataParams.resourceDestinationSettings = params.resourcePatchResourceGroupDestinationSettings;
-
-		patchPutDataParams.data = &patchResourceGroupData;
-
-		Result patchResourceGroupPutResult = patchResourceGroupInfo.PutData( patchPutDataParams );
-
-        if( patchResourceGroupPutResult.type != ResultType::SUCCESS )
-		{
-			return patchResourceGroupPutResult;
-		}
-
-        // Update status
-		if( params.statusCallback )
-		{
-			params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Patch Created" );
-		}
-
-        return Result{ ResultType::SUCCESS };
-    }
-
-
-    Result ResourceGroup::ResourceGroupImpl::AddResource( ResourceInfo* resource )
-    {
-		m_resourcesParameter.PushBack( resource );
-
-        m_numberOfResources = m_numberOfResources.GetValue() + 1;
-
-        uintmax_t resourceUncompressedSize;
-            
-        Result resourceGetUncompressedSizeResult = resource->GetUncompressedSize( resourceUncompressedSize );
-
-        if( resourceGetUncompressedSizeResult.type != ResultType::SUCCESS )
-        {
-			return resourceGetUncompressedSizeResult;
-        }
-
-        m_totalResourcesSizeUncompressed = m_totalResourcesSizeUncompressed.GetValue() + resourceUncompressedSize;
-
-        uintmax_t resourceCompressedSize;
-
-		Result resourceGetCompressedSizeResult = resource->GetCompressedSize( resourceCompressedSize );
-
-		if( resourceGetCompressedSizeResult.type != ResultType::SUCCESS )
-		{
-			return resourceGetCompressedSizeResult;
-		}
-
-		m_totalResourcesSizeCompressed = m_totalResourcesSizeCompressed.GetValue() + resourceCompressedSize;
+		return createResourceInfoResult;
+	}
+	else
+	{
+		resourceOut = resourceInfo.release();
 
 		return Result{ ResultType::SUCCESS };
-    }
+	}
+}
 
-    Result ResourceGroup::ResourceGroupImpl::RemoveResources( const ResourceGroupRemoveResourcesParams& params )
-    {
-        if (!params.resourcesToRemove)
-        {
-			return Result{ ResultType::RESOURCE_LIST_NOT_SET };
-        }
+Result ResourceGroup::ResourceGroupImpl::ImportFromYamlString( const std::string& data, StatusCallback statusCallback /* = nullptr */ )
+{
+	YAML::Node resourceGroupFile;
+	try
+	{
+		resourceGroupFile = YAML::Load( data );
+	}
+	catch( YAML::ParserException& )
+	{
+		return Result{ ResultType::FAILED_TO_PARSE_YAML };
+	}
+	return ImportFromYaml( resourceGroupFile, statusCallback );
+}
 
-        for (std::filesystem::path& relativePath : *params.resourcesToRemove)
-        {
-            // Construct a ResourceInfo from relativePath
-			ResourceInfoParams resourceInfoParams;
+Result ResourceGroup::ResourceGroupImpl::ImportFromYaml( YAML::Node& resourceGroupFile, StatusCallback statusCallback )
+{
+	YAML::Node typeNode = resourceGroupFile[m_type.GetTag()];
+	if( !typeNode.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+	}
+	m_type = typeNode.as<std::string>();
+	if( m_type.GetValue() != GetType() )
+	{
+		return Result{ ResultType::FILE_TYPE_MISMATCH };
+	}
 
-			resourceInfoParams.relativePath = relativePath;
+	YAML::Node resourceGroupVersionNode = resourceGroupFile[m_versionParameter.GetTag()];
+	if( !resourceGroupVersionNode.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+	}
+	std::string versionStr = resourceGroupVersionNode.as<std::string>(); //version stringID needs to be in one place
 
-			ResourceInfo resource( resourceInfoParams );
+	VersionInternal version;
+	version.FromString( versionStr );
+	m_versionParameter = version;
 
-			Result removeResourceResult = RemoveResource( resource );
+	if( m_versionParameter.GetValue().getMajor() > S_DOCUMENT_VERSION.major )
+	{
+		return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
+	}
 
-            if (removeResourceResult.type != ResultType::SUCCESS)
-            {
-                if (removeResourceResult.type != ResultType::RESOURCE_NOT_FOUND)
-                {
-					return removeResourceResult;
-                }
-                else
-                {
-                    if (params.errorIfResourceNotFound == true)
-                    {
-						return removeResourceResult;
-                    }
-                }
-            }
-        }
-
-        return Result{ ResultType::SUCCESS };
-    }
-
-    Result ResourceGroup::ResourceGroupImpl::RemoveResource( ResourceInfo& resource )
-    {
-	
-		auto iter = m_resourcesParameter.Find( &resource );
-
-        if (iter == m_resourcesParameter.end())
-        {
-			return Result{ ResultType::RESOURCE_NOT_FOUND };
-        }
-
-        ResourceInfo* foundResource = *iter;
-
-        // Update counters
-        m_numberOfResources = m_numberOfResources.GetValue() - 1;
-
-		uintmax_t resourceUncompressedSize;
-
-		Result resourceGetUncompressedSizeResult = foundResource->GetUncompressedSize( resourceUncompressedSize );
-
-		if( resourceGetUncompressedSizeResult.type != ResultType::SUCCESS )
+	// If version is greater than the max version supported at compile then ceil to that
+	if( version > S_DOCUMENT_VERSION )
+	{
+		if( statusCallback )
 		{
-			return resourceGetUncompressedSizeResult;
+			statusCallback( StatusLevel::OVERVIEW, StatusProgressType::WARNING, 0, "Supplied resource group version greater than resources build max version. Some data may be lost during import." );
+		}
+		version = S_DOCUMENT_VERSION;
+	}
+
+	YAML::Node numberOfResourcesNode = resourceGroupFile[m_numberOfResources.GetTag()];
+	if( !numberOfResourcesNode.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+	}
+
+	YAML::Node totalResourceSizeCompressedNode = resourceGroupFile[m_totalResourcesSizeCompressed.GetTag()];
+	if( !totalResourceSizeCompressedNode.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+	}
+
+	YAML::Node totalResourceSizeUncompressedNode = resourceGroupFile[m_totalResourcesSizeUncompressed.GetTag()];
+	if( !totalResourceSizeUncompressedNode.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+	}
+
+	Result res = ImportGroupSpecialisedYaml( resourceGroupFile );
+
+	if( res.type != ResultType::SUCCESS )
+	{
+		return res;
+	}
+
+	YAML::Node resources = resourceGroupFile[m_resourcesParameter.GetTag()];
+	if( !resources.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_GROUP };
+	}
+
+	for( auto iter = resources.begin(); iter != resources.end(); iter++ )
+	{
+		// This bit is a sequence
+		YAML::Node resourceNode = ( *iter );
+
+		ResourceInfo* resource = nullptr;
+
+		Result createResourceFromYamlResult = CreateResourceFromYaml( resourceNode, resource );
+
+		if( createResourceFromYamlResult.type != ResultType::SUCCESS )
+		{
+			return createResourceFromYamlResult;
 		}
 
-		uintmax_t resourceCompressedSize;
+		Result addResourceResult = AddResource( resource );
 
-		Result resourceGetCompressedSizeResult = foundResource->GetCompressedSize( resourceCompressedSize );
-
-		if( resourceGetCompressedSizeResult.type != ResultType::SUCCESS )
+		if( addResourceResult.type != ResultType::SUCCESS )
 		{
-			return resourceGetCompressedSizeResult;
+			return addResourceResult;
 		}
+	}
 
-        // Update sizes
-        m_totalResourcesSizeUncompressed = m_totalResourcesSizeUncompressed.GetValue() - resourceUncompressedSize;
+	return Result{ ResultType::SUCCESS };
+}
 
-		m_totalResourcesSizeCompressed = m_totalResourcesSizeCompressed.GetValue() - resourceCompressedSize;
+std::string ResourceGroup::ResourceGroupImpl::GetType() const
+{
+	return TypeId();
+}
 
-        // Remove from ResourceGroup
-        m_resourcesParameter.Remove( iter );
+std::string ResourceGroup::ResourceGroupImpl::TypeId()
+{
+	return "ResourceGroup";
+}
 
-        return Result{ ResultType::SUCCESS };
-    }
+Result ResourceGroup::ResourceGroupImpl::ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile )
+{
+	return Result{ ResultType::SUCCESS };
+}
 
-    Result ResourceGroup::ResourceGroupImpl::Merge( const ResourceGroupMergeParams& params )
-    {
-        if (params.mergedResourceGroup == nullptr)
-        {
-			return Result{ ResultType::RESOURCE_GROUP_NOT_SET };
-        }
+Result ResourceGroup::ResourceGroupImpl::ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const
+{
+	return Result{ ResultType::SUCCESS };
+}
 
-        if( params.resourceGroupToMerge == nullptr )
+Result ResourceGroup::ResourceGroupImpl::ExportYaml( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback /*= nullptr*/ ) const
+{
+
+	YAML::Emitter out;
+
+	// Output header information
+	out << YAML::BeginMap;
+
+	// It is possible to export a different version that the imported version
+	// The version must be less than the version of the document and also no higher than supported by the binary at compile
+	// Ensure document version is valid
+	if( !outputDocumentVersion.isVersionValid() )
+	{
+		return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
+	}
+
+	VersionInternal sanitisedOutputDocumentVersion = outputDocumentVersion;
+	const VersionInternal documentCurrentVersion = m_versionParameter.GetValue();
+
+	if( sanitisedOutputDocumentVersion > documentCurrentVersion )
+	{
+		sanitisedOutputDocumentVersion = documentCurrentVersion;
+	}
+
+	if( sanitisedOutputDocumentVersion > S_DOCUMENT_VERSION )
+	{
+		sanitisedOutputDocumentVersion = S_DOCUMENT_VERSION;
+	}
+
+	//Export document parameters
+	out << YAML::Key << m_versionParameter.GetTag();
+	out << YAML::Value << sanitisedOutputDocumentVersion.ToString();
+
+	out << YAML::Key << m_type.GetTag();
+	out << YAML::Value << m_type.GetValue();
+
+	out << YAML::Key << m_numberOfResources.GetTag();
+	out << YAML::Value << m_numberOfResources.GetValue();
+
+	out << YAML::Key << m_totalResourcesSizeCompressed.GetTag();
+	out << YAML::Value << m_totalResourcesSizeCompressed.GetValue();
+
+	out << YAML::Key << m_totalResourcesSizeUncompressed.GetTag();
+	out << YAML::Value << m_totalResourcesSizeUncompressed.GetValue();
+
+	Result res = ExportGroupSpecialisedYaml( out, sanitisedOutputDocumentVersion );
+
+	if( res.type != ResultType::SUCCESS )
+	{
+		return res;
+	}
+
+	out << YAML::Key << m_resourcesParameter.GetTag();
+
+	out << YAML::Value << YAML::BeginSeq;
+
+	int i = 0;
+
+	for( ResourceInfo* r : m_resourcesParameter )
+	{
+		// Update status
+		if( statusCallback )
 		{
-			return Result{ ResultType::RESOURCE_GROUP_NOT_SET };
-		}
+			std::filesystem::path relativePath;
 
-		DocumentParameterCollection<ResourceInfo*> mergeResources = params.resourceGroupToMerge->m_impl->m_resourcesParameter;
+			Result getRelativePathResult = r->GetRelativePath( relativePath );
 
-        std::vector<ResourceInfo*> sortedResourcesParameter( m_resourcesParameter.begin(), m_resourcesParameter.end() );
-		std::vector<ResourceInfo*> sortedMergeResources( mergeResources.begin(), mergeResources.end() );
-
-		std::sort( sortedResourcesParameter.begin(), sortedResourcesParameter.end(), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
-		std::sort( sortedMergeResources.begin(), sortedMergeResources.end(), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
-
-        std::vector<ResourceInfo*> unionResources;
-		std::set_union( 
-            sortedMergeResources.begin(), sortedMergeResources.end(), 
-            sortedResourcesParameter.begin(), sortedResourcesParameter.end(), 
-            std::back_inserter( unionResources ), 
-            []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
-
-        // Add result to merge ResourceGroup output
-        for (auto resource : unionResources)
-        {
-			ResourceInfo* resourceCopy = nullptr;
-
-			Result createResourceFromResourceResult = CreateResourceFromResource( *resource, resourceCopy );
-
-			if( createResourceFromResourceResult.type != ResultType::SUCCESS )
+			if( getRelativePathResult.type != ResultType::SUCCESS )
 			{
-				return createResourceFromResourceResult;
+				return Result{ ResultType::FAIL };
 			}
 
-			Result addResourceResult = params.mergedResourceGroup->m_impl->AddResource( resourceCopy );
+			auto percentage = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetValue()->size() );
 
-            if (addResourceResult.type != ResultType::SUCCESS)
-            {
-				return addResourceResult;
-            }
-        }
+			std::string message = "Exporting: " + relativePath.string();
 
-        return Result{ ResultType::SUCCESS };
-    }
+			statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, message );
 
-    Result ResourceGroup::ResourceGroupImpl::DiffChangesAsLists( const ResourceGroupDiffAgainstGroupParams& params ) const
-    {
-        if (!params.resourceGroupToDiffAgainst)
-        {
-			return Result{ ResultType::RESOURCE_GROUP_NOT_SET };
-        }
+			i++;
+		}
 
-        if ((!params.additions) || (!params.subtractions))
-        {
-			return Result{ ResultType::REQUIRED_INPUT_PARAMETER_NOT_SET };
-        }
+		out << YAML::BeginMap;
 
-		ResourceGroupSubtractionParams subtractionParams;
+		Result resourceExportResult = r->ExportToYaml( out, sanitisedOutputDocumentVersion );
 
-        ResourceGroup result1;
+		if( resourceExportResult.type != ResultType::SUCCESS )
+		{
+			return resourceExportResult;
+		}
 
-        ResourceGroup result2;
+		out << YAML::EndMap;
+	}
 
-        subtractionParams.subtractResourceGroup = params.resourceGroupToDiffAgainst->m_impl;
+	out << YAML::EndSeq;
 
-        subtractionParams.result1 = result1.m_impl;
+	out << YAML::EndMap;
 
-        subtractionParams.result2 = result2.m_impl;
+	data = out.c_str();
 
-        Result diffResult = Diff( subtractionParams );
+	return Result{ ResultType::SUCCESS };
+}
 
-        if (diffResult.type != ResultType::SUCCESS)
-        {
-			return diffResult;
-        }
+Result ResourceGroup::ResourceGroupImpl::ExportCsv( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback /*= nullptr*/ ) const
+{
+	if( outputDocumentVersion.getMajor() > 0 || outputDocumentVersion.getMinor() > 0 || outputDocumentVersion.getPatch() > 0 )
+	{
+		return Result{ ResultType::UNSUPPORTED_FILE_FORMAT };
+	}
 
-        for (auto removedResource : subtractionParams.removedResources)
-        {
-			params.subtractions->push_back( removedResource );
-        }
+	std::string out;
 
-        for (auto resource : result1.m_impl->m_resourcesParameter)
-        {
+
+	auto resourceInfos = m_resourcesParameter.GetValue();
+	std::sort(
+		resourceInfos->begin(),
+		resourceInfos->end(),
+		[]( ResourceInfo* a, ResourceInfo* b ) {
+			std::filesystem::path ap;
+			std::filesystem::path bp;
+			a->GetRelativePath( ap );
+			b->GetRelativePath( bp );
+			return ap < bp;
+		} );
+
+	int i{ 0 };
+	for( ResourceInfo* r : m_resourcesParameter )
+	{
+		// Update status
+		if( statusCallback )
+		{
+			auto percentage = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetValue()->size() );
+			statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentage, "Percentage Update" );
+			i++;
+		}
+
+		Result resourceExportResult = r->ExportToCsv( out, m_versionParameter.GetValue() );
+		if( resourceExportResult.type != ResultType::SUCCESS )
+		{
+			return resourceExportResult;
+		}
+		data += out + "\n";
+	}
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::ProcessChunk( ResourceTools::GetChunk& chunkFile, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const
+{
+	// Create resource from Patch Data
+	BundleResourceInfo* chunkResource = new BundleResourceInfo( { chunkRelativePath } );
+
+	// md5 Checksum
+	ResourceTools::Md5ChecksumStream checksumStream;
+
+	std::string checksum;
+	{
+		std::string chunk;
+
+		while( *chunkFile.uncompressedChunkIn >> chunk )
+		{
+			checksumStream << chunk;
+		}
+	}
+
+	if( !checksumStream.FinishAndRetrieve( checksum ) )
+	{
+		return Result( { ResultType::FAILED_TO_GENERATE_CHECKSUM } );
+	}
+
+	chunkResource->SetDataChecksum( checksum );
+
+	// Compressed Size
+	chunkResource->SetCompressedSize( chunkFile.compressedChunkIn->Size() );
+
+	// Uncompressed Size
+	chunkResource->SetUncompressedSize( chunkFile.uncompressedChunkIn->Size() );
+
+	// Export chunk file
+	std::filesystem::path sourceFile;
+
+	if( chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
+	{
+		sourceFile = chunkFile.compressedChunkIn->GetPath();
+	}
+	else
+	{
+		sourceFile = chunkFile.uncompressedChunkIn->GetPath();
+	}
+
+	std::filesystem::path targetFile;
+
+	if( chunkDestinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
+	{
+		std::filesystem::path relativePath;
+
+		chunkResource->GetRelativePath( relativePath );
+
+		targetFile = chunkDestinationSettings.basePath / relativePath;
+	}
+	else
+	{
+		std::string location;
+
+		chunkResource->GetLocation( location );
+
+		targetFile = chunkDestinationSettings.basePath / location;
+	}
+
+	if( std::filesystem::exists( targetFile ) )
+	{
+		std::filesystem::remove( targetFile );
+	}
+
+	if( !std::filesystem::exists( targetFile.parent_path() ) )
+	{
+		std::filesystem::create_directories( targetFile.parent_path() );
+	}
+
+	try
+	{
+		std::filesystem::copy_file( sourceFile, targetFile );
+	}
+	catch( std::filesystem::filesystem_error& e )
+	{
+		return Result( { ResultType::FAILED_TO_SAVE_FILE, e.what() } );
+	}
+
+	// Add the chunk resource to the bundleResourceGroup
+	Result addResourceResult = bundleResourceGroup.AddResource( chunkResource );
+
+	if( addResourceResult.type != ResultType::SUCCESS )
+	{
+		delete chunkResource;
+
+		return addResourceResult;
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams& params ) const
+{
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Creating Bundle" );
+	}
+
+	uintmax_t numberOfChunks = 0;
+
+	std::string chunkBaseName = params.resourceGroupRelativePath.filename().replace_extension().string();
+
+	BundleResourceGroup::BundleResourceGroupImpl bundleResourceGroup;
+
+	Result setChunkSizeResult = bundleResourceGroup.SetChunkSize( params.chunkSize );
+
+	if( setChunkSizeResult.type != ResultType::SUCCESS )
+	{
+		return setChunkSizeResult;
+	}
+
+	ResourceTools::BundleStreamOut bundleStream( params.chunkSize, params.chunkDestinationSettings.basePath );
+
+
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 5, "Generating Chunks" );
+	}
+
+	int i = 0;
+
+	std::vector<ResourceInfo*> toBundle;
+
+	std::copy( m_resourcesParameter.begin(), m_resourcesParameter.end(), std::back_inserter( toBundle ) );
+
+	Result getGroupSpecificResourcesToBundleResult = GetGroupSpecificResourcesToBundle( toBundle );
+
+	if( getGroupSpecificResourcesToBundleResult.type != ResultType::SUCCESS )
+	{
+		return getGroupSpecificResourcesToBundleResult;
+	}
+
+	// Loop through all resources and send data for chunking
+	for( ResourceInfo* resource : toBundle )
+	{
+		std::string location;
+
+		Result getLocationResult = resource->GetLocation( location );
+
+		if( getLocationResult.type != ResultType::SUCCESS )
+		{
+			return getLocationResult;
+		}
+
+		if( params.statusCallback )
+		{
 			std::filesystem::path relativePath;
 
 			Result getRelativePathResult = resource->GetRelativePath( relativePath );
@@ -1972,247 +1043,1147 @@ namespace CarbonResources
 				return getRelativePathResult;
 			}
 
-			params.additions->push_back( relativePath );
-        
-        }
+			std::string message;
 
-        return Result{ ResultType::SUCCESS };
+			if( location.empty() )
+			{
+				message = "No file to process: " + relativePath.string();
+			}
+			else
+			{
+				message = "Processing: " + relativePath.string();
+			}
 
-    }
+			auto percentComplete = static_cast<unsigned int>( ( 100 * i ) / toBundle.size() );
 
-    Result ResourceGroup::ResourceGroupImpl::Diff( ResourceGroupSubtractionParams& params ) const
-    {
-		if( params.statusCallback )
+			i++;
+
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
+		}
+		if( location.empty() )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Calculating diff between two resource groups." );
+			continue;
 		}
 
-		DocumentParameterCollection<ResourceInfo*> subtractionResources = params.subtractResourceGroup->m_resourcesParameter;
-        // Iterate through all resources
+		auto resourceDataStream = std::make_shared<ResourceTools::FileDataStreamIn>( params.fileReadChunkSize );
 
-        // Value only required for status updates
-		int i = 0;
-    	std::vector<ResourceInfo*> sortedResourcesParameter( m_resourcesParameter.begin(), m_resourcesParameter.end() );
-    	std::vector<ResourceInfo*> sortedSubtractionResources( subtractionResources.begin(), subtractionResources.end() );
-    	std::sort(sortedResourcesParameter.begin(), sortedResourcesParameter.end(), [](const ResourceInfo* a, const ResourceInfo* b){return *a < *b;});
-    	std::sort( sortedSubtractionResources.begin(), sortedSubtractionResources.end(), [](const ResourceInfo* a, const ResourceInfo* b){return *a < *b;});
+		ResourceGetDataStreamParams resourceGetDataParams;
 
-    	std::vector<ResourceInfo*> addedResources;
-    	std::set_difference(
-    		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
-    		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
-    		std::back_inserter(addedResources ),
-    		[](const ResourceInfo* a, const ResourceInfo* b){ return *a < *b; });
+		resourceGetDataParams.resourceSourceSettings = params.resourceSourceSettings;
 
-    	std::vector<ResourceInfo*> removedResources;
-    	std::set_difference(
-    		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
-    		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
-    		std::back_inserter( removedResources ),
-    		[](const ResourceInfo* a, const ResourceInfo* b){ return *a < *b; });
+		resourceGetDataParams.dataStream = resourceDataStream;
 
-    	std::vector<ResourceInfo*> potentiallyModifiedResources;
-    	std::set_intersection(
-    		sortedResourcesParameter.begin(), sortedResourcesParameter.end(),
-    		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
-    		std::back_inserter( potentiallyModifiedResources ),
-    		[](const ResourceInfo* a, const ResourceInfo* b){ return *a < *b; });
+		resourceGetDataParams.downloadRetrySeconds = params.downloadRetrySeconds;
 
-        for (ResourceInfo* resource : potentiallyModifiedResources)
-        {
-			if( params.statusCallback )
+		Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
+
+		bundleStream << resourceDataStream;
+
+		if( resourceGetDataResult.type != ResultType::SUCCESS )
+		{
+			return resourceGetDataResult;
+		}
+
+		while( !resourceDataStream->IsFinished() )
+		{
+			std::string resourceDataChunk;
+
+			if( !( *resourceDataStream >> resourceDataChunk ) )
 			{
-				std::filesystem::path relativePath;
-
-				Result getRelativePathResult = resource->GetRelativePath( relativePath );
-
-                if (getRelativePathResult.type != ResultType::SUCCESS)
-                {
-					return getRelativePathResult;
-                }
-
-				std::string message = "Processing: " + relativePath.string();
-
-                auto percentComplete = static_cast<unsigned int>( ( 100 * i )  / m_resourcesParameter.GetSize() );
-
-				params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
-				
-                i++;
+				return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
 			}
 
-        	ResourceInfo* resource2 = *std::lower_bound(
-        		sortedSubtractionResources.begin(), sortedSubtractionResources.end(),
-        		resource,
-        		[](const ResourceInfo* a, const ResourceInfo* b) { return *a < *b; } );
+			// Loop through possible created chunks
+			ResourceTools::GetChunk chunkFile;
 
-            std::string resource1Checksum;
+			chunkFile.clearCache = false;
 
-            Result getResource1ChecksumResult = resource->GetChecksum( resource1Checksum );
+			bool bundleReadOk{ true };
 
-            if (getResource1ChecksumResult.type != ResultType::SUCCESS)
-            {
-				return getResource1ChecksumResult;
-            }
+			while( ( bundleReadOk = bundleStream >> chunkFile ) && !chunkFile.outOfChunks )
+			{
+				std::stringstream ss;
+				ss << chunkBaseName << numberOfChunks << ".chunk";
+				std::string chunkName = ss.str();
 
-            std::string resource2Checksum;
+				std::filesystem::path chunkPath = params.chunkDestinationSettings.basePath / ss.str();
 
-            Result getResource2ChecksumResult = resource2->GetChecksum( resource2Checksum );
-
-            if (getResource2ChecksumResult.type != ResultType::SUCCESS)
-            {
-				return getResource2ChecksumResult;
-            }
-
-            // Has this resource changed?
-			if( resource1Checksum != resource2Checksum )
-            {
-                // The binary data has changed between versions, record an entry in both lists
-
-				// Create a copy of the resource to result 2 (Latest)
-				ResourceInfo* resourceCopy1 = nullptr;
-
-                Result createResourceFromResource1Result = CreateResourceFromResource( *resource, resourceCopy1 );
-
-                if (createResourceFromResource1Result.type != ResultType::SUCCESS)
-                {
-					return createResourceFromResource1Result;
-                }
-
-				params.result2->AddResource( resourceCopy1 );
-
-                ResourceInfo* resourceCopy2 = nullptr;
-
-                Result createResourceFromResource2Result = CreateResourceFromResource( *resource2, resourceCopy2 );
-
-                if( createResourceFromResource2Result.type != ResultType::SUCCESS )
+				if( params.statusCallback )
 				{
-					return createResourceFromResource2Result;
+					std::stringstream ss;
+
+					ss << "Generating Chunk: " << chunkPath;
+
+					params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::UNBOUNDED, 0, ss.str() );
 				}
 
-				params.result1->AddResource( resourceCopy2 );
+				Result processChunkResult = ProcessChunk( chunkFile, chunkPath, bundleResourceGroup, params.chunkDestinationSettings );
+
+				if( processChunkResult.type != ResultType::SUCCESS )
+				{
+					return processChunkResult;
+				}
+
+				numberOfChunks++;
 			}
-        }
+			if( !bundleReadOk )
+			{
+				return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
+			}
+		}
+	}
 
-    	for( auto resource : addedResources )
-        {
-            // This is a new resource, add it to target
-            // Note: Could be made optional, perhaps it is desirable to only include patch updates
-			// Not new files, probably make as optional pass in setting
-    		if( params.statusCallback )
-    		{
-    			std::filesystem::path relativePath;
-				Result getRelativePathResult = resource->GetRelativePath( relativePath );
-                if (getRelativePathResult.type != ResultType::SUCCESS)
-                {
-					return getRelativePathResult;
-                }
-    			std::string message = "Processing new resource: " + relativePath.string();
-    			auto percentComplete = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetSize() );
-    			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
-    			i++;
-    		}
 
+	ResourceTools::GetChunk chunkFile;
+
+	chunkFile.clearCache = true;
+
+	bundleStream.Flush();
+
+	if( !( bundleStream >> chunkFile ) )
+	{
+		return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
+	}
+
+	std::stringstream ss;
+	ss << chunkBaseName << numberOfChunks << ".chunk";
+	std::string chunkName = ss.str();
+
+	std::filesystem::path chunkPath = params.chunkDestinationSettings.basePath / ss.str();
+
+	Result processChunkResult = ProcessChunk( chunkFile, chunkPath, bundleResourceGroup, params.chunkDestinationSettings );
+
+	if( processChunkResult.type != ResultType::SUCCESS )
+	{
+		return processChunkResult;
+	}
+
+	// Export this resource list
+	//
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 75, "Exporting ResourceGroups" );
+	}
+
+	std::string resourceGroupData;
+
+	Result exportToDataResult = ExportToData( resourceGroupData );
+
+	if( exportToDataResult.type != ResultType::SUCCESS )
+	{
+		return exportToDataResult;
+	}
+
+	ResourceGroupInfo resourceGroupInfo( { params.resourceGroupRelativePath } );
+
+	Result setParametersFromDataResult = resourceGroupInfo.SetParametersFromData( resourceGroupData );
+
+	if( setParametersFromDataResult.type != ResultType::SUCCESS )
+	{
+		return setParametersFromDataResult;
+	}
+
+	ResourcePutDataParams putDataParams;
+
+	putDataParams.resourceDestinationSettings = params.chunkDestinationSettings;
+
+	putDataParams.data = &resourceGroupData;
+
+	Result subtractionResourcePutResult = resourceGroupInfo.PutData( putDataParams );
+
+	if( subtractionResourcePutResult.type != ResultType::SUCCESS )
+	{
+		return subtractionResourcePutResult;
+	}
+
+	// Export the bundleGroup
+	Result setResourceGroupResult = bundleResourceGroup.SetResourceGroup( resourceGroupInfo );
+
+	if( setResourceGroupResult.type != ResultType::SUCCESS )
+	{
+		return setResourceGroupResult;
+	}
+
+	std::string patchResourceGroupData;
+
+	Result exportBundleResourceGroupToDataResult = bundleResourceGroup.ExportToData( patchResourceGroupData );
+
+	if( exportBundleResourceGroupToDataResult.type != ResultType::SUCCESS )
+	{
+		return exportBundleResourceGroupToDataResult;
+	}
+
+	BundleResourceGroupInfo patchResourceGroupInfo( { params.resourceGroupBundleRelativePath } );
+
+	Result setPatchParametersFromDataResult = patchResourceGroupInfo.SetParametersFromData( patchResourceGroupData );
+
+	if( setPatchParametersFromDataResult.type != ResultType::SUCCESS )
+	{
+		return setPatchParametersFromDataResult;
+	}
+
+	ResourcePutDataParams bundlePutDataParams;
+
+	bundlePutDataParams.resourceDestinationSettings = params.resourceBundleResourceGroupDestinationSettings;
+
+	bundlePutDataParams.data = &patchResourceGroupData;
+
+	Result patchResourceGroupPutResult = patchResourceGroupInfo.PutData( bundlePutDataParams );
+
+	if( patchResourceGroupPutResult.type != ResultType::SUCCESS )
+	{
+		return patchResourceGroupPutResult;
+	}
+
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Bundle Creation Complete." );
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::ConstructPatchResourceInfo( const PatchCreateParams& params, int patchId, uintmax_t dataOffset, uint64_t patchSourceOffset, ResourceInfo* resourceNext, PatchResourceInfo*& patchResource ) const
+{
+	// Create a resource from patch data
+	std::filesystem::path resourceLatestRelativePath;
+	Result getResourceLatestRelativePathResult = resourceNext->GetRelativePath( resourceLatestRelativePath );
+	if( getResourceLatestRelativePathResult.type != ResultType::SUCCESS )
+	{
+		return getResourceLatestRelativePathResult;
+	}
+
+	PatchResourceInfoParams patchResourceInfoParams;
+	std::string patchFilename = params.patchFileRelativePathPrefix.string() + "." + std::to_string( patchId );
+	patchResourceInfoParams.relativePath = patchFilename;
+	patchResourceInfoParams.targetResourceRelativePath = resourceLatestRelativePath;
+	patchResourceInfoParams.dataOffset = dataOffset;
+	patchResourceInfoParams.sourceOffset = patchSourceOffset;
+	patchResource = new PatchResourceInfo( patchResourceInfoParams );
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& params ) const
+{
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Creating Patch" );
+	}
+
+	std::string previousGroupType = params.previousResourceGroup->m_impl->GetType();
+
+	std::string nextGroupType = GetType();
+
+	if( params.previousResourceGroup->m_impl->GetType() != GetType() )
+	{
+		return Result{ ResultType::PATCH_RESOURCE_LIST_MISSMATCH };
+	}
+
+	PatchResourceGroup::PatchResourceGroupImpl patchResourceGroup;
+
+	Result setMaxInputChunkSizeResult = patchResourceGroup.SetMaxInputChunkSize( params.maxInputFileChunkSize );
+
+	if( setMaxInputChunkSizeResult.type != ResultType::SUCCESS )
+	{
+		return setMaxInputChunkSizeResult;
+	}
+
+	// Created resource groups
+
+	std::shared_ptr<ResourceGroupImpl> resourceGroupSubtractionPrevious;
+
+	Result createPreviousResourceGroupResult = CreateResourceGroupFromString( previousGroupType, resourceGroupSubtractionPrevious );
+
+	if( createPreviousResourceGroupResult.type != ResultType::SUCCESS )
+	{
+		return createPreviousResourceGroupResult;
+	}
+
+	std::shared_ptr<ResourceGroupImpl> resourceGroupSubtractionNext;
+
+	Result createNextResourceGroupResult = CreateResourceGroupFromString( nextGroupType, resourceGroupSubtractionNext );
+
+	if( createNextResourceGroupResult.type != ResultType::SUCCESS )
+	{
+		return createNextResourceGroupResult;
+	}
+
+
+	ResourceGroupSubtractionParams resourceGroupSubtractionParams;
+
+	resourceGroupSubtractionParams.subtractResourceGroup = params.previousResourceGroup->m_impl;
+
+	resourceGroupSubtractionParams.result1 = resourceGroupSubtractionPrevious.get();
+
+	resourceGroupSubtractionParams.result2 = resourceGroupSubtractionNext.get();
+
+	resourceGroupSubtractionParams.statusCallback = params.statusCallback;
+
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 20, "Calculaing resourceGroups delta." );
+	}
+
+	Result subtractionResult = Diff( resourceGroupSubtractionParams );
+
+	if( subtractionResult.type != ResultType::SUCCESS )
+	{
+		return subtractionResult;
+	}
+
+	// Ensure that the diff results have the same number of members
+	if( resourceGroupSubtractionPrevious->m_resourcesParameter.GetSize() != resourceGroupSubtractionNext->m_resourcesParameter.GetSize() )
+	{
+		return Result{ ResultType::UNEXPECTED_PATCH_DIFF_ENCOUNTERED };
+	}
+
+	int patchId = 0;
+
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 40, "Generating Patches" );
+	}
+
+	for( int i = 0; i < resourceGroupSubtractionNext->m_resourcesParameter.GetSize(); i++ )
+	{
+
+		ResourceInfo* resourcePrevious = resourceGroupSubtractionPrevious->m_resourcesParameter.At( i );
+
+		ResourceInfo* resourceNext = resourceGroupSubtractionNext->m_resourcesParameter.At( i );
+
+		if( params.statusCallback )
+		{
+			auto percentageComplete = static_cast<unsigned int>( ( 100 * i ) / resourceGroupSubtractionNext->m_resourcesParameter.GetSize() );
+
+			std::filesystem::path relativePath;
+
+			Result getRelativePathResult = resourcePrevious->GetRelativePath( relativePath );
+
+			if( getRelativePathResult.type != ResultType::SUCCESS )
+			{
+				return getRelativePathResult;
+			}
+
+			std::string message = "Creating patch for: " + relativePath.string();
+
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentageComplete, message );
+		}
+
+		size_t patchSourceOffset{ 0 };
+		uint64_t patchSourceOffsetDelta{ 0 };
+
+		// Check to see if previous entry contains dummy information
+		// Suggesting that this is a new entry in latest
+		// In which case there is no reason to create a patch
+		// The new entry will be stored with the ResourceGroup related to the PatchResourceGroup
+		uintmax_t previousUncompressedSize;
+
+		Result getResourcePreviousCompressedSizeResult = resourcePrevious->GetUncompressedSize( previousUncompressedSize );
+
+		if( getResourcePreviousCompressedSizeResult.type != ResultType::SUCCESS )
+		{
+			return getResourcePreviousCompressedSizeResult;
+		}
+
+
+
+		uintmax_t nextUncompressedSize;
+
+		Result getResourceNextCompressedSizeResult = resourceNext->GetUncompressedSize( nextUncompressedSize );
+
+		if( getResourceNextCompressedSizeResult.type != ResultType::SUCCESS )
+		{
+			return getResourceNextCompressedSizeResult;
+		}
+
+
+		// If previous size is 0 this suggests that this is a new entry in latest
+		// In which case there is no reason to create a patch
+		if( previousUncompressedSize != 0 )
+		{
+			// Get resource data previous
+			auto previousFileDataStream = std::make_shared<ResourceTools::FileDataStreamIn>( params.maxInputFileChunkSize );
+
+			ResourceGetDataStreamParams previousResourceGetDataStreamParams;
+
+			previousResourceGetDataStreamParams.resourceSourceSettings = params.resourceSourceSettingsPrevious;
+
+			previousResourceGetDataStreamParams.downloadRetrySeconds = params.downloadRetrySeconds;
+
+			previousResourceGetDataStreamParams.dataStream = previousFileDataStream;
+
+			Result getPreviousDataStreamResult = resourcePrevious->GetDataStream( previousResourceGetDataStreamParams );
+
+			if( getPreviousDataStreamResult.type != ResultType::SUCCESS )
+			{
+				return getPreviousDataStreamResult;
+			}
+
+			// Get resource data next
+			auto nextFileDataStream = std::make_shared<ResourceTools::FileDataStreamIn>( params.maxInputFileChunkSize );
+
+			ResourceGetDataStreamParams nextResourceGetDataStreamParams;
+
+			nextResourceGetDataStreamParams.resourceSourceSettings = params.resourceSourceSettingsNext;
+
+			nextResourceGetDataStreamParams.dataStream = nextFileDataStream;
+
+			Result getNextDataStreamResult = resourceNext->GetDataStream( nextResourceGetDataStreamParams );
+
+			if( getNextDataStreamResult.type != ResultType::SUCCESS )
+			{
+				return getNextDataStreamResult;
+			}
+
+			std::filesystem::path relativePath;
+			Result getRelativePathResult = resourcePrevious->GetRelativePath( relativePath );
+			if( getRelativePathResult.type != ResultType::SUCCESS )
+			{
+				return getRelativePathResult;
+			}
+
+			std::function<void( unsigned int, const std::string& )> callback = [params]( unsigned int percent, const std::string& msg ) {
+				if( params.statusCallback )
+				{
+					params.statusCallback( StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, percent, msg );
+				}
+			};
+			ResourceTools::ChunkIndex index( previousFileDataStream->GetPath(), params.maxInputFileChunkSize, params.indexFolder, callback );
+			if( params.statusCallback )
+			{
+				std::string message = "Generating index for " + relativePath.string();
+				params.statusCallback( StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, 0, message );
+			}
+			index.GenerateChecksumFilter( nextFileDataStream->GetPath() );
+			if( !index.Generate() )
+			{
+				std::string message = "Index generation failed for " + relativePath.string();
+				params.statusCallback( StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, 0, message );
+			}
+
+			// Process one chunk at a time
+			for( uintmax_t dataOffset = 0; dataOffset < nextUncompressedSize; dataOffset += params.maxInputFileChunkSize )
+			{
+				std::string previousFileData = "";
+
+				if( previousFileDataStream->IsFinished() )
+				{
+					if( previousFileDataStream->Size() > nextFileDataStream->GetCurrentPosition() )
+					{
+						// We ran out of data because we found a chunk match later in the file,
+						// but we can rewind back to where the read stream is in hopes
+						// of getting a good diff, rather than just treating it as new data.
+						previousFileDataStream->StartRead( previousFileDataStream->GetPath() );
+					}
+				}
+
+				// Handling if previous file is smaller than next file
+				// If so then previousFileData will be nothing and
+				// All next data will be used for the patch
+				if( !previousFileDataStream->IsFinished() )
+				{
+					if( !( *previousFileDataStream >> previousFileData ) )
+					{
+						return Result{ ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA };
+					}
+				}
+
+				size_t nextStreamPosition = nextFileDataStream->GetCurrentPosition();
+				// Note: in the case that the next file is smaller than previous
+				// nothing is stored, application of the patch will chop off the extra file data
+				std::string nextFileData;
+
+				if( !nextFileDataStream->IsFinished() )
+				{
+					if( !( *nextFileDataStream >> nextFileData ) )
+					{
+						return Result{ ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA };
+					}
+				}
+
+				// Create a patch
+				// Create a patch from the data
+				std::string patchData;
+
+				bool chunkMatchFound{ false };
+				size_t matchCount{ 0 };
+
+
+				if( previousFileData != "" )
+				{
+					// Here's how this should work:
+					// We find a matching chunk if it exists. If the chunk exists we make a patch with no data, because we'll get
+					// the data from the source file using the patch info. Consecutive patches should be collapsed into one big one.
+					// If we can't find a matching chunk, we will base the current diff off the chunk in the source starting after the final byte
+					// in the chunk from the source file that we last used.
+					// These should keep our patches pretty minimal, even if lots of data gets added early in the file causing offsets.
+					// It should also handle small changes in moved parts of the file pretty well.
+					if( params.statusCallback )
+					{
+						unsigned int progress = static_cast<uint32_t>( ( dataOffset * 100 ) / nextUncompressedSize );
+						std::stringstream ss;
+						ss << "Generating patch files: " << relativePath.string();
+						params.statusCallback( StatusLevel::DETAIL, StatusProgressType::PERCENTAGE, progress, ss.str() );
+					}
+
+					chunkMatchFound = index.FindMatchingChunk( nextFileData, patchSourceOffset );
+
+					if( chunkMatchFound )
+					{
+						matchCount = 1;
+						matchCount += ResourceTools::CountMatchingChunks(
+							nextFileDataStream->GetPath(),
+							nextFileDataStream->GetCurrentPosition(),
+							previousFileDataStream->GetPath(),
+							patchSourceOffset + params.maxInputFileChunkSize,
+							params.maxInputFileChunkSize );
+
+						size_t matchSize = std::min( params.maxInputFileChunkSize * matchCount, previousFileDataStream->Size() - patchSourceOffset );
+
+						PatchResourceInfo* patchResource{ nullptr };
+
+						ConstructPatchResourceInfo( params, patchId, dataOffset, patchSourceOffset, resourceNext, patchResource );
+
+						if( previousFileDataStream->IsFinished() )
+						{
+							previousFileDataStream->StartRead( previousFileDataStream->GetPath() );
+						}
+
+						previousFileDataStream->Seek( patchSourceOffset );
+
+						patchResource->SetParametersFromSourceStream( *previousFileDataStream, matchSize );
+
+						// Advance the first stream by the size of the matching data,
+						// but move the point we generate patches from for the previous
+						// file data stream to the end of the match.
+						// It's hard to tell if it would be smarter to simply advance
+						// the destination data by the same amount of the source data,
+						// or perhaps even not to move it at all.
+						nextFileDataStream->Seek( std::min( nextFileDataStream->Size(), nextStreamPosition + matchSize ) );
+
+						previousFileDataStream->Seek( std::min( previousFileDataStream->Size(), patchSourceOffset + matchSize ) );
+
+						dataOffset += matchSize - params.maxInputFileChunkSize;
+
+						patchSourceOffset += matchSize;
+
+						if( nextStreamPosition == 0 && patchSourceOffset == 0 )
+						{
+							// This is the beginning of the file and it matches.
+							// There is no need to write patch data.
+							continue;
+						}
+
+						// Add the patch resource to the patchResourceGroup
+						Result addResourceResult = patchResourceGroup.AddResource( patchResource );
+
+						if( addResourceResult.type != ResultType::SUCCESS )
+						{
+							delete patchResource;
+
+							return addResourceResult;
+						}
+
+						patchId++;
+
+						continue;
+					}
+					else
+					{
+						// Previous and next data chunk are different, create a patch
+						if( !ResourceTools::CreatePatch( previousFileData, nextFileData, patchData ) )
+						{
+							return Result{ ResultType::FAILED_TO_CREATE_PATCH };
+						}
+						patchSourceOffsetDelta = previousFileData.size();
+					}
+				}
+				else
+				{
+					// If there is no previous data then just store the data straight from the file
+					// All this data is new
+					if( !ResourceTools::CreatePatch( "", nextFileData, patchData ) )
+					{
+						return Result{ ResultType::FAILED_TO_CREATE_PATCH };
+					}
+					patchSourceOffsetDelta = nextFileData.size();
+				}
+
+				PatchResourceInfo* patchResource{ nullptr };
+				ConstructPatchResourceInfo( params, patchId, dataOffset, patchSourceOffset, resourceNext, patchResource );
+				patchSourceOffset += patchSourceOffsetDelta;
+				if( !patchData.empty() )
+				{
+					Result setParametersFromDataResult = patchResource->SetParametersFromData( patchData );
+
+					if( setParametersFromDataResult.type != ResultType::SUCCESS )
+					{
+						return setParametersFromDataResult;
+					}
+
+					// Export patch file
+					ResourcePutDataParams resourcePutDataParams;
+
+					resourcePutDataParams.resourceDestinationSettings = params.resourcePatchBinaryDestinationSettings;
+
+					resourcePutDataParams.data = &patchData;
+
+					Result putPatchDataResult = patchResource->PutData( resourcePutDataParams );
+
+					if( putPatchDataResult.type != ResultType::SUCCESS )
+					{
+						delete patchResource;
+
+						return putPatchDataResult;
+					}
+				}
+
+				// Add the patch resource to the patchResourceGroup
+				Result addResourceResult = patchResourceGroup.AddResource( patchResource );
+
+				if( addResourceResult.type != ResultType::SUCCESS )
+				{
+					delete patchResource;
+
+					return addResourceResult;
+				}
+
+				patchId++;
+			}
+		}
+	}
+
+	patchResourceGroup.SetRemovedResourceRelativePaths( resourceGroupSubtractionParams.removedResources );
+
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 60, "Exporting ResourceGroups." );
+	}
+
+	// Export the subtraction ResourceGroup
+	std::string resourceGroupData;
+
+	Result exportResourceGroupSubtractionLatestResult = resourceGroupSubtractionNext->ExportToData( resourceGroupData );
+
+	if( exportResourceGroupSubtractionLatestResult.type != ResultType::SUCCESS )
+	{
+		return exportResourceGroupSubtractionLatestResult;
+	}
+
+	ResourceGroupInfo subtractionResourceGroupInfo( { params.resourceGroupRelativePath } );
+
+	Result setParametersFromDataResult = subtractionResourceGroupInfo.SetParametersFromData( resourceGroupData );
+
+	if( setParametersFromDataResult.type != ResultType::SUCCESS )
+	{
+		return setParametersFromDataResult;
+	}
+
+	ResourcePutDataParams putDataParams;
+
+	putDataParams.resourceDestinationSettings = params.resourcePatchBinaryDestinationSettings;
+
+	putDataParams.data = &resourceGroupData;
+
+	Result subtractionResourcePutResult = subtractionResourceGroupInfo.PutData( putDataParams );
+
+	if( subtractionResourcePutResult.type != ResultType::SUCCESS )
+	{
+		return subtractionResourcePutResult;
+	}
+
+
+
+	// Export the patchGroup
+	Result setResourceGroupResult = patchResourceGroup.SetResourceGroup( subtractionResourceGroupInfo );
+
+	if( setResourceGroupResult.type != ResultType::SUCCESS )
+	{
+		return setResourceGroupResult;
+	}
+
+	std::string patchResourceGroupData;
+
+	Result exportToDataResult = patchResourceGroup.ExportToData( patchResourceGroupData );
+
+	if( exportToDataResult.type != ResultType::SUCCESS )
+	{
+		return exportToDataResult;
+	}
+
+	PatchResourceGroupInfo patchResourceGroupInfo( { params.resourceGroupPatchRelativePath } );
+
+	Result setPatchParametersFromDataResult = patchResourceGroupInfo.SetParametersFromData( patchResourceGroupData );
+
+	if( setPatchParametersFromDataResult.type != ResultType::SUCCESS )
+	{
+		return setPatchParametersFromDataResult;
+	}
+
+	ResourcePutDataParams patchPutDataParams;
+
+	patchPutDataParams.resourceDestinationSettings = params.resourcePatchResourceGroupDestinationSettings;
+
+	patchPutDataParams.data = &patchResourceGroupData;
+
+	Result patchResourceGroupPutResult = patchResourceGroupInfo.PutData( patchPutDataParams );
+
+	if( patchResourceGroupPutResult.type != ResultType::SUCCESS )
+	{
+		return patchResourceGroupPutResult;
+	}
+
+	// Update status
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::PROCEDURE, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Patch Created" );
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+
+Result ResourceGroup::ResourceGroupImpl::AddResource( ResourceInfo* resource )
+{
+	m_resourcesParameter.PushBack( resource );
+
+	m_numberOfResources = m_numberOfResources.GetValue() + 1;
+
+	uintmax_t resourceUncompressedSize;
+
+	Result resourceGetUncompressedSizeResult = resource->GetUncompressedSize( resourceUncompressedSize );
+
+	if( resourceGetUncompressedSizeResult.type != ResultType::SUCCESS )
+	{
+		return resourceGetUncompressedSizeResult;
+	}
+
+	m_totalResourcesSizeUncompressed = m_totalResourcesSizeUncompressed.GetValue() + resourceUncompressedSize;
+
+	uintmax_t resourceCompressedSize;
+
+	Result resourceGetCompressedSizeResult = resource->GetCompressedSize( resourceCompressedSize );
+
+	if( resourceGetCompressedSizeResult.type != ResultType::SUCCESS )
+	{
+		return resourceGetCompressedSizeResult;
+	}
+
+	m_totalResourcesSizeCompressed = m_totalResourcesSizeCompressed.GetValue() + resourceCompressedSize;
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::RemoveResources( const ResourceGroupRemoveResourcesParams& params )
+{
+	if( !params.resourcesToRemove )
+	{
+		return Result{ ResultType::RESOURCE_LIST_NOT_SET };
+	}
+
+	for( std::filesystem::path& relativePath : *params.resourcesToRemove )
+	{
+		// Construct a ResourceInfo from relativePath
+		ResourceInfoParams resourceInfoParams;
+
+		resourceInfoParams.relativePath = relativePath;
+
+		ResourceInfo resource( resourceInfoParams );
+
+		Result removeResourceResult = RemoveResource( resource );
+
+		if( removeResourceResult.type != ResultType::SUCCESS )
+		{
+			if( removeResourceResult.type != ResultType::RESOURCE_NOT_FOUND )
+			{
+				return removeResourceResult;
+			}
+			else
+			{
+				if( params.errorIfResourceNotFound == true )
+				{
+					return removeResourceResult;
+				}
+			}
+		}
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::RemoveResource( ResourceInfo& resource )
+{
+
+	auto iter = m_resourcesParameter.Find( &resource );
+
+	if( iter == m_resourcesParameter.end() )
+	{
+		return Result{ ResultType::RESOURCE_NOT_FOUND };
+	}
+
+	ResourceInfo* foundResource = *iter;
+
+	// Update counters
+	m_numberOfResources = m_numberOfResources.GetValue() - 1;
+
+	uintmax_t resourceUncompressedSize;
+
+	Result resourceGetUncompressedSizeResult = foundResource->GetUncompressedSize( resourceUncompressedSize );
+
+	if( resourceGetUncompressedSizeResult.type != ResultType::SUCCESS )
+	{
+		return resourceGetUncompressedSizeResult;
+	}
+
+	uintmax_t resourceCompressedSize;
+
+	Result resourceGetCompressedSizeResult = foundResource->GetCompressedSize( resourceCompressedSize );
+
+	if( resourceGetCompressedSizeResult.type != ResultType::SUCCESS )
+	{
+		return resourceGetCompressedSizeResult;
+	}
+
+	// Update sizes
+	m_totalResourcesSizeUncompressed = m_totalResourcesSizeUncompressed.GetValue() - resourceUncompressedSize;
+
+	m_totalResourcesSizeCompressed = m_totalResourcesSizeCompressed.GetValue() - resourceCompressedSize;
+
+	// Remove from ResourceGroup
+	m_resourcesParameter.Remove( iter );
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::Merge( const ResourceGroupMergeParams& params )
+{
+	if( params.mergedResourceGroup == nullptr )
+	{
+		return Result{ ResultType::RESOURCE_GROUP_NOT_SET };
+	}
+
+	if( params.resourceGroupToMerge == nullptr )
+	{
+		return Result{ ResultType::RESOURCE_GROUP_NOT_SET };
+	}
+
+	DocumentParameterCollection<ResourceInfo*> mergeResources = params.resourceGroupToMerge->m_impl->m_resourcesParameter;
+
+	std::vector<ResourceInfo*> sortedResourcesParameter( m_resourcesParameter.begin(), m_resourcesParameter.end() );
+	std::vector<ResourceInfo*> sortedMergeResources( mergeResources.begin(), mergeResources.end() );
+
+	std::sort( sortedResourcesParameter.begin(), sortedResourcesParameter.end(), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+	std::sort( sortedMergeResources.begin(), sortedMergeResources.end(), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+	std::vector<ResourceInfo*> unionResources;
+	std::set_union(
+		sortedMergeResources.begin(), sortedMergeResources.end(), sortedResourcesParameter.begin(), sortedResourcesParameter.end(), std::back_inserter( unionResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+	// Add result to merge ResourceGroup output
+	for( auto resource : unionResources )
+	{
+		ResourceInfo* resourceCopy = nullptr;
+
+		Result createResourceFromResourceResult = CreateResourceFromResource( *resource, resourceCopy );
+
+		if( createResourceFromResourceResult.type != ResultType::SUCCESS )
+		{
+			return createResourceFromResourceResult;
+		}
+
+		Result addResourceResult = params.mergedResourceGroup->m_impl->AddResource( resourceCopy );
+
+		if( addResourceResult.type != ResultType::SUCCESS )
+		{
+			return addResourceResult;
+		}
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::DiffChangesAsLists( const ResourceGroupDiffAgainstGroupParams& params ) const
+{
+	if( !params.resourceGroupToDiffAgainst )
+	{
+		return Result{ ResultType::RESOURCE_GROUP_NOT_SET };
+	}
+
+	if( ( !params.additions ) || ( !params.subtractions ) )
+	{
+		return Result{ ResultType::REQUIRED_INPUT_PARAMETER_NOT_SET };
+	}
+
+	ResourceGroupSubtractionParams subtractionParams;
+
+	ResourceGroup result1;
+
+	ResourceGroup result2;
+
+	subtractionParams.subtractResourceGroup = params.resourceGroupToDiffAgainst->m_impl;
+
+	subtractionParams.result1 = result1.m_impl;
+
+	subtractionParams.result2 = result2.m_impl;
+
+	Result diffResult = Diff( subtractionParams );
+
+	if( diffResult.type != ResultType::SUCCESS )
+	{
+		return diffResult;
+	}
+
+	for( auto removedResource : subtractionParams.removedResources )
+	{
+		params.subtractions->push_back( removedResource );
+	}
+
+	for( auto resource : result1.m_impl->m_resourcesParameter )
+	{
+		std::filesystem::path relativePath;
+
+		Result getRelativePathResult = resource->GetRelativePath( relativePath );
+
+		if( getRelativePathResult.type != ResultType::SUCCESS )
+		{
+			return getRelativePathResult;
+		}
+
+		params.additions->push_back( relativePath );
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::Diff( ResourceGroupSubtractionParams& params ) const
+{
+	if( params.statusCallback )
+	{
+		params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, 0, "Calculating diff between two resource groups." );
+	}
+
+	DocumentParameterCollection<ResourceInfo*> subtractionResources = params.subtractResourceGroup->m_resourcesParameter;
+	// Iterate through all resources
+
+	// Value only required for status updates
+	int i = 0;
+	std::vector<ResourceInfo*> sortedResourcesParameter( m_resourcesParameter.begin(), m_resourcesParameter.end() );
+	std::vector<ResourceInfo*> sortedSubtractionResources( subtractionResources.begin(), subtractionResources.end() );
+	std::sort( sortedResourcesParameter.begin(), sortedResourcesParameter.end(), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+	std::sort( sortedSubtractionResources.begin(), sortedSubtractionResources.end(), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+	std::vector<ResourceInfo*> addedResources;
+	std::set_difference(
+		sortedResourcesParameter.begin(), sortedResourcesParameter.end(), sortedSubtractionResources.begin(), sortedSubtractionResources.end(), std::back_inserter( addedResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+	std::vector<ResourceInfo*> removedResources;
+	std::set_difference(
+		sortedSubtractionResources.begin(), sortedSubtractionResources.end(), sortedResourcesParameter.begin(), sortedResourcesParameter.end(), std::back_inserter( removedResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+	std::vector<ResourceInfo*> potentiallyModifiedResources;
+	std::set_intersection(
+		sortedResourcesParameter.begin(), sortedResourcesParameter.end(), sortedSubtractionResources.begin(), sortedSubtractionResources.end(), std::back_inserter( potentiallyModifiedResources ), []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+	for( ResourceInfo* resource : potentiallyModifiedResources )
+	{
+		if( params.statusCallback )
+		{
+			std::filesystem::path relativePath;
+
+			Result getRelativePathResult = resource->GetRelativePath( relativePath );
+
+			if( getRelativePathResult.type != ResultType::SUCCESS )
+			{
+				return getRelativePathResult;
+			}
+
+			std::string message = "Processing: " + relativePath.string();
+
+			auto percentComplete = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetSize() );
+
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
+
+			i++;
+		}
+
+		ResourceInfo* resource2 = *std::lower_bound(
+			sortedSubtractionResources.begin(), sortedSubtractionResources.end(), resource, []( const ResourceInfo* a, const ResourceInfo* b ) { return *a < *b; } );
+
+		std::string resource1Checksum;
+
+		Result getResource1ChecksumResult = resource->GetChecksum( resource1Checksum );
+
+		if( getResource1ChecksumResult.type != ResultType::SUCCESS )
+		{
+			return getResource1ChecksumResult;
+		}
+
+		std::string resource2Checksum;
+
+		Result getResource2ChecksumResult = resource2->GetChecksum( resource2Checksum );
+
+		if( getResource2ChecksumResult.type != ResultType::SUCCESS )
+		{
+			return getResource2ChecksumResult;
+		}
+
+		// Has this resource changed?
+		if( resource1Checksum != resource2Checksum )
+		{
+			// The binary data has changed between versions, record an entry in both lists
+
+			// Create a copy of the resource to result 2 (Latest)
 			ResourceInfo* resourceCopy1 = nullptr;
 
-            Result createResourceFromResourceResult = CreateResourceFromResource( *resource, resourceCopy1 );
+			Result createResourceFromResource1Result = CreateResourceFromResource( *resource, resourceCopy1 );
 
-            if (createResourceFromResourceResult.type != ResultType::SUCCESS)
-            {
-				return createResourceFromResourceResult;
-            }
+			if( createResourceFromResource1Result.type != ResultType::SUCCESS )
+			{
+				return createResourceFromResource1Result;
+			}
 
 			params.result2->AddResource( resourceCopy1 );
 
-            // Place in a dummy entry into result1 which shows that resource is new
-            // This ensures that both lists stay the same size which makes it easier
-            // To parse later
-			std::filesystem::path resourceRelativePath;
+			ResourceInfo* resourceCopy2 = nullptr;
 
-            Result getResourceRelativepathResult = resource->GetRelativePath( resourceRelativePath );
+			Result createResourceFromResource2Result = CreateResourceFromResource( *resource2, resourceCopy2 );
 
-            if (getResourceRelativepathResult.type != ResultType::SUCCESS)
-            {
-				return getResourceRelativepathResult;
-            }
+			if( createResourceFromResource2Result.type != ResultType::SUCCESS )
+			{
+				return createResourceFromResource2Result;
+			}
 
-			ResourceInfoParams dummyResourceParams;
-			dummyResourceParams.relativePath = resourceRelativePath;
+			params.result1->AddResource( resourceCopy2 );
+		}
+	}
 
-			ResourceInfo* dummyResource = new ResourceInfo( dummyResourceParams );
-			params.result1->AddResource( dummyResource );
-        }
-
-    	for( auto resource : removedResources )
-    	{
-    		if( params.statusCallback )
-    		{
-    			std::filesystem::path relativePath;
-				Result getRelativePathResult = resource->GetRelativePath( relativePath );
-                if (getRelativePathResult.type != ResultType::SUCCESS)
-                {
-					return getRelativePathResult;
-                }
-    			std::string message = "Processing removed resource: " + relativePath.string();
-    			auto percentComplete = static_cast<uint32_t>( ( 100 * i ) / m_resourcesParameter.GetSize() );
-    			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
-    			i++;
-    		}
-    		std::filesystem::path path;
-    		auto result = resource->GetRelativePath( path );
-    		if( result.type != ResultType::SUCCESS )
-    		{
-    			return result;
-    		}
-    		params.removedResources.push_back( path );
-    	}
-
-        if( params.statusCallback )
+	for( auto resource : addedResources )
+	{
+		// This is a new resource, add it to target
+		// Note: Could be made optional, perhaps it is desirable to only include patch updates
+		// Not new files, probably make as optional pass in setting
+		if( params.statusCallback )
 		{
-			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Diff calculation complete." );
+			std::filesystem::path relativePath;
+			Result getRelativePathResult = resource->GetRelativePath( relativePath );
+			if( getRelativePathResult.type != ResultType::SUCCESS )
+			{
+				return getRelativePathResult;
+			}
+			std::string message = "Processing new resource: " + relativePath.string();
+			auto percentComplete = static_cast<unsigned int>( ( 100 * i ) / m_resourcesParameter.GetSize() );
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
+			i++;
 		}
 
-        return Result{ ResultType::SUCCESS };
-    }
+		ResourceInfo* resourceCopy1 = nullptr;
 
-    std::vector<ResourceInfo*>::iterator ResourceGroup::ResourceGroupImpl::begin()
-	{
-		return m_resourcesParameter.begin();
+		Result createResourceFromResourceResult = CreateResourceFromResource( *resource, resourceCopy1 );
+
+		if( createResourceFromResourceResult.type != ResultType::SUCCESS )
+		{
+			return createResourceFromResourceResult;
+		}
+
+		params.result2->AddResource( resourceCopy1 );
+
+		// Place in a dummy entry into result1 which shows that resource is new
+		// This ensures that both lists stay the same size which makes it easier
+		// To parse later
+		std::filesystem::path resourceRelativePath;
+
+		Result getResourceRelativepathResult = resource->GetRelativePath( resourceRelativePath );
+
+		if( getResourceRelativepathResult.type != ResultType::SUCCESS )
+		{
+			return getResourceRelativepathResult;
+		}
+
+		ResourceInfoParams dummyResourceParams;
+		dummyResourceParams.relativePath = resourceRelativePath;
+
+		ResourceInfo* dummyResource = new ResourceInfo( dummyResourceParams );
+		params.result1->AddResource( dummyResource );
 	}
 
-	std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::begin() const
+	for( auto resource : removedResources )
 	{
-		return m_resourcesParameter.begin();
+		if( params.statusCallback )
+		{
+			std::filesystem::path relativePath;
+			Result getRelativePathResult = resource->GetRelativePath( relativePath );
+			if( getRelativePathResult.type != ResultType::SUCCESS )
+			{
+				return getRelativePathResult;
+			}
+			std::string message = "Processing removed resource: " + relativePath.string();
+			auto percentComplete = static_cast<uint32_t>( ( 100 * i ) / m_resourcesParameter.GetSize() );
+			params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, message );
+			i++;
+		}
+		std::filesystem::path path;
+		auto result = resource->GetRelativePath( path );
+		if( result.type != ResultType::SUCCESS )
+		{
+			return result;
+		}
+		params.removedResources.push_back( path );
 	}
 
-	std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::cbegin()
+	if( params.statusCallback )
 	{
-		return m_resourcesParameter.begin();
+		params.statusCallback( CarbonResources::StatusLevel::DETAIL, CarbonResources::StatusProgressType::PERCENTAGE, 100, "Diff calculation complete." );
 	}
 
-	std::vector<ResourceInfo*>::iterator ResourceGroup::ResourceGroupImpl::end()
-	{
-		return m_resourcesParameter.end();
-	}
+	return Result{ ResultType::SUCCESS };
+}
 
-	std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::end() const
-	{
-		return m_resourcesParameter.end();
-	}
+std::vector<ResourceInfo*>::iterator ResourceGroup::ResourceGroupImpl::begin()
+{
+	return m_resourcesParameter.begin();
+}
 
-	std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::cend()
-	{
-		return m_resourcesParameter.end();
-	}
+std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::begin() const
+{
+	return m_resourcesParameter.begin();
+}
 
-    size_t ResourceGroup::ResourceGroupImpl::GetSize() const
-    {
-		return m_resourcesParameter.GetSize();
-    }
+std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::cbegin()
+{
+	return m_resourcesParameter.begin();
+}
 
-	Result ResourceGroup::ResourceGroupImpl::GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const
-	{
-		return Result{ ResultType::SUCCESS };
-	}
+std::vector<ResourceInfo*>::iterator ResourceGroup::ResourceGroupImpl::end()
+{
+	return m_resourcesParameter.end();
+}
+
+std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::end() const
+{
+	return m_resourcesParameter.end();
+}
+
+std::vector<ResourceInfo*>::const_iterator ResourceGroup::ResourceGroupImpl::cend()
+{
+	return m_resourcesParameter.end();
+}
+
+size_t ResourceGroup::ResourceGroupImpl::GetSize() const
+{
+	return m_resourcesParameter.GetSize();
+}
+
+Result ResourceGroup::ResourceGroupImpl::GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const
+{
+	return Result{ ResultType::SUCCESS };
+}
 
 
 }

--- a/src/ResourceGroupImpl.h
+++ b/src/ResourceGroupImpl.h
@@ -16,127 +16,124 @@
 
 namespace YAML
 {
-    class Emitter;
-    class Node;
+class Emitter;
+class Node;
 }
 
 namespace CarbonResources
 {
 
-    struct ResourceGroupSubtractionParams
-    {
-		ResourceGroup::ResourceGroupImpl* subtractResourceGroup = nullptr;
+struct ResourceGroupSubtractionParams
+{
+	ResourceGroup::ResourceGroupImpl* subtractResourceGroup = nullptr;
 
-	    ResourceGroup::ResourceGroupImpl* result1 = nullptr;
+	ResourceGroup::ResourceGroupImpl* result1 = nullptr;
 
-	    ResourceGroup::ResourceGroupImpl* result2 = nullptr;
+	ResourceGroup::ResourceGroupImpl* result2 = nullptr;
 
-    	std::vector<std::filesystem::path> removedResources;
+	std::vector<std::filesystem::path> removedResources;
 
-        StatusCallback statusCallback = nullptr;
-    };
+	StatusCallback statusCallback = nullptr;
+};
 
-    enum class DocumentType
-    {
-        CSV,
-        YAML
-    };
+enum class DocumentType
+{
+	CSV,
+	YAML
+};
 
-    class ResourceGroup::ResourceGroupImpl
-    {
-    public:
-		ResourceGroupImpl();
+class ResourceGroup::ResourceGroupImpl
+{
+public:
+	ResourceGroupImpl();
 
-	    virtual ~ResourceGroupImpl();
+	virtual ~ResourceGroupImpl();
 
-        Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params );
+	Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params );
 
-	    Result ImportFromFile( const ResourceGroupImportFromFileParams& params );
+	Result ImportFromFile( const ResourceGroupImportFromFileParams& params );
 
-        Result ImportFromData( const std::string& data, DocumentType documentType = DocumentType::YAML );
+	Result ImportFromData( const std::string& data, DocumentType documentType = DocumentType::YAML );
 
-	    Result ExportToFile( const ResourceGroupExportToFileParams& params ) const;
+	Result ExportToFile( const ResourceGroupExportToFileParams& params ) const;
 
-        Result ExportToData( std::string& data, VersionInternal outputDocumentVersion = S_DOCUMENT_VERSION ) const;
+	Result ExportToData( std::string& data, VersionInternal outputDocumentVersion = S_DOCUMENT_VERSION ) const;
 
-        Result CreateBundle( const BundleCreateParams& params ) const;
+	Result CreateBundle( const BundleCreateParams& params ) const;
 
-		Result ConstructPatchResourceInfo( const PatchCreateParams& params, int patchId, uintmax_t dataOffset, uint64_t patchSourceOffset, ResourceInfo* resourceNext, PatchResourceInfo*& patchResource ) const;
+	Result ConstructPatchResourceInfo( const PatchCreateParams& params, int patchId, uintmax_t dataOffset, uint64_t patchSourceOffset, ResourceInfo* resourceNext, PatchResourceInfo*& patchResource ) const;
 
-		Result CreatePatch( const PatchCreateParams& params ) const;
+	Result CreatePatch( const PatchCreateParams& params ) const;
 
-	    Result AddResource( ResourceInfo* resource );
+	Result AddResource( ResourceInfo* resource );
 
-        Result Diff( ResourceGroupSubtractionParams& params ) const;
+	Result Diff( ResourceGroupSubtractionParams& params ) const;
 
-        Result DiffChangesAsLists( const ResourceGroupDiffAgainstGroupParams& params ) const;
+	Result DiffChangesAsLists( const ResourceGroupDiffAgainstGroupParams& params ) const;
 
-        Result Merge( const ResourceGroupMergeParams& params );
+	Result Merge( const ResourceGroupMergeParams& params );
 
-        Result RemoveResources( const ResourceGroupRemoveResourcesParams& params );
-        
-        virtual std::string GetType() const;
+	Result RemoveResources( const ResourceGroupRemoveResourcesParams& params );
 
-        static std::string TypeId();
+	virtual std::string GetType() const;
 
-        std::vector<ResourceInfo*>::iterator begin();
+	static std::string TypeId();
 
-        std::vector<ResourceInfo*>::const_iterator begin() const;
+	std::vector<ResourceInfo*>::iterator begin();
 
-		std::vector<ResourceInfo*>::const_iterator cbegin();
+	std::vector<ResourceInfo*>::const_iterator begin() const;
 
-        std::vector<ResourceInfo*>::iterator end();
+	std::vector<ResourceInfo*>::const_iterator cbegin();
 
-		std::vector<ResourceInfo*>::const_iterator end() const;
+	std::vector<ResourceInfo*>::iterator end();
 
-		std::vector<ResourceInfo*>::const_iterator cend();
+	std::vector<ResourceInfo*>::const_iterator end() const;
 
-        size_t GetSize() const;
+	std::vector<ResourceInfo*>::const_iterator cend();
 
-	    Result ImportFromYamlString( const std::string& data, StatusCallback statusCallback = nullptr );
+	size_t GetSize() const;
 
-    	Result ImportFromYaml( YAML::Node& data, StatusCallback statusCallback = nullptr );
+	Result ImportFromYamlString( const std::string& data, StatusCallback statusCallback = nullptr );
 
-		virtual Result GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const;
+	Result ImportFromYaml( YAML::Node& data, StatusCallback statusCallback = nullptr );
 
-    protected:
+	virtual Result GetGroupSpecificResourcesToBundle( std::vector<ResourceInfo*>& toBundle ) const;
 
-        virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut );
+protected:
+	virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut );
 
-    private:
+private:
+	virtual Result CreateResourceFromResource( const ResourceInfo& resourceIn, ResourceInfo*& resourceOut ) const;
 
-        virtual Result CreateResourceFromResource( const ResourceInfo& resourceIn, ResourceInfo*& resourceOut ) const;
+	virtual Result ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile );
 
-	    virtual Result ImportGroupSpecialisedYaml( YAML::Node& resourceGroupFile );
+	virtual Result ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const;
 
-	    virtual Result ExportGroupSpecialisedYaml( YAML::Emitter& out, VersionInternal outputDocumentVersion ) const;
+	[[deprecated( "Prefer yaml" )]]
+	virtual Result ImportFromCSV( const std::string& data, StatusCallback statusCallback = nullptr );
 
-    	[[deprecated( "Prefer yaml" )]]
-		virtual Result ImportFromCSV( const std::string& data, StatusCallback statusCallback = nullptr );
+	Result ExportYaml( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback = nullptr ) const;
 
-	    Result ExportYaml( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback = nullptr ) const;
+	Result ExportCsv( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback = nullptr ) const;
 
-	    Result ExportCsv( const VersionInternal& outputDocumentVersion, std::string& data, StatusCallback statusCallback = nullptr ) const;
+	Result ProcessChunk( ResourceTools::GetChunk& chunkData, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const;
 
-        Result ProcessChunk( ResourceTools::GetChunk& chunkData, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const;
+	Result RemoveResource( ResourceInfo& relativePath );
 
-        Result RemoveResource( ResourceInfo& relativePath );
+protected:
+	// Document Parameters
+	DocumentParameter<VersionInternal> m_versionParameter = DocumentParameter<VersionInternal>( VERSION, TypeId() );
 
-    protected:
+	DocumentParameter<std::string> m_type = DocumentParameter<std::string>( TYPE, TypeId() );
 
-	    // Document Parameters
-	    DocumentParameter<VersionInternal> m_versionParameter = DocumentParameter<VersionInternal>( VERSION, TypeId() );
+	DocumentParameter<uintmax_t> m_numberOfResources = DocumentParameter<uintmax_t>( NUMBER_OF_RESOURCES, TypeId() );
 
-        DocumentParameter<std::string> m_type = DocumentParameter<std::string>( TYPE, TypeId() );
+	DocumentParameter<uintmax_t> m_totalResourcesSizeCompressed = DocumentParameter<uintmax_t>( TOTAL_RESOURCE_SIZE_COMPRESSED, TypeId() );
 
-        DocumentParameter<uintmax_t> m_numberOfResources = DocumentParameter<uintmax_t>( NUMBER_OF_RESOURCES, TypeId() );
+	DocumentParameter<uintmax_t> m_totalResourcesSizeUncompressed = DocumentParameter<uintmax_t>( TOTAL_RESOURCE_SIZE_UNCOMPRESSED, TypeId() );
 
-        DocumentParameter<uintmax_t> m_totalResourcesSizeCompressed = DocumentParameter<uintmax_t>( TOTAL_RESOURCE_SIZE_COMPRESSED, TypeId() );
-
-        DocumentParameter<uintmax_t> m_totalResourcesSizeUncompressed = DocumentParameter<uintmax_t>( TOTAL_RESOURCE_SIZE_UNCOMPRESSED, TypeId() );
-
-	    DocumentParameterCollection<ResourceInfo*> m_resourcesParameter = DocumentParameterCollection<ResourceInfo*>( RESOURCE, TypeId() );
-    };
+	DocumentParameterCollection<ResourceInfo*> m_resourcesParameter = DocumentParameterCollection<ResourceInfo*>( RESOURCE, TypeId() );
+};
 
 }
 

--- a/src/ResourceInfo/BundleResourceGroupInfo.cpp
+++ b/src/ResourceInfo/BundleResourceGroupInfo.cpp
@@ -9,20 +9,19 @@
 namespace CarbonResources
 {
 
-    BundleResourceGroupInfo::BundleResourceGroupInfo( const BundleResourceGroupInfoParams& params ) :
-      ResourceInfo(params)
-    {
-		m_type = TypeId();
-    }
+BundleResourceGroupInfo::BundleResourceGroupInfo( const BundleResourceGroupInfoParams& params ) :
+	ResourceInfo( params )
+{
+	m_type = TypeId();
+}
 
-    BundleResourceGroupInfo::~BundleResourceGroupInfo()
-    {
+BundleResourceGroupInfo::~BundleResourceGroupInfo()
+{
+}
 
-    }
-
-    std::string BundleResourceGroupInfo::TypeId()
-    {
-		return "BundleResourceGroup";
-    }
+std::string BundleResourceGroupInfo::TypeId()
+{
+	return "BundleResourceGroup";
+}
 
 }

--- a/src/ResourceInfo/BundleResourceGroupInfo.h
+++ b/src/ResourceInfo/BundleResourceGroupInfo.h
@@ -8,21 +8,19 @@
 
 namespace CarbonResources
 {
-    struct BundleResourceGroupInfoParams : public ResourceGroupInfoParams
-    {
+struct BundleResourceGroupInfoParams : public ResourceGroupInfoParams
+{
+};
 
-    };
+class BundleResourceGroupInfo : public ResourceInfo
+{
+public:
+	BundleResourceGroupInfo( const BundleResourceGroupInfoParams& params );
 
-    class BundleResourceGroupInfo : public ResourceInfo
-    {
-    public:
-	    BundleResourceGroupInfo( const BundleResourceGroupInfoParams& params );
+	~BundleResourceGroupInfo();
 
-        ~BundleResourceGroupInfo();
-
-        static std::string TypeId( );
-
-    };
+	static std::string TypeId();
+};
 
 }
 

--- a/src/ResourceInfo/BundleResourceInfo.cpp
+++ b/src/ResourceInfo/BundleResourceInfo.cpp
@@ -9,25 +9,24 @@
 namespace CarbonResources
 {
 
-    BundleResourceInfo::BundleResourceInfo( const BundleResourceInfoParams& params ):
-      ResourceInfo(params)
-    {
-		m_type = TypeId();
-    }
+BundleResourceInfo::BundleResourceInfo( const BundleResourceInfoParams& params ) :
+	ResourceInfo( params )
+{
+	m_type = TypeId();
+}
 
-    BundleResourceInfo::~BundleResourceInfo()
-    {
+BundleResourceInfo::~BundleResourceInfo()
+{
+}
 
-    }
+std::string BundleResourceInfo::TypeId()
+{
+	return "BinaryChunk";
+}
 
-    std::string BundleResourceInfo::TypeId( )
-    {
-		return "BinaryChunk";
-    }
-
-    Result BundleResourceInfo::SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion )
-	{
-		return ResourceInfo::SetParametersFromResource( other, documentVersion );
-	}
+Result BundleResourceInfo::SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion )
+{
+	return ResourceInfo::SetParametersFromResource( other, documentVersion );
+}
 
 }

--- a/src/ResourceInfo/BundleResourceInfo.h
+++ b/src/ResourceInfo/BundleResourceInfo.h
@@ -8,23 +8,21 @@
 
 namespace CarbonResources
 {
-    struct BundleResourceInfoParams : public ResourceInfoParams
-    {
+struct BundleResourceInfoParams : public ResourceInfoParams
+{
+};
 
-    };
+class BundleResourceInfo : public ResourceInfo
+{
+public:
+	BundleResourceInfo( const BundleResourceInfoParams& params );
 
-    class BundleResourceInfo : public ResourceInfo
-    {
-    public:
-	    BundleResourceInfo( const BundleResourceInfoParams& params );
+	~BundleResourceInfo();
 
-        ~BundleResourceInfo();
+	static std::string TypeId();
 
-        static std::string TypeId( );
-
-        virtual Result SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion ) override;
-
-    };
+	virtual Result SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion ) override;
+};
 
 }
 

--- a/src/ResourceInfo/PatchResourceGroupInfo.cpp
+++ b/src/ResourceInfo/PatchResourceGroupInfo.cpp
@@ -9,20 +9,19 @@
 namespace CarbonResources
 {
 
-    PatchResourceGroupInfo::PatchResourceGroupInfo( const PatchResourceGroupInfoParams& params ):
-      ResourceInfo(params)
-    {
-		m_type = TypeId();
-    }
+PatchResourceGroupInfo::PatchResourceGroupInfo( const PatchResourceGroupInfoParams& params ) :
+	ResourceInfo( params )
+{
+	m_type = TypeId();
+}
 
-    PatchResourceGroupInfo::~PatchResourceGroupInfo()
-    {
+PatchResourceGroupInfo::~PatchResourceGroupInfo()
+{
+}
 
-    }
-
-    std::string PatchResourceGroupInfo::TypeId()
-    {
-		return "PatchResourceGroup";
-    }
+std::string PatchResourceGroupInfo::TypeId()
+{
+	return "PatchResourceGroup";
+}
 
 }

--- a/src/ResourceInfo/PatchResourceGroupInfo.h
+++ b/src/ResourceInfo/PatchResourceGroupInfo.h
@@ -8,21 +8,19 @@
 
 namespace CarbonResources
 {
-    struct PatchResourceGroupInfoParams : public ResourceGroupInfoParams
-    {
+struct PatchResourceGroupInfoParams : public ResourceGroupInfoParams
+{
+};
 
-    };
+class PatchResourceGroupInfo : public ResourceInfo
+{
+public:
+	PatchResourceGroupInfo( const PatchResourceGroupInfoParams& params );
 
-    class PatchResourceGroupInfo : public ResourceInfo
-    {
-    public:
-	    PatchResourceGroupInfo( const PatchResourceGroupInfoParams& params );
+	~PatchResourceGroupInfo();
 
-        ~PatchResourceGroupInfo();
-
-        static std::string TypeId( );
-
-    };
+	static std::string TypeId();
+};
 
 }
 

--- a/src/ResourceInfo/PatchResourceInfo.cpp
+++ b/src/ResourceInfo/PatchResourceInfo.cpp
@@ -13,184 +13,183 @@
 namespace CarbonResources
 {
 
-    PatchResourceInfo::PatchResourceInfo( const PatchResourceInfoParams& params ):
-      ResourceInfo(params)
-    {
-		m_targetResourceRelativepath = params.targetResourceRelativePath;
+PatchResourceInfo::PatchResourceInfo( const PatchResourceInfoParams& params ) :
+	ResourceInfo( params )
+{
+	m_targetResourceRelativepath = params.targetResourceRelativePath;
 
-        m_dataOffset = params.dataOffset;
+	m_dataOffset = params.dataOffset;
 
-    	m_sourceOffset = params.sourceOffset;
+	m_sourceOffset = params.sourceOffset;
 
-		m_type = TypeId();
-    }
+	m_type = TypeId();
+}
 
-    PatchResourceInfo::~PatchResourceInfo()
-    {
+PatchResourceInfo::~PatchResourceInfo()
+{
+}
 
-    }
-
-    Result PatchResourceInfo::GetTargetResourceRelativePath( std::filesystem::path& targetResourceRelativePath ) const
+Result PatchResourceInfo::GetTargetResourceRelativePath( std::filesystem::path& targetResourceRelativePath ) const
+{
+	if( !m_targetResourceRelativepath.HasValue() )
 	{
-		if( !m_targetResourceRelativepath.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			targetResourceRelativePath = m_targetResourceRelativepath.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
 	}
-
-    Result PatchResourceInfo::GetDataOffset( uintmax_t& dataoffset ) const
-    {
-		if( !m_dataOffset.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			dataoffset = m_dataOffset.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-	Result PatchResourceInfo::GetSourceOffset( uintmax_t& sourceOffset ) const
+	else
 	{
-		if( !m_sourceOffset.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			sourceOffset = m_sourceOffset.GetValue();
-			return Result{ ResultType::SUCCESS };
-		}
-	}
-
-	Result PatchResourceInfo::ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion )
-	{
-    	Result result = SetParameterFromYamlNode( resource, m_targetResourceRelativepath, TypeId(), documentVersion );
-    	if( result.type != ResultType::SUCCESS )
-    	{
-    		return result;
-    	}
-
-    	result = SetParameterFromYamlNode( resource, m_dataOffset, TypeId(), documentVersion );
-		if( result.type != ResultType::SUCCESS )
-    	{
-    		return result;
-    	}
-
-    	result = SetParameterFromYamlNode( resource, m_sourceOffset, TypeId(), documentVersion );
-    	if( result.type != ResultType::SUCCESS )
-    	{
-    		return result;
-    	}
-
-		return ResourceInfo::ImportFromYaml( resource, documentVersion );
-	}
-
-	Result PatchResourceInfo::ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion )
-	{
-		Result resourceExportResult = ResourceInfo::ExportToYaml( out, documentVersion );
-
-		if( resourceExportResult.type != ResultType::SUCCESS )
-		{
-			return resourceExportResult;
-		}
-
-		// Resource relative path
-		if( m_targetResourceRelativepath.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_targetResourceRelativepath.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
-
-			out << YAML::Key << m_targetResourceRelativepath.GetTag();
-			out << YAML::Value << m_targetResourceRelativepath.GetValue().string();
-		}
-
-        // Data offset
-        if( m_dataOffset.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_dataOffset.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
-
-			out << YAML::Key << m_dataOffset.GetTag();
-			out << YAML::Value << m_dataOffset.GetValue();
-		}
-
-    	// Source offset
-    	if( m_sourceOffset.IsParameterExpectedInDocumentVersion( documentVersion ) )
-    	{
-    		if( !m_sourceOffset.HasValue() )
-    		{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-    		}
-
-    		out << YAML::Key << m_sourceOffset.GetTag();
-    		out << YAML::Value << m_sourceOffset.GetValue();
-    	}
+		targetResourceRelativePath = m_targetResourceRelativepath.GetValue();
 
 		return Result{ ResultType::SUCCESS };
 	}
+}
 
-    std::string PatchResourceInfo::TypeId( )
-    {
-		return "BinaryPatch";
-    }
-
-    Result PatchResourceInfo::SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion )
+Result PatchResourceInfo::GetDataOffset( uintmax_t& dataoffset ) const
+{
+	if( !m_dataOffset.HasValue() )
 	{
-		if( other == nullptr )
-        {
-			return Result{ ResultType::FAIL };
-        }
-
-        if (other->TypeId() != TypeId())
-        {
-			return Result{ ResultType::RESOURCE_TYPE_MISSMATCH };
-        }
-
-        const PatchResourceInfo* otherAsPatch = reinterpret_cast<const PatchResourceInfo*>( other );
-
-        if (m_dataOffset.IsParameterExpectedInDocumentVersion(documentVersion))
-        {
-			uintmax_t dataOffset;
-
-			Result getOffsetResult = otherAsPatch->GetDataOffset( dataOffset );
-
-			if( getOffsetResult.type != ResultType::SUCCESS )
-			{
-				return getOffsetResult;
-			}
-
-			m_dataOffset = dataOffset;
-        }
-		
-        if (m_targetResourceRelativepath.IsParameterExpectedInDocumentVersion(documentVersion))
-        {
-			std::filesystem::path targetResourceRelativePath;
-
-			Result getTargetResourceRelativePathResult = otherAsPatch->GetTargetResourceRelativePath( targetResourceRelativePath );
-
-			if( getTargetResourceRelativePathResult.type != ResultType::SUCCESS )
-			{
-				return getTargetResourceRelativePathResult;
-			}
-
-			m_targetResourceRelativepath = targetResourceRelativePath;
-        }
-
-		return ResourceInfo::SetParametersFromResource( other, documentVersion );
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
 	}
+	else
+	{
+		dataoffset = m_dataOffset.GetValue();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result PatchResourceInfo::GetSourceOffset( uintmax_t& sourceOffset ) const
+{
+	if( !m_sourceOffset.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		sourceOffset = m_sourceOffset.GetValue();
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result PatchResourceInfo::ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion )
+{
+	Result result = SetParameterFromYamlNode( resource, m_targetResourceRelativepath, TypeId(), documentVersion );
+	if( result.type != ResultType::SUCCESS )
+	{
+		return result;
+	}
+
+	result = SetParameterFromYamlNode( resource, m_dataOffset, TypeId(), documentVersion );
+	if( result.type != ResultType::SUCCESS )
+	{
+		return result;
+	}
+
+	result = SetParameterFromYamlNode( resource, m_sourceOffset, TypeId(), documentVersion );
+	if( result.type != ResultType::SUCCESS )
+	{
+		return result;
+	}
+
+	return ResourceInfo::ImportFromYaml( resource, documentVersion );
+}
+
+Result PatchResourceInfo::ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion )
+{
+	Result resourceExportResult = ResourceInfo::ExportToYaml( out, documentVersion );
+
+	if( resourceExportResult.type != ResultType::SUCCESS )
+	{
+		return resourceExportResult;
+	}
+
+	// Resource relative path
+	if( m_targetResourceRelativepath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_targetResourceRelativepath.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+		}
+
+		out << YAML::Key << m_targetResourceRelativepath.GetTag();
+		out << YAML::Value << m_targetResourceRelativepath.GetValue().string();
+	}
+
+	// Data offset
+	if( m_dataOffset.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_dataOffset.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+		}
+
+		out << YAML::Key << m_dataOffset.GetTag();
+		out << YAML::Value << m_dataOffset.GetValue();
+	}
+
+	// Source offset
+	if( m_sourceOffset.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_sourceOffset.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+		}
+
+		out << YAML::Key << m_sourceOffset.GetTag();
+		out << YAML::Value << m_sourceOffset.GetValue();
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+std::string PatchResourceInfo::TypeId()
+{
+	return "BinaryPatch";
+}
+
+Result PatchResourceInfo::SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion )
+{
+	if( other == nullptr )
+	{
+		return Result{ ResultType::FAIL };
+	}
+
+	if( other->TypeId() != TypeId() )
+	{
+		return Result{ ResultType::RESOURCE_TYPE_MISSMATCH };
+	}
+
+	const PatchResourceInfo* otherAsPatch = reinterpret_cast<const PatchResourceInfo*>( other );
+
+	if( m_dataOffset.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		uintmax_t dataOffset;
+
+		Result getOffsetResult = otherAsPatch->GetDataOffset( dataOffset );
+
+		if( getOffsetResult.type != ResultType::SUCCESS )
+		{
+			return getOffsetResult;
+		}
+
+		m_dataOffset = dataOffset;
+	}
+
+	if( m_targetResourceRelativepath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		std::filesystem::path targetResourceRelativePath;
+
+		Result getTargetResourceRelativePathResult = otherAsPatch->GetTargetResourceRelativePath( targetResourceRelativePath );
+
+		if( getTargetResourceRelativePathResult.type != ResultType::SUCCESS )
+		{
+			return getTargetResourceRelativePathResult;
+		}
+
+		m_targetResourceRelativepath = targetResourceRelativePath;
+	}
+
+	return ResourceInfo::SetParametersFromResource( other, documentVersion );
+}
 
 
 }

--- a/src/ResourceInfo/PatchResourceInfo.h
+++ b/src/ResourceInfo/PatchResourceInfo.h
@@ -8,45 +8,44 @@
 
 namespace CarbonResources
 {
-    struct PatchResourceInfoParams : public ResourceGroupInfoParams
-    {
-		std::filesystem::path targetResourceRelativePath = "NOT_SET";
+struct PatchResourceInfoParams : public ResourceGroupInfoParams
+{
+	std::filesystem::path targetResourceRelativePath = "NOT_SET";
 
-        uintmax_t dataOffset = 0;
+	uintmax_t dataOffset = 0;
 
-    	uintmax_t sourceOffset = 0;
-    };
+	uintmax_t sourceOffset = 0;
+};
 
-    class ResourceGroup;
+class ResourceGroup;
 
-    class PatchResourceInfo : public ResourceInfo
-    {
-    public:
-	    PatchResourceInfo( const PatchResourceInfoParams& params );
+class PatchResourceInfo : public ResourceInfo
+{
+public:
+	PatchResourceInfo( const PatchResourceInfoParams& params );
 
-	    ~PatchResourceInfo();
+	~PatchResourceInfo();
 
-        static std::string TypeId( );
+	static std::string TypeId();
 
-        Result GetTargetResourceRelativePath( std::filesystem::path& targetResourceRelativePath ) const;
+	Result GetTargetResourceRelativePath( std::filesystem::path& targetResourceRelativePath ) const;
 
-        Result GetDataOffset( uintmax_t& dataoffset ) const;
+	Result GetDataOffset( uintmax_t& dataoffset ) const;
 
-    	Result GetSourceOffset( uintmax_t& sourceOffset ) const;
+	Result GetSourceOffset( uintmax_t& sourceOffset ) const;
 
-		virtual Result ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion ) override;
+	virtual Result ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion ) override;
 
-		virtual Result ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion ) override;
+	virtual Result ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion ) override;
 
-        virtual Result SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion ) override;
+	virtual Result SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion ) override;
 
-    private:
+private:
+	DocumentParameter<uintmax_t> m_dataOffset = DocumentParameter<uintmax_t>( DATA_OFFSET, TypeId() );
+	DocumentParameter<uintmax_t> m_sourceOffset = DocumentParameter<uintmax_t>( SOURCE_OFFSET, TypeId() );
 
-        DocumentParameter<uintmax_t> m_dataOffset = DocumentParameter<uintmax_t>( DATA_OFFSET, TypeId() );
-    	DocumentParameter<uintmax_t> m_sourceOffset = DocumentParameter<uintmax_t>( SOURCE_OFFSET, TypeId() );
-
-		DocumentParameter<std::filesystem::path> m_targetResourceRelativepath = DocumentParameter<std::filesystem::path>( TARGET_RESOURCE_RELATIVE_PATH, TypeId() );
-    };
+	DocumentParameter<std::filesystem::path> m_targetResourceRelativepath = DocumentParameter<std::filesystem::path>( TARGET_RESOURCE_RELATIVE_PATH, TypeId() );
+};
 
 
 }

--- a/src/ResourceInfo/ResourceGroupInfo.cpp
+++ b/src/ResourceInfo/ResourceGroupInfo.cpp
@@ -9,20 +9,19 @@
 namespace CarbonResources
 {
 
-    ResourceGroupInfo::ResourceGroupInfo( const ResourceGroupInfoParams& params ) :
-      ResourceInfo(params)
-    {
-		m_type = TypeId();
-    }
+ResourceGroupInfo::ResourceGroupInfo( const ResourceGroupInfoParams& params ) :
+	ResourceInfo( params )
+{
+	m_type = TypeId();
+}
 
-    ResourceGroupInfo::~ResourceGroupInfo()
-    {
+ResourceGroupInfo::~ResourceGroupInfo()
+{
+}
 
-    }
-
-    std::string ResourceGroupInfo::TypeId()
-    {
-		return "ResourceGroup";
-    }
+std::string ResourceGroupInfo::TypeId()
+{
+	return "ResourceGroup";
+}
 
 }

--- a/src/ResourceInfo/ResourceGroupInfo.h
+++ b/src/ResourceInfo/ResourceGroupInfo.h
@@ -8,21 +8,19 @@
 
 namespace CarbonResources
 {
-    struct ResourceGroupInfoParams : public ResourceInfoParams
-    {
+struct ResourceGroupInfoParams : public ResourceInfoParams
+{
+};
 
-    };
+class ResourceGroupInfo : public ResourceInfo
+{
+public:
+	ResourceGroupInfo( const ResourceGroupInfoParams& params );
 
-    class ResourceGroupInfo : public ResourceInfo
-    {
-    public:
-	    ResourceGroupInfo( const ResourceGroupInfoParams& params );
+	~ResourceGroupInfo();
 
-        ~ResourceGroupInfo();
-
-        static std::string TypeId( );
-
-    };
+	static std::string TypeId();
+};
 
 }
 

--- a/src/ResourceInfo/ResourceInfo.cpp
+++ b/src/ResourceInfo/ResourceInfo.cpp
@@ -21,1190 +21,1172 @@
 namespace CarbonResources
 {
 
-    std::string Location::CalculateLocationFromChecksums( const std::string& relativePathChecksum, const std::string& dataChecksum ) const
-    {
-		std::stringstream ss; 
-		ss << relativePathChecksum.substr( 0, 2 );
-		ss << "/";
-		ss << relativePathChecksum;
-		ss << "_";
-		ss << dataChecksum;
+std::string Location::CalculateLocationFromChecksums( const std::string& relativePathChecksum, const std::string& dataChecksum ) const
+{
+	std::stringstream ss;
+	ss << relativePathChecksum.substr( 0, 2 );
+	ss << "/";
+	ss << relativePathChecksum;
+	ss << "_";
+	ss << dataChecksum;
 
-        return ss.str();
-    }
+	return ss.str();
+}
 
-    Result Location::SetFromRelativePathAndDataChecksum(const std::filesystem::path& relativePath, const std::string& dataChecksum)
-    {
-		std::string relativePathChecksum = "";
+Result Location::SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum )
+{
+	std::string relativePathChecksum = "";
 
-		if( !ResourceTools::GenerateFowlerNollVoChecksum( relativePath.generic_string(), relativePathChecksum ) )
-		{
-			return Result{ ResultType::FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM };
-		}
+	if( !ResourceTools::GenerateFowlerNollVoChecksum( relativePath.generic_string(), relativePathChecksum ) )
+	{
+		return Result{ ResultType::FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM };
+	}
 
-		location = CalculateLocationFromChecksums( relativePathChecksum, dataChecksum );
+	location = CalculateLocationFromChecksums( relativePathChecksum, dataChecksum );
+
+	return Result{ ResultType::SUCCESS };
+}
+
+
+ResourceInfo::ResourceInfo( const ResourceInfoParams& params )
+{
+	m_relativePath = params.relativePath;
+
+	m_location = params.location;
+
+	m_type = TypeId();
+
+	m_checksum = params.checksum;
+
+	m_compressedSize = params.compressedSize;
+
+	m_uncompressedSize = params.uncompressedSize;
+
+	if( params.binaryOperation )
+	{
+		m_binaryOperation = params.binaryOperation;
+	}
+
+	if( !params.prefix.empty() )
+	{
+		m_prefix = params.prefix;
+	}
+	else
+	{
+		m_prefix.Reset();
+	}
+}
+
+ResourceInfo::~ResourceInfo()
+{
+}
+
+Result ResourceInfo::GetBinaryOperation( unsigned int& binaryOperation ) const
+{
+	if( !m_binaryOperation.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		binaryOperation = m_binaryOperation.GetValue();
 
 		return Result{ ResultType::SUCCESS };
-    }
+	}
+}
 
-
-    ResourceInfo::ResourceInfo( const ResourceInfoParams& params )
-    {
-		m_relativePath = params.relativePath;
-
-		m_location = params.location;
-
-        m_type = TypeId();
-		
-		m_checksum = params.checksum;
-
-		m_compressedSize = params.compressedSize;
-
-		m_uncompressedSize = params.uncompressedSize;
-
-    	if( params.binaryOperation )
-    	{
-    		m_binaryOperation = params.binaryOperation;
-    	}
-
-    	if( !params.prefix.empty() )
-    	{
-    		m_prefix = params.prefix;
-    	}
-    	else
-    	{
-    		m_prefix.Reset();
-    	}
-    }
-
-    ResourceInfo::~ResourceInfo()
-    {
-
-    }
-
-	Result ResourceInfo::GetBinaryOperation( unsigned int& binaryOperation ) const
+Result ResourceInfo::GetRelativePath( std::filesystem::path& relativePath ) const
+{
+	if( !m_relativePath.HasValue() )
 	{
-		if( !m_binaryOperation.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			binaryOperation = m_binaryOperation.GetValue();
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		relativePath = m_relativePath.GetValue();
 
-			return Result{ ResultType::SUCCESS };
-		}
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+void ResourceInfo::SetRelativePath( const std::filesystem::path& relativePath )
+{
+	m_relativePath = relativePath;
+}
+
+Result ResourceInfo::GetLocation( std::string& location ) const
+{
+	if( !m_location.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		location = m_location.GetValue().ToString();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result ResourceInfo::GetType( std::string& type ) const
+{
+	if( !m_type.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		type = m_type.GetValue();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result ResourceInfo::GetPrefix( std::string& prefix ) const
+{
+	if( !m_prefix.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		prefix = m_prefix.GetValue();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result ResourceInfo::GetChecksum( std::string& checksum ) const
+{
+	if( !m_checksum.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		checksum = m_checksum.GetValue();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result ResourceInfo::GetUncompressedSize( uintmax_t& uncompressedSize ) const
+{
+	if( !m_uncompressedSize.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		uncompressedSize = m_uncompressedSize.GetValue();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result ResourceInfo::GetCompressedSize( uintmax_t& compressedSize ) const
+{
+	if( !m_compressedSize.HasValue() )
+	{
+		return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
+	}
+	else
+	{
+		compressedSize = m_compressedSize.GetValue();
+
+		return Result{ ResultType::SUCCESS };
+	}
+}
+
+Result ResourceInfo::PutDataStream( ResourcePutDataStreamParams& params ) const
+{
+	if( !params.dataStream )
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
 	}
 
-    Result ResourceInfo::GetRelativePath(std::filesystem::path& relativePath) const
-    {
-        if (!m_relativePath.HasValue())
-        {
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-        }
-        else
-        {
-			relativePath = m_relativePath.GetValue();
-
-            return Result{ ResultType::SUCCESS };
-        }
-    }
-
-    void ResourceInfo::SetRelativePath( const std::filesystem::path& relativePath )
-    {
-		m_relativePath = relativePath;
-    }
-
-    Result ResourceInfo::GetLocation(std::string& location) const
-    {
-		if( !m_location.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			location = m_location.GetValue().ToString();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-    Result ResourceInfo::GetType(std::string& type) const
-    {
-		if( !m_type.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			type = m_type.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-    Result ResourceInfo::GetPrefix( std::string& prefix ) const
-    {
-		if( !m_prefix.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			prefix = m_prefix.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-    Result ResourceInfo::GetChecksum(std::string& checksum) const
-    {
-		if( !m_checksum.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			checksum = m_checksum.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-    Result ResourceInfo::GetUncompressedSize( uintmax_t& uncompressedSize ) const
-    {
-		if( !m_uncompressedSize.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			uncompressedSize = m_uncompressedSize.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-    Result ResourceInfo::GetCompressedSize( uintmax_t& compressedSize ) const
-    {
-		if( !m_compressedSize.HasValue() )
-		{
-			return Result{ ResultType::RESOURCE_VALUE_NOT_SET };
-		}
-		else
-		{
-			compressedSize = m_compressedSize.GetValue();
-
-			return Result{ ResultType::SUCCESS };
-		}
-    }
-
-    Result ResourceInfo::PutDataStream( ResourcePutDataStreamParams& params ) const
-    {
-		if( !params.dataStream )
-		{
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-
-        switch( params.resourceDestinationSettings.destinationType )
-		{
-		case ResourceDestinationType::LOCAL_RELATIVE:
-
-			return PutDataStreamLocalRelative( params );
-
-			break;
-
-		case ResourceDestinationType::LOCAL_CDN:
-
-			return PutDataStreamLocalCdn( params );
-
-			break;
-
-        case ResourceDestinationType::REMOTE_CDN:
-
-            return PutDataStreamRemoteCdn( params );
-
-		default:
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-    }
-   
-    Result ResourceInfo::PutData( ResourcePutDataParams& params ) const
-    {
-        if (!params.data)
-        {
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-        }
-
-        switch (params.resourceDestinationSettings.destinationType)
-        {
-		case ResourceDestinationType::LOCAL_RELATIVE:
-
-			return PutDataLocalRelative( params );
-
-			break;
-
-        case ResourceDestinationType::LOCAL_CDN:
-
-			return PutDataLocalCdn( params );
-		
-			break;
-
-        case ResourceDestinationType::REMOTE_CDN:
-
-            return PutDataRemoteCdn( params );
-
-			break;
-
-		default:
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-
-        }
-
-    }
-
-    Result ResourceInfo::PutDataLocalRelative( ResourcePutDataParams& params ) const
-    {
-		std::string& data = *params.data;
-
-		std::filesystem::path path = params.resourceDestinationSettings.basePath / m_relativePath.GetValue();
-
-        bool res = ResourceTools::SaveFile( path, data );
-
-        if (res)
-        {
-			return Result{ ResultType::SUCCESS };
-        }
-        else
-        {
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-        }
-
-    }
-
-    Result ResourceInfo::PutDataRemoteCdn( ResourcePutDataParams& params ) const
-    {
-		std::string& data = *params.data;
-
-		// Construct path
-		std::filesystem::path dataPath = params.resourceDestinationSettings.basePath / m_location.GetValue().ToString();
-
-        std::string compressedData;
-
-        if (!ResourceTools::GZipCompressData(data, compressedData))
-        {
-			return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
-        }
-
-        bool res = ResourceTools::SaveFile( dataPath, compressedData );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-    }
-
-    Result ResourceInfo::PutDataLocalCdn( ResourcePutDataParams& params ) const
-    {
-		std::string& data = *params.data;
-
-        // Construct path
-		std::filesystem::path dataPath = params.resourceDestinationSettings.basePath / m_location.GetValue().ToString();
-
-        bool res = ResourceTools::SaveFile( dataPath, data );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-
-    }
-
-    Result ResourceInfo::PutDataStreamLocalRelative( ResourcePutDataStreamParams& params ) const
-    {
-		std::filesystem::path path = params.resourceDestinationSettings.basePath / m_relativePath.GetValue();
-
-        bool res = params.dataStream->StartWrite( path );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-    }
-
-    Result ResourceInfo::PutDataStreamLocalCdn( ResourcePutDataStreamParams& params ) const
-    {
-		// Construct path
-		std::filesystem::path dataPath = params.resourceDestinationSettings.basePath / m_location.GetValue().ToString();
-
-		bool res = params.dataStream->StartWrite( dataPath );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			return Result{ ResultType::FAILED_TO_SAVE_FILE };
-		}
-    }
-
-    Result ResourceInfo::PutDataStreamRemoteCdn( ResourcePutDataStreamParams& params ) const
+	switch( params.resourceDestinationSettings.destinationType )
 	{
-        // Ensure the correct type has been passed to compress
-		ResourceTools::CompressedFileDataStreamOut* castTest = dynamic_cast<ResourceTools::CompressedFileDataStreamOut*>( params.dataStream );
+	case ResourceDestinationType::LOCAL_RELATIVE:
 
-        if (!castTest)
-        {
-			return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-        }
+		return PutDataStreamLocalRelative( params );
 
-        return PutDataStreamLocalCdn( params );
+		break;
+
+	case ResourceDestinationType::LOCAL_CDN:
+
+		return PutDataStreamLocalCdn( params );
+
+		break;
+
+	case ResourceDestinationType::REMOTE_CDN:
+
+		return PutDataStreamRemoteCdn( params );
+
+	default:
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutData( ResourcePutDataParams& params ) const
+{
+	if( !params.data )
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
 	}
 
+	switch( params.resourceDestinationSettings.destinationType )
+	{
+	case ResourceDestinationType::LOCAL_RELATIVE:
 
-    Result ResourceInfo::GetDataStream( ResourceGetDataStreamParams& params ) const
-    {
-		if( !params.dataStream )
+		return PutDataLocalRelative( params );
+
+		break;
+
+	case ResourceDestinationType::LOCAL_CDN:
+
+		return PutDataLocalCdn( params );
+
+		break;
+
+	case ResourceDestinationType::REMOTE_CDN:
+
+		return PutDataRemoteCdn( params );
+
+		break;
+
+	default:
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutDataLocalRelative( ResourcePutDataParams& params ) const
+{
+	std::string& data = *params.data;
+
+	std::filesystem::path path = params.resourceDestinationSettings.basePath / m_relativePath.GetValue();
+
+	bool res = ResourceTools::SaveFile( path, data );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutDataRemoteCdn( ResourcePutDataParams& params ) const
+{
+	std::string& data = *params.data;
+
+	// Construct path
+	std::filesystem::path dataPath = params.resourceDestinationSettings.basePath / m_location.GetValue().ToString();
+
+	std::string compressedData;
+
+	if( !ResourceTools::GZipCompressData( data, compressedData ) )
+	{
+		return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+	}
+
+	bool res = ResourceTools::SaveFile( dataPath, compressedData );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutDataLocalCdn( ResourcePutDataParams& params ) const
+{
+	std::string& data = *params.data;
+
+	// Construct path
+	std::filesystem::path dataPath = params.resourceDestinationSettings.basePath / m_location.GetValue().ToString();
+
+	bool res = ResourceTools::SaveFile( dataPath, data );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutDataStreamLocalRelative( ResourcePutDataStreamParams& params ) const
+{
+	std::filesystem::path path = params.resourceDestinationSettings.basePath / m_relativePath.GetValue();
+
+	bool res = params.dataStream->StartWrite( path );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutDataStreamLocalCdn( ResourcePutDataStreamParams& params ) const
+{
+	// Construct path
+	std::filesystem::path dataPath = params.resourceDestinationSettings.basePath / m_location.GetValue().ToString();
+
+	bool res = params.dataStream->StartWrite( dataPath );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		return Result{ ResultType::FAILED_TO_SAVE_FILE };
+	}
+}
+
+Result ResourceInfo::PutDataStreamRemoteCdn( ResourcePutDataStreamParams& params ) const
+{
+	// Ensure the correct type has been passed to compress
+	ResourceTools::CompressedFileDataStreamOut* castTest = dynamic_cast<ResourceTools::CompressedFileDataStreamOut*>( params.dataStream );
+
+	if( !castTest )
+	{
+		return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+	}
+
+	return PutDataStreamLocalCdn( params );
+}
+
+
+Result ResourceInfo::GetDataStream( ResourceGetDataStreamParams& params ) const
+{
+	if( !params.dataStream )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE, "Data Stream not provided." };
+	}
+
+	// GetDataStream attempts to retrieve resources from arbitary size number of base paths.
+	// Each failure adds to the error string
+	// If function ultimately ends in failure then all information of attempted locations are displayed
+	std::string errorString = "";
+
+	for( int i = 0; i < params.resourceSourceSettings.basePaths.size(); i++ )
+	{
+
+		switch( params.resourceSourceSettings.sourceType )
 		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE, "Data Stream not provided." };
-		}
+		case ResourceSourceType::LOCAL_RELATIVE: {
+			Result getDataStreamLocalRelativeResult = GetDataStreamLocalRelative( params, i );
 
-        // GetDataStream attempts to retrieve resources from arbitary size number of base paths.
-        // Each failure adds to the error string
-        // If function ultimately ends in failure then all information of attempted locations are displayed
-        std::string errorString = "";
-
-        for( int i = 0; i < params.resourceSourceSettings.basePaths.size(); i++ )
-		{
-
-			switch( params.resourceSourceSettings.sourceType )
+			if( getDataStreamLocalRelativeResult.type == ResultType::SUCCESS )
 			{
-			case ResourceSourceType::LOCAL_RELATIVE: 
-            {
-				Result getDataStreamLocalRelativeResult = GetDataStreamLocalRelative( params, i );
-
-                if( getDataStreamLocalRelativeResult.type == ResultType::SUCCESS )
-				{
-					return getDataStreamLocalRelativeResult;
-				}
-
-                errorString += getDataStreamLocalRelativeResult.info;
-				errorString += "\n";
-
-				break;
-			}
-			case ResourceSourceType::LOCAL_CDN: 
-            {
-				Result getDataStreamLocalCdnResult = GetDataStreamLocalCdn( params, i );
-
-                if( getDataStreamLocalCdnResult.type == ResultType::SUCCESS )
-				{
-					return getDataStreamLocalCdnResult;
-				}
-
-                errorString += getDataStreamLocalCdnResult.info;
-				errorString += "\n";
-
-				break;
+				return getDataStreamLocalRelativeResult;
 			}
 
-			case ResourceSourceType::REMOTE_CDN:
-            {
-				Result getDataStreamRemoteCdnResult = GetDataStreamRemoteCdn( params, i );
+			errorString += getDataStreamLocalRelativeResult.info;
+			errorString += "\n";
 
-                if( getDataStreamRemoteCdnResult.type == ResultType::SUCCESS )
-				{
-					return getDataStreamRemoteCdnResult;
-				}
+			break;
+		}
+		case ResourceSourceType::LOCAL_CDN: {
+			Result getDataStreamLocalCdnResult = GetDataStreamLocalCdn( params, i );
 
-                errorString += getDataStreamRemoteCdnResult.info;
-				errorString += "\n";
-
-				break;
-            }
-			default:
-
-				return Result{ ResultType::FAILED_TO_OPEN_FILE };
+			if( getDataStreamLocalCdnResult.type == ResultType::SUCCESS )
+			{
+				return getDataStreamLocalCdnResult;
 			}
+
+			errorString += getDataStreamLocalCdnResult.info;
+			errorString += "\n";
+
+			break;
 		}
 
-        return Result{ ResultType::FAILED_TO_OPEN_FILE, errorString };
-    }
+		case ResourceSourceType::REMOTE_CDN: {
+			Result getDataStreamRemoteCdnResult = GetDataStreamRemoteCdn( params, i );
 
-	Result ResourceInfo::GetData( ResourceGetDataParams& params ) const
-    {
-		if( params.data == nullptr )
-		{
+			if( getDataStreamRemoteCdnResult.type == ResultType::SUCCESS )
+			{
+				return getDataStreamRemoteCdnResult;
+			}
+
+			errorString += getDataStreamRemoteCdnResult.info;
+			errorString += "\n";
+
+			break;
+		}
+		default:
+
 			return Result{ ResultType::FAILED_TO_OPEN_FILE };
 		}
+	}
 
-        // GetDataStream attempts to retrieve resources from arbitary size number of base paths.
-		// Each failure adds to the error string
-		// If function ultimately ends in failure then all information of attempted locations are displayed
-		std::string errorString = "";
+	return Result{ ResultType::FAILED_TO_OPEN_FILE, errorString };
+}
 
-        for( int i = 0; i < params.resourceSourceSettings.basePaths.size(); i++ )
-        {
-			switch( params.resourceSourceSettings.sourceType )
-			{
-			case ResourceSourceType::LOCAL_RELATIVE:
-            {
-				Result getDataLocalRelativeResult = GetDataLocalRelative( params, i );
-
-                if (getDataLocalRelativeResult.type == ResultType::SUCCESS)
-                {
-					return getDataLocalRelativeResult;
-                }
-
-                errorString += getDataLocalRelativeResult.info;
-				errorString += "\n";
-
-				break;
-            }
-			case ResourceSourceType::LOCAL_CDN:
-            {
-				Result getDataLocalCdnResult = GetDataLocalCdn( params, i );
-
-                if( getDataLocalCdnResult.type == ResultType::SUCCESS )
-				{
-					return getDataLocalCdnResult;
-				}
-
-                errorString += getDataLocalCdnResult.info;
-				errorString += "\n";
-
-				break;
-            }
-			case ResourceSourceType::REMOTE_CDN:
-            {
-				Result getDataRemoteCdn = GetDataRemoteCdn( params, i );
-
-                if( getDataRemoteCdn.type == ResultType::SUCCESS )
-				{
-					return getDataRemoteCdn;
-				}
-
-				errorString += getDataRemoteCdn.info;
-				errorString += "\n";
-
-				break;
-			}
-			default:
-				return Result{ ResultType::FAILED_TO_OPEN_FILE };
-			}
-        }
-
-        return Result{ ResultType::FAILED_TO_OPEN_FILE, errorString };
-
-    }
-
-    Result ResourceInfo::GetDataLocalRelative( ResourceGetDataParams& params, const int basePathId ) const
-    {
-        if (basePathId >= params.resourceSourceSettings.basePaths.size())
-        {
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
-        }
-
-		std::string& data = *params.data;
-
-        std::filesystem::path dataPath = params.resourceSourceSettings.basePaths.at( basePathId ) / m_relativePath.GetValue();
-
-		bool res = ResourceTools::GetLocalFileData( dataPath, data );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			std::stringstream ss;
-
-			ss << "Failed to open file at: " << dataPath;
-
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
-		}
-    }
-
-    Result ResourceInfo::GetDataLocalCdn( ResourceGetDataParams& params, const int basePathId ) const
-    {
-		if( basePathId >= params.resourceSourceSettings.basePaths.size() )
-		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
-		}
-
-		std::string& data = *params.data;
-
-        // Construct path
-        std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
-
-		bool res = ResourceTools::GetLocalFileData( path, data );
-
-        if (res)
-        {
-			return Result{ ResultType::SUCCESS };
-        }
-        else
-        {
-			std::stringstream ss;
-
-			ss << "Failed to open file at: " << path << "\n Relative Path: " << m_relativePath.GetValue();
-
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
-
-        }
-    }
-
-	Result ResourceInfo::GetDataRemoteCdn( ResourceGetDataParams& params, const int basePathId ) const
-    {
-		if( basePathId >= params.resourceSourceSettings.basePaths.size() )
-		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
-		}
-
-		std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
-
-        std::filesystem::path tempPath = params.cacheBasePath / m_location.GetValue().ToString();
-
-        std::string url = path.string();
-
-		std::replace( url.begin(), url.end(), '\\', '/' );
-
-		bool haveFileCached{false};
-
-		if( std::filesystem::exists( tempPath ) )
-		{
-			if( ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
-			{
-				haveFileCached = true;
-			}
-			else
-			{
-				std::filesystem::remove( tempPath );
-			}
-		}
-
-		if( !haveFileCached )
-		{
-			ResourceTools::Downloader downloader;
-
-			bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadRetrySeconds );
-
-			if (!downloadFileResult)
-			{
-				std::stringstream ss;
-
-				ss << "Failed to download file \nfrom remote url: " << url << "\nto local path: " << tempPath.string();
-
-				return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
-			}
-
-			if( !params.expectedChecksum.empty() && !ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
-			{
-				return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, "The downloaded file does not have the expected checksum" };
-			}
-		}
-
-		ResourceGetDataParams localParams = params;
-
-        localParams.resourceSourceSettings.sourceType = ResourceSourceType::LOCAL_CDN;
-
-        localParams.resourceSourceSettings.basePaths.clear();
-
-        localParams.resourceSourceSettings.basePaths.push_back( params.cacheBasePath );
-
-        // Attempt locally now it has been downloaded
-		return GetDataLocalCdn( localParams, 0 );
-        
-
-    }
-
-    Result ResourceInfo::GetDataStreamLocalRelative( ResourceGetDataStreamParams& params, const int basePathId ) const
-    {
-		if( basePathId >= params.resourceSourceSettings.basePaths.size() )
-		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
-		}
-
-		std::filesystem::path dataPath = params.resourceSourceSettings.basePaths.at( basePathId ) / m_relativePath.GetValue();
-
-		bool res = params.dataStream->StartRead( dataPath );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			std::stringstream ss;
-
-			ss << "Failed to open file at: " << dataPath;
-
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
-		}
-    }
-
-    Result ResourceInfo::GetDataStreamLocalCdn( ResourceGetDataStreamParams& params, const int basePathId ) const
-    {
-		if( basePathId >= params.resourceSourceSettings.basePaths.size() )
-		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
-		}
-
-		// Construct path
-		std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
-
-		bool res = params.dataStream->StartRead( path );
-
-		if( res )
-		{
-			return Result{ ResultType::SUCCESS };
-		}
-		else
-		{
-			std::stringstream ss;
-
-			ss << "Failed to open file at: " << path << "\n Relative Path: " << m_relativePath.GetValue();
-
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
-		}
-    }
-
-    Result ResourceInfo::GetDataStreamRemoteCdn( ResourceGetDataStreamParams& params, const int basePathId ) const
-    {
-		if( basePathId >= params.resourceSourceSettings.basePaths.size() )
-		{
-			return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
-		}
-
-		std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
-
-		std::filesystem::path tempPath = params.cacheBasePath / m_location.GetValue().ToString();
-
-        std::string url = path.string();
-
-        std::replace( url.begin(), url.end(), '\\', '/' );
-		bool haveFileCached{false};
-
-		if( std::filesystem::exists( tempPath ) )
-		{
-			if( ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
-			{
-				haveFileCached = true;
-			}
-			else
-			{
-				std::filesystem::remove( tempPath );
-			}
-		}
-
-		if( !haveFileCached )
-		{
-			ResourceTools::Downloader downloader;
-
-			bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadRetrySeconds );
-
-			if (!downloadFileResult)
-			{
-				std::stringstream ss;
-
-				ss << "Failed to download file \nfrom remote url: " << url << "\nto local path: " << tempPath.string();
-
-				return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
-			}
-
-			if( !params.expectedChecksum.empty() && !ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
-			{
-				return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, "The downloaded file does not have the expected checksum" };
-			}
-		}
-
-        ResourceGetDataStreamParams localCdnParams = params;
-
-        localCdnParams.resourceSourceSettings.sourceType = ResourceSourceType::LOCAL_CDN;
-
-        localCdnParams.resourceSourceSettings.basePaths.clear();
-
-        localCdnParams.resourceSourceSettings.basePaths.push_back( params.cacheBasePath );
-
-        return GetDataStreamLocalCdn( localCdnParams, 0 );
-
-    }
-
-    Result ResourceInfo::ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion )
+Result ResourceInfo::GetData( ResourceGetDataParams& params ) const
+{
+	if( params.data == nullptr )
 	{
-    	if( m_binaryOperation.IsParameterExpectedInDocumentVersion( documentVersion ) )
-    	{
-    		if( YAML::Node parameter = resource[m_binaryOperation.GetTag()] )
-    		{
-    			m_binaryOperation = parameter.as<unsigned int>();
-    		}
-    		else
-    		{
-    			m_binaryOperation.Reset();
-    		}
-    	}
+		return Result{ ResultType::FAILED_TO_OPEN_FILE };
+	}
 
-		if( m_relativePath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	// GetDataStream attempts to retrieve resources from arbitary size number of base paths.
+	// Each failure adds to the error string
+	// If function ultimately ends in failure then all information of attempted locations are displayed
+	std::string errorString = "";
+
+	for( int i = 0; i < params.resourceSourceSettings.basePaths.size(); i++ )
+	{
+		switch( params.resourceSourceSettings.sourceType )
 		{
-			if( YAML::Node parameter = resource[m_relativePath.GetTag()] )
-            {
-				m_relativePath = parameter.as<std::string>();
-            }
-            else
-            {
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-            }
+		case ResourceSourceType::LOCAL_RELATIVE: {
+			Result getDataLocalRelativeResult = GetDataLocalRelative( params, i );
+
+			if( getDataLocalRelativeResult.type == ResultType::SUCCESS )
+			{
+				return getDataLocalRelativeResult;
+			}
+
+			errorString += getDataLocalRelativeResult.info;
+			errorString += "\n";
+
+			break;
 		}
+		case ResourceSourceType::LOCAL_CDN: {
+			Result getDataLocalCdnResult = GetDataLocalCdn( params, i );
 
-		if( m_location.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( YAML::Node parameter = resource[m_location.GetTag()] )
+			if( getDataLocalCdnResult.type == ResultType::SUCCESS )
 			{
-				m_location = parameter.as<std::string>();
+				return getDataLocalCdnResult;
 			}
-			else
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
+
+			errorString += getDataLocalCdnResult.info;
+			errorString += "\n";
+
+			break;
 		}
+		case ResourceSourceType::REMOTE_CDN: {
+			Result getDataRemoteCdn = GetDataRemoteCdn( params, i );
 
-        if( m_type.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( YAML::Node parameter = resource[m_type.GetTag()] )
+			if( getDataRemoteCdn.type == ResultType::SUCCESS )
 			{
-				m_type = parameter.as<std::string>();
+				return getDataRemoteCdn;
 			}
-			else
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
+
+			errorString += getDataRemoteCdn.info;
+			errorString += "\n";
+
+			break;
 		}
-
-		if( m_checksum.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( YAML::Node parameter = resource[m_checksum.GetTag()] )
-			{
-				m_checksum = parameter.as<std::string>();
-			}
-			else
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
+		default:
+			return Result{ ResultType::FAILED_TO_OPEN_FILE };
 		}
+	}
 
-		if( m_uncompressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( YAML::Node parameter = resource[m_uncompressedSize.GetTag()] )
-			{
-				m_uncompressedSize = parameter.as<uintmax_t>();
-			}
-			else
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
-		}
+	return Result{ ResultType::FAILED_TO_OPEN_FILE, errorString };
+}
 
-		if( m_compressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( YAML::Node parameter = resource[m_compressedSize.GetTag()] )
-			{
-				m_compressedSize = parameter.as<uintmax_t>();
-			}
-			else
-			{
-				return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-			}
+Result ResourceInfo::GetDataLocalRelative( ResourceGetDataParams& params, const int basePathId ) const
+{
+	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
+	}
 
-		}
+	std::string& data = *params.data;
 
-    	if( m_prefix.IsParameterExpectedInDocumentVersion( documentVersion ) )
-    	{
-    		YAML::Node parameter = resource[m_prefix.GetTag()];
-    		if( parameter.IsDefined() )
-    		{
-    			m_prefix = parameter.as<std::string>();
-    		}
-    	}
+	std::filesystem::path dataPath = params.resourceSourceSettings.basePaths.at( basePathId ) / m_relativePath.GetValue();
 
+	bool res = ResourceTools::GetLocalFileData( dataPath, data );
 
+	if( res )
+	{
 		return Result{ ResultType::SUCCESS };
 	}
-
-    std::string ResourceInfo::TypeId()
-    {
-		return "Resource";
-    }
-
-    Result ResourceInfo::SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion )
-    {
-        if (!other)
-        {
-			return Result{ ResultType::FAIL };
-        }
-
-        if (m_relativePath.IsParameterExpectedInDocumentVersion( documentVersion ))
-        {
-			std::filesystem::path relativePath;
-
-			Result getRelativePathResult = other->GetRelativePath( relativePath );
-
-			if( getRelativePathResult.type != ResultType::SUCCESS )
-			{
-				return getRelativePathResult;
-			}
-
-			m_relativePath = relativePath;
-        }
-        
-        if (m_location.IsParameterExpectedInDocumentVersion( documentVersion ))
-        {
-			std::string location;
-
-			Result getLocationResult = other->GetLocation( location );
-
-			if( getLocationResult.type != ResultType::SUCCESS )
-			{
-				return getLocationResult;
-			}
-
-			m_location = location;
-        }
-		
-        if (m_checksum.IsParameterExpectedInDocumentVersion( documentVersion ))
-        {
-			std::string checksum;
-
-			Result getChecksumResult = other->GetChecksum( checksum );
-
-			if( getChecksumResult.type != ResultType::SUCCESS )
-			{
-				return getChecksumResult;
-			}
-
-			m_checksum = checksum;
-        }
-        
-        if (m_uncompressedSize.IsParameterExpectedInDocumentVersion( documentVersion ))
-        {
-			uintmax_t uncompressedSize;
-
-			Result getUncompressedSizeResult = other->GetUncompressedSize( uncompressedSize );
-
-			if( getUncompressedSizeResult.type != ResultType::SUCCESS )
-			{
-				return getUncompressedSizeResult;
-			}
-
-			m_uncompressedSize = uncompressedSize;
-        }
-        
-        if (m_compressedSize.IsParameterExpectedInDocumentVersion( documentVersion ))
-        {
-			uintmax_t compressedSize;
-
-			Result getCompressedSizeResult = other->GetCompressedSize( compressedSize );
-
-			if( getCompressedSizeResult.type != ResultType::SUCCESS )
-			{
-				return getCompressedSizeResult;
-			}
-
-			m_compressedSize = compressedSize;
-        }
-
-        if( m_prefix.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			std::string prefix;
-
-			Result getPrefixResult = other->GetPrefix( prefix );
-
-            if( getPrefixResult.type == ResultType::SUCCESS )
-			{
-				m_prefix = prefix;
-			}
-            else
-            {
-                // Prefix is optional, value may not be set
-				if( getPrefixResult.type != ResultType::RESOURCE_VALUE_NOT_SET )
-				{
-					return getPrefixResult;
-				}
-                else
-                {
-					m_prefix.Reset();
-                }
-            }
-		}
-
-    	if (m_binaryOperation.IsParameterExpectedInDocumentVersion( documentVersion ))
-    	{
-    		unsigned int binaryOperation;
-
-    		Result getBinaryOperationResult = other->GetBinaryOperation( binaryOperation );
-
-    		if( getBinaryOperationResult.type != ResultType::SUCCESS )
-    		{
-    			if( getBinaryOperationResult.type == ResultType::RESOURCE_VALUE_NOT_SET )
-    			{
-    				m_binaryOperation.Reset();
-    				return Result{ ResultType::SUCCESS };
-    			}
-    			return getBinaryOperationResult;
-    		}
-			if( binaryOperation != 0 )
-			{
-				m_binaryOperation = binaryOperation;
-			}
-    		else
-    		{
-    			m_binaryOperation.Reset();
-    		}
-    	}
-
-        return Result{ ResultType::SUCCESS };
-    }
-
-    bool ResourceInfo::operator == ( const ResourceInfo* other ) const
+	else
 	{
-		if( !m_relativePath.HasValue() )
-		{
-			return false;
-		}
-		if( !other->m_relativePath.HasValue() )
-		{
-			return false;
-		}
-		// Equality is defined as having the same relative path, not same data
-		return ( m_relativePath.GetValue() == other->m_relativePath.GetValue() );
+		std::stringstream ss;
+
+		ss << "Failed to open file at: " << dataPath;
+
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
+	}
+}
+
+Result ResourceInfo::GetDataLocalCdn( ResourceGetDataParams& params, const int basePathId ) const
+{
+	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
 	}
 
-	bool ResourceInfo::operator < ( const ResourceInfo& other ) const
+	std::string& data = *params.data;
+
+	// Construct path
+	std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
+
+	bool res = ResourceTools::GetLocalFileData( path, data );
+
+	if( res )
 	{
-		if( !m_relativePath.HasValue() )
-		{
-			return other.m_relativePath.HasValue();
-		}
-		if( !other.m_relativePath.HasValue() )
-		{
-			return true;
-		}
-		// Equality is defined as having the same relative path, not same data
-		return m_relativePath.GetValue() < other.m_relativePath.GetValue();
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		std::stringstream ss;
+
+		ss << "Failed to open file at: " << path << "\n Relative Path: " << m_relativePath.GetValue();
+
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
+	}
+}
+
+Result ResourceInfo::GetDataRemoteCdn( ResourceGetDataParams& params, const int basePathId ) const
+{
+	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
 	}
 
-	Result ResourceInfo::UpdateLocation()
+	std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
+
+	std::filesystem::path tempPath = params.cacheBasePath / m_location.GetValue().ToString();
+
+	std::string url = path.string();
+
+	std::replace( url.begin(), url.end(), '\\', '/' );
+
+	bool haveFileCached{ false };
+
+	if( std::filesystem::exists( tempPath ) )
 	{
-        std::filesystem::path relativePath;
+		if( ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
+		{
+			haveFileCached = true;
+		}
+		else
+		{
+			std::filesystem::remove( tempPath );
+		}
+	}
 
-        Result getRelativePathResult = GetRelativePath( relativePath );
+	if( !haveFileCached )
+	{
+		ResourceTools::Downloader downloader;
 
-        if( getRelativePathResult.type != ResultType::SUCCESS )
-        {
+		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadRetrySeconds );
+
+		if( !downloadFileResult )
+		{
+			std::stringstream ss;
+
+			ss << "Failed to download file \nfrom remote url: " << url << "\nto local path: " << tempPath.string();
+
+			return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
+		}
+
+		if( !params.expectedChecksum.empty() && !ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
+		{
+			return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, "The downloaded file does not have the expected checksum" };
+		}
+	}
+
+	ResourceGetDataParams localParams = params;
+
+	localParams.resourceSourceSettings.sourceType = ResourceSourceType::LOCAL_CDN;
+
+	localParams.resourceSourceSettings.basePaths.clear();
+
+	localParams.resourceSourceSettings.basePaths.push_back( params.cacheBasePath );
+
+	// Attempt locally now it has been downloaded
+	return GetDataLocalCdn( localParams, 0 );
+}
+
+Result ResourceInfo::GetDataStreamLocalRelative( ResourceGetDataStreamParams& params, const int basePathId ) const
+{
+	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
+	}
+
+	std::filesystem::path dataPath = params.resourceSourceSettings.basePaths.at( basePathId ) / m_relativePath.GetValue();
+
+	bool res = params.dataStream->StartRead( dataPath );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		std::stringstream ss;
+
+		ss << "Failed to open file at: " << dataPath;
+
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
+	}
+}
+
+Result ResourceInfo::GetDataStreamLocalCdn( ResourceGetDataStreamParams& params, const int basePathId ) const
+{
+	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
+	}
+
+	// Construct path
+	std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
+
+	bool res = params.dataStream->StartRead( path );
+
+	if( res )
+	{
+		return Result{ ResultType::SUCCESS };
+	}
+	else
+	{
+		std::stringstream ss;
+
+		ss << "Failed to open file at: " << path << "\n Relative Path: " << m_relativePath.GetValue();
+
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, ss.str() };
+	}
+}
+
+Result ResourceInfo::GetDataStreamRemoteCdn( ResourceGetDataStreamParams& params, const int basePathId ) const
+{
+	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
+	{
+		return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM, "Internal component error" };
+	}
+
+	std::filesystem::path path = params.resourceSourceSettings.basePaths.at( basePathId ) / m_location.GetValue().ToString();
+
+	std::filesystem::path tempPath = params.cacheBasePath / m_location.GetValue().ToString();
+
+	std::string url = path.string();
+
+	std::replace( url.begin(), url.end(), '\\', '/' );
+	bool haveFileCached{ false };
+
+	if( std::filesystem::exists( tempPath ) )
+	{
+		if( ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
+		{
+			haveFileCached = true;
+		}
+		else
+		{
+			std::filesystem::remove( tempPath );
+		}
+	}
+
+	if( !haveFileCached )
+	{
+		ResourceTools::Downloader downloader;
+
+		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadRetrySeconds );
+
+		if( !downloadFileResult )
+		{
+			std::stringstream ss;
+
+			ss << "Failed to download file \nfrom remote url: " << url << "\nto local path: " << tempPath.string();
+
+			return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
+		}
+
+		if( !params.expectedChecksum.empty() && !ResourceTools::Md5ChecksumMatches( tempPath, params.expectedChecksum ) )
+		{
+			return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, "The downloaded file does not have the expected checksum" };
+		}
+	}
+
+	ResourceGetDataStreamParams localCdnParams = params;
+
+	localCdnParams.resourceSourceSettings.sourceType = ResourceSourceType::LOCAL_CDN;
+
+	localCdnParams.resourceSourceSettings.basePaths.clear();
+
+	localCdnParams.resourceSourceSettings.basePaths.push_back( params.cacheBasePath );
+
+	return GetDataStreamLocalCdn( localCdnParams, 0 );
+}
+
+Result ResourceInfo::ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion )
+{
+	if( m_binaryOperation.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_binaryOperation.GetTag()] )
+		{
+			m_binaryOperation = parameter.as<unsigned int>();
+		}
+		else
+		{
+			m_binaryOperation.Reset();
+		}
+	}
+
+	if( m_relativePath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_relativePath.GetTag()] )
+		{
+			m_relativePath = parameter.as<std::string>();
+		}
+		else
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+	}
+
+	if( m_location.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_location.GetTag()] )
+		{
+			m_location = parameter.as<std::string>();
+		}
+		else
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+	}
+
+	if( m_type.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_type.GetTag()] )
+		{
+			m_type = parameter.as<std::string>();
+		}
+		else
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+	}
+
+	if( m_checksum.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_checksum.GetTag()] )
+		{
+			m_checksum = parameter.as<std::string>();
+		}
+		else
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+	}
+
+	if( m_uncompressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_uncompressedSize.GetTag()] )
+		{
+			m_uncompressedSize = parameter.as<uintmax_t>();
+		}
+		else
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+	}
+
+	if( m_compressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( YAML::Node parameter = resource[m_compressedSize.GetTag()] )
+		{
+			m_compressedSize = parameter.as<uintmax_t>();
+		}
+		else
+		{
+			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+		}
+	}
+
+	if( m_prefix.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		YAML::Node parameter = resource[m_prefix.GetTag()];
+		if( parameter.IsDefined() )
+		{
+			m_prefix = parameter.as<std::string>();
+		}
+	}
+
+
+	return Result{ ResultType::SUCCESS };
+}
+
+std::string ResourceInfo::TypeId()
+{
+	return "Resource";
+}
+
+Result ResourceInfo::SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion )
+{
+	if( !other )
+	{
+		return Result{ ResultType::FAIL };
+	}
+
+	if( m_relativePath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		std::filesystem::path relativePath;
+
+		Result getRelativePathResult = other->GetRelativePath( relativePath );
+
+		if( getRelativePathResult.type != ResultType::SUCCESS )
+		{
 			return getRelativePathResult;
-        }
-
-        Location l;
-
-		Result setLocationResult = l.SetFromRelativePathAndDataChecksum( relativePath, m_checksum.GetValue() );
-
-        if (setLocationResult.type != ResultType::SUCCESS)
-        {
-			return setLocationResult;
-        }
-
-		m_location = l;
-    	return Result({ ResultType::SUCCESS } );
-	}
-
-    Result ResourceInfo::SetParametersFromData( const std::string& data )
-    {
-        std::string checksum;
-
-		if( !ResourceTools::GenerateMd5Checksum( data, checksum ) )
-		{
-			return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
 		}
 
-    	SetDataChecksum( checksum );
+		m_relativePath = relativePath;
+	}
 
-        std::string type;
-
-        Result getTypeResult = GetType( type );
-
-        if( getTypeResult.type != ResultType::SUCCESS )
-        {
-			return getTypeResult;
-        }
-
-        std::string compressedData;
-
-        if (!ResourceTools::GZipCompressData(data, compressedData))
-        {
-			return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
-        }
-
-        m_compressedSize = compressedData.size();
-
-        m_uncompressedSize = data.size();
-
-        return Result{ ResultType::SUCCESS };
-        
-    }
-
-	Result ResourceInfo::SetParametersFromSourceStream( ResourceTools::FileDataStreamIn& stream, size_t matchSize )
+	if( m_location.IsParameterExpectedInDocumentVersion( documentVersion ) )
 	{
-		std::string chunk;
+		std::string location;
+
+		Result getLocationResult = other->GetLocation( location );
+
+		if( getLocationResult.type != ResultType::SUCCESS )
+		{
+			return getLocationResult;
+		}
+
+		m_location = location;
+	}
+
+	if( m_checksum.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
 		std::string checksum;
 
-    	m_uncompressedSize = matchSize;
+		Result getChecksumResult = other->GetChecksum( checksum );
 
-    	auto start = stream.GetCurrentPosition();
+		if( getChecksumResult.type != ResultType::SUCCESS )
+		{
+			return getChecksumResult;
+		}
 
-    	ResourceTools::Md5ChecksumStream md5ChecksumStream;
-    	while(matchSize)
-    	{
-
-    		stream >> chunk;
-    		size_t chunkSize = chunk.size() > matchSize ? matchSize : chunk.size();
-    		md5ChecksumStream << chunk.substr( chunkSize );
-    		matchSize -= chunkSize;
-    		if(!chunkSize)
-    		{
-				return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-    		}
-    	}
-
-    	if (!md5ChecksumStream.FinishAndRetrieve(checksum))
-    	{
-    		stream.Seek( start );
-			return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-    	}
-
-    	m_checksum = checksum;
-    	stream.Seek( start );
-		return Result{ ResultType::SUCCESS };
+		m_checksum = checksum;
 	}
 
-    Result ResourceInfo::ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion )
+	if( m_uncompressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
 	{
-		// Relative path
-		if( m_relativePath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+		uintmax_t uncompressedSize;
+
+		Result getUncompressedSizeResult = other->GetUncompressedSize( uncompressedSize );
+
+		if( getUncompressedSizeResult.type != ResultType::SUCCESS )
 		{
-			if( !m_relativePath.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
-
-            std::filesystem::path relativePath;
-
-            Result getRelativePathResult = GetRelativePath( relativePath );
-
-            if (getRelativePathResult.type != ResultType::SUCCESS)
-            {
-				return getRelativePathResult;
-            }
-
-            std::string relativePathStr = relativePath.string();
-			std::replace( relativePathStr.begin(), relativePathStr.end(), '\\', '/' );
-
-			out << YAML::Key << m_relativePath.GetTag();
-			out << YAML::Value << relativePathStr;
+			return getUncompressedSizeResult;
 		}
 
-        // Type
-		if( m_type.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_type.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
+		m_uncompressedSize = uncompressedSize;
+	}
 
-			out << YAML::Key << m_type.GetTag();
-			out << YAML::Value << m_type.GetValue();
+	if( m_compressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		uintmax_t compressedSize;
+
+		Result getCompressedSizeResult = other->GetCompressedSize( compressedSize );
+
+		if( getCompressedSizeResult.type != ResultType::SUCCESS )
+		{
+			return getCompressedSizeResult;
 		}
 
-        // Location
-		if( m_location.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_location.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
+		m_compressedSize = compressedSize;
+	}
 
-			out << YAML::Key << m_location.GetTag();
-			out << YAML::Value << m_location.GetValue().ToString();
+	if( m_prefix.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		std::string prefix;
+
+		Result getPrefixResult = other->GetPrefix( prefix );
+
+		if( getPrefixResult.type == ResultType::SUCCESS )
+		{
+			m_prefix = prefix;
+		}
+		else
+		{
+			// Prefix is optional, value may not be set
+			if( getPrefixResult.type != ResultType::RESOURCE_VALUE_NOT_SET )
+			{
+				return getPrefixResult;
+			}
+			else
+			{
+				m_prefix.Reset();
+			}
+		}
+	}
+
+	if( m_binaryOperation.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		unsigned int binaryOperation;
+
+		Result getBinaryOperationResult = other->GetBinaryOperation( binaryOperation );
+
+		if( getBinaryOperationResult.type != ResultType::SUCCESS )
+		{
+			if( getBinaryOperationResult.type == ResultType::RESOURCE_VALUE_NOT_SET )
+			{
+				m_binaryOperation.Reset();
+				return Result{ ResultType::SUCCESS };
+			}
+			return getBinaryOperationResult;
+		}
+		if( binaryOperation != 0 )
+		{
+			m_binaryOperation = binaryOperation;
+		}
+		else
+		{
+			m_binaryOperation.Reset();
+		}
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+bool ResourceInfo::operator==( const ResourceInfo* other ) const
+{
+	if( !m_relativePath.HasValue() )
+	{
+		return false;
+	}
+	if( !other->m_relativePath.HasValue() )
+	{
+		return false;
+	}
+	// Equality is defined as having the same relative path, not same data
+	return ( m_relativePath.GetValue() == other->m_relativePath.GetValue() );
+}
+
+bool ResourceInfo::operator<( const ResourceInfo& other ) const
+{
+	if( !m_relativePath.HasValue() )
+	{
+		return other.m_relativePath.HasValue();
+	}
+	if( !other.m_relativePath.HasValue() )
+	{
+		return true;
+	}
+	// Equality is defined as having the same relative path, not same data
+	return m_relativePath.GetValue() < other.m_relativePath.GetValue();
+}
+
+Result ResourceInfo::UpdateLocation()
+{
+	std::filesystem::path relativePath;
+
+	Result getRelativePathResult = GetRelativePath( relativePath );
+
+	if( getRelativePathResult.type != ResultType::SUCCESS )
+	{
+		return getRelativePathResult;
+	}
+
+	Location l;
+
+	Result setLocationResult = l.SetFromRelativePathAndDataChecksum( relativePath, m_checksum.GetValue() );
+
+	if( setLocationResult.type != ResultType::SUCCESS )
+	{
+		return setLocationResult;
+	}
+
+	m_location = l;
+	return Result( { ResultType::SUCCESS } );
+}
+
+Result ResourceInfo::SetParametersFromData( const std::string& data )
+{
+	std::string checksum;
+
+	if( !ResourceTools::GenerateMd5Checksum( data, checksum ) )
+	{
+		return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+	}
+
+	SetDataChecksum( checksum );
+
+	std::string type;
+
+	Result getTypeResult = GetType( type );
+
+	if( getTypeResult.type != ResultType::SUCCESS )
+	{
+		return getTypeResult;
+	}
+
+	std::string compressedData;
+
+	if( !ResourceTools::GZipCompressData( data, compressedData ) )
+	{
+		return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+	}
+
+	m_compressedSize = compressedData.size();
+
+	m_uncompressedSize = data.size();
+
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceInfo::SetParametersFromSourceStream( ResourceTools::FileDataStreamIn& stream, size_t matchSize )
+{
+	std::string chunk;
+	std::string checksum;
+
+	m_uncompressedSize = matchSize;
+
+	auto start = stream.GetCurrentPosition();
+
+	ResourceTools::Md5ChecksumStream md5ChecksumStream;
+	while( matchSize )
+	{
+
+		stream >> chunk;
+		size_t chunkSize = chunk.size() > matchSize ? matchSize : chunk.size();
+		md5ChecksumStream << chunk.substr( chunkSize );
+		matchSize -= chunkSize;
+		if( !chunkSize )
+		{
+			return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+		}
+	}
+
+	if( !md5ChecksumStream.FinishAndRetrieve( checksum ) )
+	{
+		stream.Seek( start );
+		return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+	}
+
+	m_checksum = checksum;
+	stream.Seek( start );
+	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceInfo::ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion )
+{
+	// Relative path
+	if( m_relativePath.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_relativePath.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
 		}
 
-		// Checksum
-		if( m_checksum.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_checksum.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
+		std::filesystem::path relativePath;
 
-			out << YAML::Key << m_checksum.GetTag();
-			out << YAML::Value << m_checksum.GetValue();
+		Result getRelativePathResult = GetRelativePath( relativePath );
+
+		if( getRelativePathResult.type != ResultType::SUCCESS )
+		{
+			return getRelativePathResult;
 		}
 
-		if( m_uncompressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_uncompressedSize.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
+		std::string relativePathStr = relativePath.string();
+		std::replace( relativePathStr.begin(), relativePathStr.end(), '\\', '/' );
 
-			out << YAML::Key << m_uncompressedSize.GetTag();
-			out << YAML::Value << m_uncompressedSize.GetValue();
+		out << YAML::Key << m_relativePath.GetTag();
+		out << YAML::Value << relativePathStr;
+	}
+
+	// Type
+	if( m_type.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_type.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
 		}
 
-        // Compressed Size
-		if( m_compressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			if( !m_compressedSize.HasValue() )
-			{
-				return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-			}
+		out << YAML::Key << m_type.GetTag();
+		out << YAML::Value << m_type.GetValue();
+	}
 
-			out << YAML::Key << m_compressedSize.GetTag();
-			out << YAML::Value << m_compressedSize.GetValue();
+	// Location
+	if( m_location.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_location.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
 		}
 
-    	// Binary Operation
-    	if( m_binaryOperation.IsParameterExpectedInDocumentVersion( documentVersion ) )
-    	{
-    		// This is an optional field
-    		if( m_binaryOperation.HasValue() )
-    		{
-    			out << YAML::Key << m_binaryOperation.GetTag();
-    			out << YAML::Value << m_binaryOperation.GetValue();
-    		}
-    	}
+		out << YAML::Key << m_location.GetTag();
+		out << YAML::Value << m_location.GetValue().ToString();
+	}
 
-    	if( m_prefix.IsParameterExpectedInDocumentVersion( documentVersion ) )
-    	{
-    		// This is an optional field
-    		if( m_prefix.HasValue() )
-    		{
-    			out << YAML::Key << m_prefix.GetTag();
-    			out << YAML::Value << m_prefix.GetValue();
-    		}
-    	}
+	// Checksum
+	if( m_checksum.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_checksum.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+		}
 
-        /*
+		out << YAML::Key << m_checksum.GetTag();
+		out << YAML::Value << m_checksum.GetValue();
+	}
+
+	if( m_uncompressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_uncompressedSize.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+		}
+
+		out << YAML::Key << m_uncompressedSize.GetTag();
+		out << YAML::Value << m_uncompressedSize.GetValue();
+	}
+
+	// Compressed Size
+	if( m_compressedSize.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		if( !m_compressedSize.HasValue() )
+		{
+			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+		}
+
+		out << YAML::Key << m_compressedSize.GetTag();
+		out << YAML::Value << m_compressedSize.GetValue();
+	}
+
+	// Binary Operation
+	if( m_binaryOperation.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		// This is an optional field
+		if( m_binaryOperation.HasValue() )
+		{
+			out << YAML::Key << m_binaryOperation.GetTag();
+			out << YAML::Value << m_binaryOperation.GetValue();
+		}
+	}
+
+	if( m_prefix.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		// This is an optional field
+		if( m_prefix.HasValue() )
+		{
+			out << YAML::Key << m_prefix.GetTag();
+			out << YAML::Value << m_prefix.GetValue();
+		}
+	}
+
+	/*
         // Clean this up after ABI thought exercises finished
 
 
@@ -1220,97 +1202,97 @@ namespace CarbonResources
 		}
         */
 
-		return Result{ ResultType::SUCCESS };
-	}
+	return Result{ ResultType::SUCCESS };
+}
 
-	void ResourceInfo::SetDataChecksum( const std::string& checksum )
-    {
-	    m_checksum = checksum;
+void ResourceInfo::SetDataChecksum( const std::string& checksum )
+{
+	m_checksum = checksum;
 
-    	UpdateLocation();
-    }
+	UpdateLocation();
+}
 
-	void ResourceInfo::SetCompressedSize( uintmax_t compressedSize )
-    {
-	    m_compressedSize = compressedSize;
-    }
+void ResourceInfo::SetCompressedSize( uintmax_t compressedSize )
+{
+	m_compressedSize = compressedSize;
+}
 
-	void ResourceInfo::SetUncompressedSize( uintmax_t uncompressedSize )
+void ResourceInfo::SetUncompressedSize( uintmax_t uncompressedSize )
+{
+	m_uncompressedSize = uncompressedSize;
+}
+
+
+Result ResourceInfo::ExportToCsv( std::string& out, const VersionInternal& documentVersion )
+{
+	std::stringstream result;
+
+	if( m_prefix.HasValue() )
 	{
-		m_uncompressedSize = uncompressedSize;
+		result << m_prefix.GetValue() << ":/";
 	}
 
+	// Relative path
+	if( !m_relativePath.HasValue() )
+	{
+		return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+	}
 
-    Result ResourceInfo::ExportToCsv( std::string& out, const VersionInternal& documentVersion )
-    {
-    	std::stringstream result;
+	std::filesystem::path relativePath;
 
-    	if( m_prefix.HasValue() )
-    	{
-    		result << m_prefix.GetValue() << ":/";
-    	}
+	Result getRelativePathResult = GetRelativePath( relativePath );
 
-    	// Relative path
-		if( !m_relativePath.HasValue() )
-		{
-			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-		}
+	if( getRelativePathResult.type != ResultType::SUCCESS )
+	{
+		return getRelativePathResult;
+	}
 
-        std::filesystem::path relativePath;
+	std::string relativePathStr = relativePath.string();
+	std::replace( relativePathStr.begin(), relativePathStr.end(), '\\', '/' );
 
-        Result getRelativePathResult = GetRelativePath( relativePath );
-
-        if (getRelativePathResult.type != ResultType::SUCCESS)
-        {
-			return getRelativePathResult;
-        }
-
-        std::string relativePathStr = relativePath.string();
-		std::replace( relativePathStr.begin(), relativePathStr.end(), '\\', '/' );
-
-		result << relativePathStr << ",";
+	result << relativePathStr << ",";
 
 
-        // Location
-		if( !m_location.HasValue() )
-		{
-			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-		}
+	// Location
+	if( !m_location.HasValue() )
+	{
+		return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+	}
 
-		result << m_location.GetValue().ToString() << ",";
+	result << m_location.GetValue().ToString() << ",";
 
-		// Checksum
-		if( !m_checksum.HasValue() )
-		{
-			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-		}
+	// Checksum
+	if( !m_checksum.HasValue() )
+	{
+		return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+	}
 
-		result << m_checksum.GetValue() << ",";
+	result << m_checksum.GetValue() << ",";
 
-		if( !m_uncompressedSize.HasValue() )
-		{
-			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-		}
+	if( !m_uncompressedSize.HasValue() )
+	{
+		return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+	}
 
-		result << m_uncompressedSize.GetValue() << ",";
+	result << m_uncompressedSize.GetValue() << ",";
 
-        // Compressed Size
-		if( !m_compressedSize.HasValue() )
-		{
-			return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
-		}
+	// Compressed Size
+	if( !m_compressedSize.HasValue() )
+	{
+		return Result{ ResultType::REQUIRED_RESOURCE_PARAMETER_NOT_SET };
+	}
 
-		result << m_compressedSize.GetValue(); // End of required fields
+	result << m_compressedSize.GetValue(); // End of required fields
 
-    	// This is an optional field
-    	if( m_binaryOperation.HasValue() )
-    	{
-    		result << "," << m_binaryOperation.GetValue();
-    	}
+	// This is an optional field
+	if( m_binaryOperation.HasValue() )
+	{
+		result << "," << m_binaryOperation.GetValue();
+	}
 
-    	out = result.str();
+	out = result.str();
 
-		return Result{ ResultType::SUCCESS };
-    }
+	return Result{ ResultType::SUCCESS };
+}
 
 }

--- a/src/ResourceInfo/ResourceInfo.h
+++ b/src/ResourceInfo/ResourceInfo.h
@@ -9,7 +9,7 @@
 #include <optional>
 #include <vector>
 #include <filesystem>
-#include<yaml-cpp/yaml.h>
+#include <yaml-cpp/yaml.h>
 #include "Enums.h"
 #include "ResourceGroup.h"
 #include "../VersionInternal.h"
@@ -17,393 +17,391 @@
 
 namespace ResourceTools
 {
-    class FileDataStreamIn;
-    class FileDataStreamOut;
+class FileDataStreamIn;
+class FileDataStreamOut;
 }
 
 namespace CarbonResources
 {
-	class VersionedParameter
+class VersionedParameter
+{
+public:
+	VersionedParameter( Parameter parameter, std::string context ) :
+		m_parameter( parameter ), m_context( std::move( context ) )
 	{
-	public:
-		VersionedParameter( Parameter parameter, std::string context ) : m_parameter( parameter ), m_context(std::move( context ))
-		{
-			const ParameterInfo* info = GetParameterInfo( parameter );
-			m_tag = info->m_tag;
-		};
-
-		bool IsParameterExpectedInDocumentVersion( VersionInternal documentVersion ) const
-		{
-			return IsParameterExpected( m_parameter, m_context, documentVersion );
-		}
-
-	    std::string GetTag() const
-	    {
-		    return m_tag;
-	    }
-
-	protected:
-	    std::string m_tag;
-		std::string m_context;
-		Parameter m_parameter;
+		const ParameterInfo* info = GetParameterInfo( parameter );
+		m_tag = info->m_tag;
 	};
 
-    template <typename T>
-    class DocumentParameter : public VersionedParameter
-    {
-    public:
-	    DocumentParameter( Parameter parameter, const std::string& context ) :
-		    VersionedParameter( parameter, context )
-	    {
-	    }
-
-	    void operator=( T value )
-	    {
-		    m_value = value;
-	    }
-
-	    T GetValue() const
-	    {
-		    return m_value.value();
-	    }
-
-	    bool HasValue() const
-	    {
-            
-		    return m_value.has_value();
-	    }
-
-        void Reset()
-        {
-			m_value.reset();
-        }
-
-    protected:
-	    std::optional<T> m_value;
-    };
-
-    template <typename T>
-    class DocumentParameterCollection : public DocumentParameter<std::vector<T>*>
-    {
-    public:
-	    DocumentParameterCollection(Parameter parameter, const std::string& context ) :
-		    DocumentParameter<std::vector<T>*>( parameter, context )
-	    {
-		    this->m_value = &m_collection;
-	    }
-
-	    void PushBack( T attribute )
-	    {
-		    m_collection.push_back( attribute );
-	    }
-
-        void Clear()
-        {
-            m_collection.clear();
-        }
-
-        size_t GetSize() const
-        {
-			return m_collection.size();
-        }
-
-        T At(unsigned int index)
-		{
-			return m_collection.at( index );
-		}
-
-        typename std::vector<T>::iterator Find( const T other )
-		{
-            for (auto iter = m_collection.begin(); iter != m_collection.end(); iter++)
-            {
-				T attribute = (*iter);
-
-                if( attribute->operator==( other ) ) // This is assuming pointers again, not allowed
-				{
-					return iter;
-				}
-            }
-
-            return m_collection.end();
-		}
-
-        bool Contains( const T other )
-		{
-            for (T attribute : m_collection)
-            {
-				if( attribute->operator==(other) )  // This is assuming pointers again, not allowed
-                {
-					return true;
-                }
-            }
-
-			return false;
-        }
-
-        void Erase( typename std::vector<T>::const_iterator attributeIterator )
-		{
-			m_collection.erase( attributeIterator );
-		}
-
-	    void Remove( typename std::vector<T>::const_iterator attributeIterator )
-	    {
-			delete( *attributeIterator );
-			
-		    m_collection.erase( attributeIterator );
-	    }
-
-	    typename std::vector<T>::iterator begin()
-	    {
-		    return m_collection.begin();
-	    }
-
-	    typename std::vector<T>::const_iterator begin() const
-	    {
-		    return m_collection.begin();
-	    }
-
-	    typename std::vector<T>::const_iterator cbegin()
-	    {
-		    return m_collection.begin();
-	    }
-
-	    typename std::vector<T>::iterator end()
-	    {
-		    return m_collection.end();
-	    }
-
-	    typename std::vector<T>::const_iterator end() const
-	    {
-		    return m_collection.end();
-	    }
-
-	    typename std::vector<T>::const_iterator cend()
-	    {
-		    return m_collection.end();
-	    }
-
-    protected:
-	    std::vector<T> m_collection;
-    };
-
-    class Location
+	bool IsParameterExpectedInDocumentVersion( VersionInternal documentVersion ) const
 	{
-	public:
-		Location()
+		return IsParameterExpected( m_parameter, m_context, documentVersion );
+	}
+
+	std::string GetTag() const
+	{
+		return m_tag;
+	}
+
+protected:
+	std::string m_tag;
+	std::string m_context;
+	Parameter m_parameter;
+};
+
+template <typename T>
+class DocumentParameter : public VersionedParameter
+{
+public:
+	DocumentParameter( Parameter parameter, const std::string& context ) :
+		VersionedParameter( parameter, context )
+	{
+	}
+
+	void operator=( T value )
+	{
+		m_value = value;
+	}
+
+	T GetValue() const
+	{
+		return m_value.value();
+	}
+
+	bool HasValue() const
+	{
+
+		return m_value.has_value();
+	}
+
+	void Reset()
+	{
+		m_value.reset();
+	}
+
+protected:
+	std::optional<T> m_value;
+};
+
+template <typename T>
+class DocumentParameterCollection : public DocumentParameter<std::vector<T>*>
+{
+public:
+	DocumentParameterCollection( Parameter parameter, const std::string& context ) :
+		DocumentParameter<std::vector<T>*>( parameter, context )
+	{
+		this->m_value = &m_collection;
+	}
+
+	void PushBack( T attribute )
+	{
+		m_collection.push_back( attribute );
+	}
+
+	void Clear()
+	{
+		m_collection.clear();
+	}
+
+	size_t GetSize() const
+	{
+		return m_collection.size();
+	}
+
+	T At( unsigned int index )
+	{
+		return m_collection.at( index );
+	}
+
+	typename std::vector<T>::iterator Find( const T other )
+	{
+		for( auto iter = m_collection.begin(); iter != m_collection.end(); iter++ )
 		{
+			T attribute = ( *iter );
+
+			if( attribute->operator==( other ) ) // This is assuming pointers again, not allowed
+			{
+				return iter;
+			}
 		}
 
-		Location( const std::string inLocation ) :
-			location( inLocation )
+		return m_collection.end();
+	}
+
+	bool Contains( const T other )
+	{
+		for( T attribute : m_collection )
 		{
+			if( attribute->operator==( other ) ) // This is assuming pointers again, not allowed
+			{
+				return true;
+			}
 		}
 
-		Result SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum );
+		return false;
+	}
 
-        std::string ToString()
-        {
-			return location;
-        }
-
-    private:
-
-        std::string CalculateLocationFromChecksums( const std::string& relativePathChecksum, const std::string& dataChecksum ) const;
-
-	private:
-
-		std::string location = "";
-	};
-
-
-    struct ResourceInfoParams
+	void Erase( typename std::vector<T>::const_iterator attributeIterator )
 	{
-		std::filesystem::path relativePath;
+		m_collection.erase( attributeIterator );
+	}
 
-		std::string location = "";
-
-		std::string checksum = "";
-
-		uintmax_t compressedSize = 0;
-
-		uintmax_t uncompressedSize = 0;
-
-    	uint32_t binaryOperation = 0;
-
-    	std::string prefix;
-	};
-
-    struct ResourceGetDataStreamParams
+	void Remove( typename std::vector<T>::const_iterator attributeIterator )
 	{
-		ResourceSourceSettings resourceSourceSettings;
+		delete( *attributeIterator );
 
-		std::shared_ptr<ResourceTools::FileDataStreamIn> dataStream;
+		m_collection.erase( attributeIterator );
+	}
 
-        std::filesystem::path cacheBasePath = "cache";
-
-		std::string expectedChecksum = "";
-
-    	std::chrono::seconds downloadRetrySeconds{120};
-	};
-
-    struct ResourceGetDataParams
+	typename std::vector<T>::iterator begin()
 	{
-		ResourceSourceSettings resourceSourceSettings;
+		return m_collection.begin();
+	}
 
-		std::string* data = nullptr;
-
-        std::filesystem::path cacheBasePath = "cache";
-
-        std::string expectedChecksum = "";
-
-    	std::chrono::seconds downloadRetrySeconds{120};
-	};
-
-    struct ResourcePutDataStreamParams
+	typename std::vector<T>::const_iterator begin() const
 	{
-		ResourceDestinationSettings resourceDestinationSettings;
+		return m_collection.begin();
+	}
 
-		ResourceTools::FileDataStreamOut* dataStream = nullptr;
-	};
-
-    struct ResourcePutDataParams
+	typename std::vector<T>::const_iterator cbegin()
 	{
-		ResourceDestinationSettings resourceDestinationSettings;
+		return m_collection.begin();
+	}
 
-		std::string* data = nullptr;
-	};
+	typename std::vector<T>::iterator end()
+	{
+		return m_collection.end();
+	}
+
+	typename std::vector<T>::const_iterator end() const
+	{
+		return m_collection.end();
+	}
+
+	typename std::vector<T>::const_iterator cend()
+	{
+		return m_collection.end();
+	}
+
+protected:
+	std::vector<T> m_collection;
+};
+
+class Location
+{
+public:
+	Location()
+	{
+	}
+
+	Location( const std::string inLocation ) :
+		location( inLocation )
+	{
+	}
+
+	Result SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum );
+
+	std::string ToString()
+	{
+		return location;
+	}
+
+private:
+	std::string CalculateLocationFromChecksums( const std::string& relativePathChecksum, const std::string& dataChecksum ) const;
+
+private:
+	std::string location = "";
+};
 
 
-    class ResourceInfo
-    {
-    public:
-	    ResourceInfo( const ResourceInfoParams& params );
+struct ResourceInfoParams
+{
+	std::filesystem::path relativePath;
 
-	    virtual ~ResourceInfo();
+	std::string location = "";
 
-	    void SetRelativePath( const std::filesystem::path& relativePath );
+	std::string checksum = "";
 
-    	Result GetBinaryOperation( unsigned int& binaryOperation ) const;
+	uintmax_t compressedSize = 0;
 
-		Result GetRelativePath(std::filesystem::path& relativePath) const;
+	uintmax_t uncompressedSize = 0;
 
-	    Result GetLocation(std::string& location) const;
+	uint32_t binaryOperation = 0;
 
-        Result GetType(std::string& type) const;
+	std::string prefix;
+};
 
-        Result GetPrefix( std::string& prefix ) const;
+struct ResourceGetDataStreamParams
+{
+	ResourceSourceSettings resourceSourceSettings;
 
-	    Result GetChecksum(std::string& checksum) const;
+	std::shared_ptr<ResourceTools::FileDataStreamIn> dataStream;
 
-	    Result GetUncompressedSize( uintmax_t& uncompressedSize ) const;
+	std::filesystem::path cacheBasePath = "cache";
 
-	    Result GetCompressedSize( uintmax_t& compressedSize ) const;
+	std::string expectedChecksum = "";
 
-        Result GetDataStream( ResourceGetDataStreamParams& params ) const;
+	std::chrono::seconds downloadRetrySeconds{ 120 };
+};
 
-	    Result GetData( ResourceGetDataParams& params ) const;
+struct ResourceGetDataParams
+{
+	ResourceSourceSettings resourceSourceSettings;
 
-        Result PutDataStream( ResourcePutDataStreamParams& params ) const;
+	std::string* data = nullptr;
 
-        Result PutData( ResourcePutDataParams& params ) const;
+	std::filesystem::path cacheBasePath = "cache";
 
-        virtual Result ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion ); 
+	std::string expectedChecksum = "";
 
-        virtual Result ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion );
+	std::chrono::seconds downloadRetrySeconds{ 120 };
+};
 
-    	Result ExportToCsv( std::string& out, const VersionInternal& documentVersion );
+struct ResourcePutDataStreamParams
+{
+	ResourceDestinationSettings resourceDestinationSettings;
 
-        Result SetParametersFromData( const std::string& data );
+	ResourceTools::FileDataStreamOut* dataStream = nullptr;
+};
 
-    	Result SetParametersFromSourceStream( ResourceTools::FileDataStreamIn& stream, size_t matchSize );
+struct ResourcePutDataParams
+{
+	ResourceDestinationSettings resourceDestinationSettings;
 
-		void SetDataChecksum( const std::string& checksum );
+	std::string* data = nullptr;
+};
 
-    	void SetCompressedSize( uintmax_t compressedSize );
 
-    	void SetUncompressedSize( uintmax_t uncompressedSize );
+class ResourceInfo
+{
+public:
+	ResourceInfo( const ResourceInfoParams& params );
 
-        virtual Result SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion );
+	virtual ~ResourceInfo();
 
-        bool operator==( const ResourceInfo* other ) const;
+	void SetRelativePath( const std::filesystem::path& relativePath );
 
-        bool operator<( const ResourceInfo& other ) const;
+	Result GetBinaryOperation( unsigned int& binaryOperation ) const;
 
-        static std::string TypeId();
+	Result GetRelativePath( std::filesystem::path& relativePath ) const;
 
-    private:
-	    Result GetDataLocalRelative( ResourceGetDataParams& params, const int basePathId ) const;
+	Result GetLocation( std::string& location ) const;
 
-	    Result GetDataLocalCdn( ResourceGetDataParams& params, const int basePathId ) const;
+	Result GetType( std::string& type ) const;
 
-	    Result GetDataRemoteCdn( ResourceGetDataParams& params, const int basePathId ) const;
+	Result GetPrefix( std::string& prefix ) const;
 
-        Result GetDataStreamLocalRelative( ResourceGetDataStreamParams& params, const int basePathId ) const;
+	Result GetChecksum( std::string& checksum ) const;
 
-		Result GetDataStreamLocalCdn( ResourceGetDataStreamParams& params, const int basePathId ) const;
+	Result GetUncompressedSize( uintmax_t& uncompressedSize ) const;
 
-		Result GetDataStreamRemoteCdn( ResourceGetDataStreamParams& params, const int basePathId ) const;
+	Result GetCompressedSize( uintmax_t& compressedSize ) const;
 
-        Result PutDataLocalRelative( ResourcePutDataParams& params ) const;
+	Result GetDataStream( ResourceGetDataStreamParams& params ) const;
 
-		Result PutDataLocalCdn( ResourcePutDataParams& params ) const;
+	Result GetData( ResourceGetDataParams& params ) const;
 
-        Result PutDataStreamLocalRelative( ResourcePutDataStreamParams& params ) const;
+	Result PutDataStream( ResourcePutDataStreamParams& params ) const;
 
-		Result PutDataStreamLocalCdn( ResourcePutDataStreamParams& params ) const;
+	Result PutData( ResourcePutDataParams& params ) const;
 
-        Result PutDataStreamRemoteCdn( ResourcePutDataStreamParams& params ) const;
+	virtual Result ImportFromYaml( YAML::Node& resource, const VersionInternal& documentVersion );
 
-        Result PutDataRemoteCdn( ResourcePutDataParams& params ) const;
+	virtual Result ExportToYaml( YAML::Emitter& out, const VersionInternal& documentVersion );
 
-    	Result UpdateLocation(); // Regenerate location parameter after changing checksum or relative path.
+	Result ExportToCsv( std::string& out, const VersionInternal& documentVersion );
 
-    protected:
+	Result SetParametersFromData( const std::string& data );
 
-        // Parameters for document version 0.0.0
-		DocumentParameter<std::filesystem::path> m_relativePath = DocumentParameter<std::filesystem::path>( RELATIVE_PATH, TypeId() );
+	Result SetParametersFromSourceStream( ResourceTools::FileDataStreamIn& stream, size_t matchSize );
 
-		DocumentParameter<Location> m_location = DocumentParameter<Location>( LOCATION, TypeId() );
+	void SetDataChecksum( const std::string& checksum );
 
-        DocumentParameter<std::string> m_type = DocumentParameter<std::string>( TYPE, TypeId() );
+	void SetCompressedSize( uintmax_t compressedSize );
 
-		DocumentParameter<std::string> m_checksum = DocumentParameter<std::string>( CHECKSUM, TypeId() );
+	void SetUncompressedSize( uintmax_t uncompressedSize );
 
-		DocumentParameter<uintmax_t> m_compressedSize = DocumentParameter<uintmax_t>( COMPRESSED_SIZE, TypeId() );
+	virtual Result SetParametersFromResource( const ResourceInfo* other, const VersionInternal& documentVersion );
 
-		DocumentParameter<uintmax_t> m_uncompressedSize = DocumentParameter<uintmax_t>( UNCOMPRESSED_SIZE, TypeId() );
+	bool operator==( const ResourceInfo* other ) const;
 
-    	DocumentParameter<unsigned int> m_binaryOperation = DocumentParameter<unsigned int>( BINARY_OPERATION, TypeId() );
+	bool operator<( const ResourceInfo& other ) const;
 
-    	DocumentParameter<std::string> m_prefix = DocumentParameter<std::string>( PREFIX, TypeId() );
-    };
+	static std::string TypeId();
 
-	inline Result SetParameterFromYamlNodeData(YAML::Node& node, DocumentParameter<std::filesystem::path>& parameter)
-    {
-	    parameter = node.as<std::string>();
-		return Result{ ResultType::SUCCESS };
-    }
+private:
+	Result GetDataLocalRelative( ResourceGetDataParams& params, const int basePathId ) const;
 
-	template <typename T>
-	Result SetParameterFromYamlNodeData(YAML::Node& node, DocumentParameter<T>& parameter)
-    {
-	    parameter = node.as<T>();
-		return Result{ ResultType::SUCCESS };
-    }
+	Result GetDataLocalCdn( ResourceGetDataParams& params, const int basePathId ) const;
 
-	template <typename T>
-	Result SetParameterFromYamlNode(YAML::Node& resource, DocumentParameter<T>& parameter, const std::string& context, const VersionInternal& documentVersion )
-    {
-		if( !parameter.IsParameterExpectedInDocumentVersion( documentVersion ) )
-		{
-			return Result{ ResultType::SUCCESS }; // Ignore unexpected parameter
-		}
-		YAML::Node param = resource[parameter.GetTag()];
-		if( !param.IsDefined() )
-		{
-			return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
-		}
-		return SetParameterFromYamlNodeData( param, parameter );
-    }
+	Result GetDataRemoteCdn( ResourceGetDataParams& params, const int basePathId ) const;
+
+	Result GetDataStreamLocalRelative( ResourceGetDataStreamParams& params, const int basePathId ) const;
+
+	Result GetDataStreamLocalCdn( ResourceGetDataStreamParams& params, const int basePathId ) const;
+
+	Result GetDataStreamRemoteCdn( ResourceGetDataStreamParams& params, const int basePathId ) const;
+
+	Result PutDataLocalRelative( ResourcePutDataParams& params ) const;
+
+	Result PutDataLocalCdn( ResourcePutDataParams& params ) const;
+
+	Result PutDataStreamLocalRelative( ResourcePutDataStreamParams& params ) const;
+
+	Result PutDataStreamLocalCdn( ResourcePutDataStreamParams& params ) const;
+
+	Result PutDataStreamRemoteCdn( ResourcePutDataStreamParams& params ) const;
+
+	Result PutDataRemoteCdn( ResourcePutDataParams& params ) const;
+
+	Result UpdateLocation(); // Regenerate location parameter after changing checksum or relative path.
+
+protected:
+	// Parameters for document version 0.0.0
+	DocumentParameter<std::filesystem::path> m_relativePath = DocumentParameter<std::filesystem::path>( RELATIVE_PATH, TypeId() );
+
+	DocumentParameter<Location> m_location = DocumentParameter<Location>( LOCATION, TypeId() );
+
+	DocumentParameter<std::string> m_type = DocumentParameter<std::string>( TYPE, TypeId() );
+
+	DocumentParameter<std::string> m_checksum = DocumentParameter<std::string>( CHECKSUM, TypeId() );
+
+	DocumentParameter<uintmax_t> m_compressedSize = DocumentParameter<uintmax_t>( COMPRESSED_SIZE, TypeId() );
+
+	DocumentParameter<uintmax_t> m_uncompressedSize = DocumentParameter<uintmax_t>( UNCOMPRESSED_SIZE, TypeId() );
+
+	DocumentParameter<unsigned int> m_binaryOperation = DocumentParameter<unsigned int>( BINARY_OPERATION, TypeId() );
+
+	DocumentParameter<std::string> m_prefix = DocumentParameter<std::string>( PREFIX, TypeId() );
+};
+
+inline Result SetParameterFromYamlNodeData( YAML::Node& node, DocumentParameter<std::filesystem::path>& parameter )
+{
+	parameter = node.as<std::string>();
+	return Result{ ResultType::SUCCESS };
+}
+
+template <typename T>
+Result SetParameterFromYamlNodeData( YAML::Node& node, DocumentParameter<T>& parameter )
+{
+	parameter = node.as<T>();
+	return Result{ ResultType::SUCCESS };
+}
+
+template <typename T>
+Result SetParameterFromYamlNode( YAML::Node& resource, DocumentParameter<T>& parameter, const std::string& context, const VersionInternal& documentVersion )
+{
+	if( !parameter.IsParameterExpectedInDocumentVersion( documentVersion ) )
+	{
+		return Result{ ResultType::SUCCESS }; // Ignore unexpected parameter
+	}
+	YAML::Node param = resource[parameter.GetTag()];
+	if( !param.IsDefined() )
+	{
+		return Result{ ResultType::MALFORMED_RESOURCE_INPUT };
+	}
+	return SetParameterFromYamlNodeData( param, parameter );
+}
 
 }
 #endif // ResourceInfo_H

--- a/src/VersionInternal.cpp
+++ b/src/VersionInternal.cpp
@@ -5,200 +5,199 @@
 
 namespace CarbonResources
 {
-    VersionInternal::VersionInternal()
-    {
-    }
+VersionInternal::VersionInternal()
+{
+}
 
-    VersionInternal::VersionInternal( const Version& v ) :
-		m_major(v.major),
-		m_minor(v.minor),
-		m_patch(v.patch)
-    {
-        
-    }
+VersionInternal::VersionInternal( const Version& v ) :
+	m_major( v.major ),
+	m_minor( v.minor ),
+	m_patch( v.patch )
+{
+}
 
-    VersionInternal::VersionInternal( unsigned int major, unsigned int minor, unsigned int patch ) :
-	    m_major( major ),
-	    m_minor( minor ),
-	    m_patch( patch )
-    {
-    }
+VersionInternal::VersionInternal( unsigned int major, unsigned int minor, unsigned int patch ) :
+	m_major( major ),
+	m_minor( minor ),
+	m_patch( patch )
+{
+}
 
-    bool VersionInternal::operator>( const VersionInternal& value ) const
-    {
-	    if( m_major > value.m_major )
-	    {
-		    return true;
-	    }
-	    else
-	    {
-		    if( m_minor > value.m_minor )
-		    {
-			    return true;
-		    }
-		    else
-		    {
-			    return m_patch > value.m_patch;
-		    }
-	    }
-    }
-
-    bool VersionInternal::operator<( const VersionInternal& value ) const
-    {
-	    if( m_major < value.m_major )
-	    {
-		    return true;
-	    }
-	    else
-	    {
-		    if( m_minor < value.m_minor )
-		    {
-			    return true;
-		    }
-		    else
-		    {
-			    return m_patch < value.m_patch;
-		    }
-	    }
-    }
-
-    bool VersionInternal::operator>=( const VersionInternal& value ) const
-    {
-
-	    if( m_major > value.m_major )
-	    {
-		    return true;
-	    }
-	    else if( m_major == value.m_major )
-	    {
-		    if( m_minor > value.m_minor )
-		    {
-			    return true;
-		    }
-		    else if( m_minor == value.m_minor )
-		    {
-			    if( m_patch >= value.m_patch )
-			    {
-				    return true;
-			    }
-			    else
-			    {
-				    return false;
-			    }
-		    }
-		    else
-		    {
-			    return false;
-		    }
-	    }
-	    else
-	    {
-		    return false;
-	    }
-    }
-
-    bool VersionInternal::operator == ( const VersionInternal& value ) const
-    {
-        if (value.m_major != m_major)
-        {
-			return false;
-        }
-        else if (value.m_minor != m_minor)
-        {
-			return false;
-        }
-        else if (value.m_patch != m_patch)
-        {
-			return false;
-        }
-        else
-        {
+bool VersionInternal::operator>( const VersionInternal& value ) const
+{
+	if( m_major > value.m_major )
+	{
+		return true;
+	}
+	else
+	{
+		if( m_minor > value.m_minor )
+		{
 			return true;
-        }
-    }
+		}
+		else
+		{
+			return m_patch > value.m_patch;
+		}
+	}
+}
 
-    bool VersionInternal::operator<=( const VersionInternal& value ) const
-    {
-	    return !(*this > value);
-    }
+bool VersionInternal::operator<( const VersionInternal& value ) const
+{
+	if( m_major < value.m_major )
+	{
+		return true;
+	}
+	else
+	{
+		if( m_minor < value.m_minor )
+		{
+			return true;
+		}
+		else
+		{
+			return m_patch < value.m_patch;
+		}
+	}
+}
 
-    std::string VersionInternal::ToString() const
-    {
-	    std::stringstream ss;
-	    ss << m_major << "." << m_minor << "." << m_patch;
-	    return ss.str();
-    }
+bool VersionInternal::operator>=( const VersionInternal& value ) const
+{
 
-    bool VersionInternal::FromString( std::string versionString )
-    {
-	    try
-	    {
-		    std::stringstream ss( versionString );
-
-		    char delimiter = '.';
-
-		    std::string majorStr = "";
-
-		    if( !std::getline( ss, majorStr, delimiter ) )
-		    {
-			    return false;
-		    }
-
-		    m_major = std::stoi( majorStr );
-
-		    std::string minorStr = "";
-
-		    if( !std::getline( ss, minorStr, delimiter ) )
-		    {
-			    return false;
-		    }
-
-		    m_minor = std::stoi( minorStr );
-
-		    std::string patchStr = "";
-
-		    if( !std::getline( ss, patchStr, delimiter ) )
-		    {
-			    return false;
-		    }
-
-		    m_patch = std::stoi( patchStr );
-
-		    return true;
-	    }
-	    catch( ... )
-	    {
-		    return false;
-	    }
-    }
-
-    unsigned int VersionInternal::getMajor() const
-    {
-		return m_major;
-    }
-
-    unsigned int VersionInternal::getMinor() const
-    {
-		return m_minor;
-    }
-
-    unsigned int VersionInternal::getPatch() const
-    {
-		return m_patch;
-    }
-
-    bool VersionInternal::isVersionValid() const
-    {
-        for (Version v : S_VALID_DOCUMENT_VERSIONS)
-        {
-			VersionInternal internalVersion( v );
-
-            if (this->operator==(internalVersion))
-            {
+	if( m_major > value.m_major )
+	{
+		return true;
+	}
+	else if( m_major == value.m_major )
+	{
+		if( m_minor > value.m_minor )
+		{
+			return true;
+		}
+		else if( m_minor == value.m_minor )
+		{
+			if( m_patch >= value.m_patch )
+			{
 				return true;
-            }
-        }
+			}
+			else
+			{
+				return false;
+			}
+		}
+		else
+		{
+			return false;
+		}
+	}
+	else
+	{
+		return false;
+	}
+}
 
-        return false;
-    }
+bool VersionInternal::operator==( const VersionInternal& value ) const
+{
+	if( value.m_major != m_major )
+	{
+		return false;
+	}
+	else if( value.m_minor != m_minor )
+	{
+		return false;
+	}
+	else if( value.m_patch != m_patch )
+	{
+		return false;
+	}
+	else
+	{
+		return true;
+	}
+}
+
+bool VersionInternal::operator<=( const VersionInternal& value ) const
+{
+	return !( *this > value );
+}
+
+std::string VersionInternal::ToString() const
+{
+	std::stringstream ss;
+	ss << m_major << "." << m_minor << "." << m_patch;
+	return ss.str();
+}
+
+bool VersionInternal::FromString( std::string versionString )
+{
+	try
+	{
+		std::stringstream ss( versionString );
+
+		char delimiter = '.';
+
+		std::string majorStr = "";
+
+		if( !std::getline( ss, majorStr, delimiter ) )
+		{
+			return false;
+		}
+
+		m_major = std::stoi( majorStr );
+
+		std::string minorStr = "";
+
+		if( !std::getline( ss, minorStr, delimiter ) )
+		{
+			return false;
+		}
+
+		m_minor = std::stoi( minorStr );
+
+		std::string patchStr = "";
+
+		if( !std::getline( ss, patchStr, delimiter ) )
+		{
+			return false;
+		}
+
+		m_patch = std::stoi( patchStr );
+
+		return true;
+	}
+	catch( ... )
+	{
+		return false;
+	}
+}
+
+unsigned int VersionInternal::getMajor() const
+{
+	return m_major;
+}
+
+unsigned int VersionInternal::getMinor() const
+{
+	return m_minor;
+}
+
+unsigned int VersionInternal::getPatch() const
+{
+	return m_patch;
+}
+
+bool VersionInternal::isVersionValid() const
+{
+	for( Version v : S_VALID_DOCUMENT_VERSIONS )
+	{
+		VersionInternal internalVersion( v );
+
+		if( this->operator==( internalVersion ) )
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
 }

--- a/src/VersionInternal.h
+++ b/src/VersionInternal.h
@@ -12,48 +12,46 @@
 
 namespace CarbonResources
 {
-    struct Version;
+struct Version;
 
-    class VersionInternal
-    {
-	public:
-		VersionInternal();
+class VersionInternal
+{
+public:
+	VersionInternal();
 
-        VersionInternal( const Version& v );
+	VersionInternal( const Version& v );
 
-        VersionInternal( unsigned int major, unsigned int minor, unsigned int patch );
+	VersionInternal( unsigned int major, unsigned int minor, unsigned int patch );
 
-		bool operator>( const VersionInternal& value ) const;
+	bool operator>( const VersionInternal& value ) const;
 
-        bool operator<( const VersionInternal& value ) const;
+	bool operator<( const VersionInternal& value ) const;
 
-        bool operator>=( const VersionInternal& value ) const;
+	bool operator>=( const VersionInternal& value ) const;
 
-        bool operator<=( const VersionInternal& value ) const;
+	bool operator<=( const VersionInternal& value ) const;
 
-        bool operator==( const VersionInternal& value ) const;
+	bool operator==( const VersionInternal& value ) const;
 
-        std::string ToString() const;
+	std::string ToString() const;
 
-		bool FromString( std::string versionString );
+	bool FromString( std::string versionString );
 
-        unsigned int getMajor() const;
+	unsigned int getMajor() const;
 
-        unsigned int getMinor() const;
+	unsigned int getMinor() const;
 
-        unsigned int getPatch() const;
+	unsigned int getPatch() const;
 
-        bool isVersionValid() const;
+	bool isVersionValid() const;
 
-    private:
+private:
+	unsigned int m_major;
 
-		unsigned int m_major;
+	unsigned int m_minor;
 
-        unsigned int m_minor;
-
-        unsigned int m_patch;
-        
-    };
+	unsigned int m_patch;
+};
 
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,13 +11,13 @@ find_package(tiny-process-library CONFIG REQUIRED)
 include(GoogleTest)
 
 set(SRC_FILES
-    src/ResourcesTestFixture.cpp
-    src/ResourcesTestFixture.h
-    src/CliTestFixture.cpp
-    src/CliTestFixture.h
-    src/ResourcesLibraryTest.cpp
-    src/ResourcesCliTest.cpp
-    src/ResourceToolsLibraryTest.cpp
+        src/ResourcesTestFixture.cpp
+        src/ResourcesTestFixture.h
+        src/CliTestFixture.cpp
+        src/CliTestFixture.h
+        src/ResourcesLibraryTest.cpp
+        src/ResourcesCliTest.cpp
+        src/ResourceToolsLibraryTest.cpp
 )
 
 add_executable(resources-test ${SRC_FILES})
@@ -33,27 +33,27 @@ target_include_directories(resources-test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries(resources-test PRIVATE GTest::gtest GTest::gtest_main tiny-process-library::tiny-process-library resources resources-tools)
 
-if(DEV_FEATURES)
-    target_compile_definitions( resources-test PRIVATE DEV_FEATURES )
-endif()
+if (DEV_FEATURES)
+    target_compile_definitions(resources-test PRIVATE DEV_FEATURES)
+endif ()
 
-if(WIN32)
+if (WIN32)
 
     # Get CLI exe
     add_custom_command(
-        TARGET resources-test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:resources-test>
-        COMMAND_EXPAND_LISTS
+            TARGET resources-test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:resources-cli> $<TARGET_FILE_DIR:resources-test>
+            COMMAND_EXPAND_LISTS
     )
 
     # Binaries
     add_custom_command(
-        TARGET resources-test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:resources-test> $<TARGET_FILE_DIR:resources-test>
-        COMMAND_EXPAND_LISTS
+            TARGET resources-test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:resources-test> $<TARGET_FILE_DIR:resources-test>
+            COMMAND_EXPAND_LISTS
     )
 
-elseif(APPLE)
+elseif (APPLE)
     # Get CLI exe
     add_custom_command(
             TARGET resources-test POST_BUILD
@@ -61,14 +61,14 @@ elseif(APPLE)
             COMMAND_EXPAND_LISTS
 
     )
-endif()
+endif ()
 
 cmake_path(SET TEST_DATA_PATH ${CMAKE_CURRENT_SOURCE_DIR}/testData)
 
 gtest_discover_tests(
         resources-test capiTests
         PROPERTIES
-            ENVIRONMENT "TEST_DATA_PATH=${TEST_DATA_PATH}"
-            WORKING_DIRECTORY $<TARGET_FILE_DIR:resources-test>  # So that we can find the CLI executable.
+        ENVIRONMENT "TEST_DATA_PATH=${TEST_DATA_PATH}"
+        WORKING_DIRECTORY $<TARGET_FILE_DIR:resources-test>  # So that we can find the CLI executable.
         DISCOVERY_MODE PRE_TEST # Workaround to get builds working on macOS on ARM https://gitlab.kitware.com/cmake/cmake/-/issues/21845
 )

--- a/tests/src/CliTestFixture.cpp
+++ b/tests/src/CliTestFixture.cpp
@@ -8,17 +8,17 @@
 
 int CliTestFixture::RunCli( std::vector<std::string>& arguments, std::string& output )
 {
-    std::string processOutput;
+	std::string processOutput;
 
-    arguments.insert( arguments.begin(), CARBON_RESOURCES_CLI_EXE_NAME );
+	arguments.insert( arguments.begin(), CARBON_RESOURCES_CLI_EXE_NAME );
 
-    TinyProcessLib::Process process1a( arguments, "", [&processOutput]( const char* bytes, size_t n ) {
-	    processOutput += std::string( bytes, n );
-    } );
+	TinyProcessLib::Process process1a( arguments, "", [&processOutput]( const char* bytes, size_t n ) {
+		processOutput += std::string( bytes, n );
+	} );
 
-    auto exit_status = process1a.get_exit_status();
+	auto exit_status = process1a.get_exit_status();
 
-    output = processOutput;
+	output = processOutput;
 
-    return exit_status;
+	return exit_status;
 }

--- a/tests/src/CliTestFixture.h
+++ b/tests/src/CliTestFixture.h
@@ -12,8 +12,7 @@
 struct CliTestFixture : public ResourcesTestFixture
 {
 
-    int RunCli( std::vector<std::string> &arguments, std::string &output );
-
+	int RunCli( std::vector<std::string>& arguments, std::string& output );
 };
 
 #endif // CliTestFixture_H

--- a/tests/src/ResourceToolsLibraryTest.cpp
+++ b/tests/src/ResourceToolsLibraryTest.cpp
@@ -30,9 +30,9 @@ TEST_F( ResourceToolsTest, Md5ChecksumGeneration )
 	std::string input = "Dummy";
 	std::string output = "";
 
-    EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( input, output ) );
+	EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( input, output ) );
 
-    EXPECT_EQ( output, "bcf036b6f33e182d4705f4f5b1af13ac" );
+	EXPECT_EQ( output, "bcf036b6f33e182d4705f4f5b1af13ac" );
 }
 
 TEST_F( ResourceToolsTest, FileMd5ChecksumGeneration )
@@ -47,9 +47,9 @@ TEST_F( ResourceToolsTest, FileMd5ChecksumGeneration )
 
 	std::string output;
 
-    EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( sourcePath, output ) );
+	EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( sourcePath, output ) );
 
-    EXPECT_EQ( output, "e9fadf6f2d386a0a0786bc863f20fa34" );
+	EXPECT_EQ( output, "e9fadf6f2d386a0a0786bc863f20fa34" );
 }
 
 TEST_F( ResourceToolsTest, FileMd5ChecksumMatches )
@@ -70,11 +70,11 @@ TEST_F( ResourceToolsTest, FileMd5ChecksumMatches )
 
 	std::string unexpectedChecksum = "e9fadf6f2d386a0a0786bc863f20fa35";
 
-    EXPECT_TRUE( ResourceTools::Md5ChecksumMatches( sourcePath, expectedChecksum ) );
+	EXPECT_TRUE( ResourceTools::Md5ChecksumMatches( sourcePath, expectedChecksum ) );
 
-    EXPECT_FALSE( ResourceTools::Md5ChecksumMatches( sourcePath, unexpectedChecksum ) );
+	EXPECT_FALSE( ResourceTools::Md5ChecksumMatches( sourcePath, unexpectedChecksum ) );
 
-    EXPECT_FALSE( ResourceTools::Md5ChecksumMatches( sourcePath2, expectedChecksum ) );
+	EXPECT_FALSE( ResourceTools::Md5ChecksumMatches( sourcePath2, expectedChecksum ) );
 }
 
 TEST_F( ResourceToolsTest, FowlerNollVoChecksumGeneration )
@@ -95,10 +95,10 @@ TEST_F( ResourceToolsTest, DownloadFile )
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
 	ResourceTools::Downloader downloader;
-	std::filesystem::path testDataPath(testDataPathStr);
+	std::filesystem::path testDataPath( testDataPathStr );
 
 	std::filesystem::path sourcePath = testDataPath / "resourcesLocal" / FOLDER_NAME / FILE_NAME;
-	std::string sourcePathString(sourcePath.string());
+	std::string sourcePathString( sourcePath.string() );
 	std::string url = "file://" + sourcePathString;
 	std::filesystem::path outputPath = std::filesystem::temp_directory_path() / FOLDER_NAME / FILE_NAME;
 	std::string outputPathString = outputPath.string();
@@ -109,7 +109,7 @@ TEST_F( ResourceToolsTest, DownloadFile )
 		std::filesystem::remove( outputPath );
 	}
 	EXPECT_FALSE( std::filesystem::exists( outputPath ) );
-	std::chrono::seconds retrySeconds{0};
+	std::chrono::seconds retrySeconds{ 0 };
 	EXPECT_TRUE( downloader.DownloadFile( url, outputPathString, retrySeconds ) );
 	EXPECT_TRUE( std::filesystem::exists( outputPath ) );
 
@@ -133,7 +133,7 @@ TEST_F( ResourceToolsTest, GZipCompressString )
 	std::string inputDataToCompress = "SomeData";
 	std::string outputData = "";
 	EXPECT_TRUE( ResourceTools::GZipCompressData( inputDataToCompress, outputData ) );
-	EXPECT_EQ( outputData.substr( 0, 2 ), "\x1F\x8B"); // Start of GZIP header.
+	EXPECT_EQ( outputData.substr( 0, 2 ), "\x1F\x8B" ); // Start of GZIP header.
 }
 
 TEST_F( ResourceToolsTest, GZipCompressData )
@@ -169,24 +169,23 @@ TEST_F( ResourceToolsTest, GZipUncompressString )
 	EXPECT_EQ( outputData, "SomeData" );
 }
 
-TEST_F(ResourceToolsTest, FileDataStremOut)
+TEST_F( ResourceToolsTest, FileDataStremOut )
 {
 	ResourceTools::FileDataStreamOut out;
 
-    std::filesystem::path outputPath = "FileDataStreamOut.txt";
+	std::filesystem::path outputPath = "FileDataStreamOut.txt";
 
-    EXPECT_TRUE( out.StartWrite( outputPath ) );
+	EXPECT_TRUE( out.StartWrite( outputPath ) );
 
-    out << "Test1\n";
+	out << "Test1\n";
 
-    out << "Test2\n";
+	out << "Test2\n";
 
-    out << "Test3\n";
+	out << "Test3\n";
 
-    EXPECT_TRUE( out.Finish() );
+	EXPECT_TRUE( out.Finish() );
 
-    EXPECT_TRUE( FilesMatch( outputPath, GetTestFileFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
-
+	EXPECT_TRUE( FilesMatch( outputPath, GetTestFileFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
 }
 
 TEST_F( ResourceToolsTest, CompressedFileDataStremOut )
@@ -199,29 +198,29 @@ TEST_F( ResourceToolsTest, CompressedFileDataStremOut )
 
 	EXPECT_TRUE( out.StartWrite( outputPath ) );
 
-    std::ifstream goldFileUncompressedIn( goldFileUncompressedPath );
+	std::ifstream goldFileUncompressedIn( goldFileUncompressedPath );
 
-    std::string line;
+	std::string line;
 	while( std::getline( goldFileUncompressedIn, line ) )
 	{
 		out << line;
 
-        out << "\n";
+		out << "\n";
 	}
 
 	EXPECT_TRUE( out.Finish() );
 
-    std::string compressedData;
+	std::string compressedData;
 
-    EXPECT_TRUE(ResourceTools::GetLocalFileData( outputPath, compressedData ));
+	EXPECT_TRUE( ResourceTools::GetLocalFileData( outputPath, compressedData ) );
 
-    std::string uncompressedData;
+	std::string uncompressedData;
 
-    EXPECT_TRUE( ResourceTools::GZipUncompressData( compressedData, uncompressedData ) );
-    
-    std::filesystem::path outputPathUncompressed = "FileDataStreamOut.txt";
+	EXPECT_TRUE( ResourceTools::GZipUncompressData( compressedData, uncompressedData ) );
 
-    EXPECT_TRUE(ResourceTools::SaveFile( outputPathUncompressed, uncompressedData ));
+	std::filesystem::path outputPathUncompressed = "FileDataStreamOut.txt";
+
+	EXPECT_TRUE( ResourceTools::SaveFile( outputPathUncompressed, uncompressedData ) );
 
 	EXPECT_TRUE( FilesMatch( outputPathUncompressed, GetTestFileFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
 }
@@ -229,14 +228,14 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 {
 	uintmax_t chunkSize = 1000;
 
-	std::filesystem::path testDir{"ResourceChunking"};
+	std::filesystem::path testDir{ "ResourceChunking" };
 
 	ResourceTools::BundleStreamOut bundleStream( chunkSize, testDir );
 
-    // Add test resource1 data
+	// Add test resource1 data
 	std::string resource1Data;
 
-    std::filesystem::path resource1Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/One.png" );
+	std::filesystem::path resource1Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/One.png" );
 
 	EXPECT_TRUE( ResourceTools::GetLocalFileData( resource1Path, resource1Data ) );
 
@@ -244,13 +243,13 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 
 	resource1StreamIn->StartRead( resource1Path );
 
-    EXPECT_TRUE(bundleStream << resource1StreamIn);
+	EXPECT_TRUE( bundleStream << resource1StreamIn );
 
-    std::string resource1Checksum;
+	std::string resource1Checksum;
 
-    EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( resource1Data, resource1Checksum ));
+	EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( resource1Data, resource1Checksum ) );
 
-    // Add test resource2 data
+	// Add test resource2 data
 	std::string resource2Data;
 
 	std::filesystem::path resource2Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/Two.png" );
@@ -263,11 +262,11 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 
 	EXPECT_TRUE( bundleStream << resource2StreamIn );
 
-    std::string resource2Checksum;
+	std::string resource2Checksum;
 
-    EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( resource2Data, resource2Checksum ) );
+	EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( resource2Data, resource2Checksum ) );
 
-    // Add test resource3 data
+	// Add test resource3 data
 	std::string resource3Data;
 
 	std::filesystem::path resource3Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/Three.png" );
@@ -280,44 +279,44 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 
 	EXPECT_TRUE( bundleStream << resource3StreamIn );
 
-    std::string resource3Checksum;
+	std::string resource3Checksum;
 
 	EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( resource3Data, resource3Checksum ) );
 
-    // Get chunks
+	// Get chunks
 	int numberOfChunks = 0;
 
 	ResourceTools::GetChunk chunk;
 
-    chunk.clearCache = false;
+	chunk.clearCache = false;
 
-	bool bundleStreamReadOk{true};
+	bool bundleStreamReadOk{ true };
 
-    while ( ( bundleStreamReadOk = ( bundleStream >> chunk ) ) && !chunk.outOfChunks )
-    {
-        // Create Filename
+	while( ( bundleStreamReadOk = ( bundleStream >> chunk ) ) && !chunk.outOfChunks )
+	{
+		// Create Filename
 		std::stringstream ss;
 
-        ss << "Chunks/Chunk";
+		ss << "Chunks/Chunk";
 
-        ss << numberOfChunks;
+		ss << numberOfChunks;
 
-        ss << ".chunk";
+		ss << ".chunk";
 
-        std::string chunkPath = ss.str();
+		std::string chunkPath = ss.str();
 
-    	std::filesystem::copy_file( chunk.uncompressedChunkIn->GetPath(), chunkPath );
+		std::filesystem::copy_file( chunk.uncompressedChunkIn->GetPath(), chunkPath );
 
-        numberOfChunks++;
-    }
+		numberOfChunks++;
+	}
 	EXPECT_TRUE( bundleStreamReadOk );
 
-    // Clear cache for last chunk
+	// Clear cache for last chunk
 	chunk.clearCache = true;
 
 	EXPECT_TRUE( bundleStream >> chunk );
 
-    // Create Filename
+	// Create Filename
 	std::stringstream ss;
 
 	ss << "Chunks/Chunk";
@@ -343,8 +342,8 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 	// Reconsitute the files
 	ResourceTools::BundleStreamIn chunkStreamReconstitute( chunkSize );
 
-    for (int i = 0; i < numberOfChunks + 1; i++)
-    {
+	for( int i = 0; i < numberOfChunks + 1; i++ )
+	{
 		// Create Filename
 		std::stringstream ss;
 
@@ -356,36 +355,35 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 
 		std::string chunkPath = ss.str();
 
-        // Get chunks
+		// Get chunks
 		std::string chunkData;
 
-		EXPECT_TRUE( ResourceTools::GetLocalFileData(chunkPath,chunkData));
+		EXPECT_TRUE( ResourceTools::GetLocalFileData( chunkPath, chunkData ) );
 
-        EXPECT_TRUE( chunkStreamReconstitute << chunkData );
+		EXPECT_TRUE( chunkStreamReconstitute << chunkData );
+	}
 
-    }
+	// Reconstitute the files and check they match original
 
-    // Reconstitute the files and check they match original
-
-    struct Resource
-    {
+	struct Resource
+	{
 		std::filesystem::path reconsitutedPath;
 
-        size_t expectedFileSize;
+		size_t expectedFileSize;
 
-        std::string expectedChecksum;
-    };
+		std::string expectedChecksum;
+	};
 
-    std::vector<Resource> reconstitutedResources;
+	std::vector<Resource> reconstitutedResources;
 
-    reconstitutedResources.push_back( Resource{ "Chunks/One.png", resource1Data.size(), resource1Checksum } );
+	reconstitutedResources.push_back( Resource{ "Chunks/One.png", resource1Data.size(), resource1Checksum } );
 
-    reconstitutedResources.push_back( Resource{ "Chunks/Two.png", resource2Data.size(), resource2Checksum } );
+	reconstitutedResources.push_back( Resource{ "Chunks/Two.png", resource2Data.size(), resource2Checksum } );
 
-    reconstitutedResources.push_back( Resource{ "Chunks/Three.png", resource3Data.size(), resource3Checksum } );
+	reconstitutedResources.push_back( Resource{ "Chunks/Three.png", resource3Data.size(), resource3Checksum } );
 
-    for( auto reconsititedResource : reconstitutedResources )
-    {
+	for( auto reconsititedResource : reconstitutedResources )
+	{
 
 		ResourceTools::FileDataStreamOut resourceDataStreamOut;
 
@@ -418,30 +416,29 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 		EXPECT_TRUE( reconstitutedResource1ChecksumStream.FinishAndRetrieve( reconstitutedChecksum ) );
 
 		EXPECT_EQ( reconsititedResource.expectedChecksum, reconstitutedChecksum );
-    }
-
+	}
 }
 
 
 TEST_F( ResourceToolsTest, GZipUncompressTestFile )
 {
 
-    std::filesystem::path resourcePath = GetTestFileFileAbsolutePath( "CompressedFiles/ab5cde4fbbf82fb6_6a9d6d4c6015616877b77865209c5064" );
+	std::filesystem::path resourcePath = GetTestFileFileAbsolutePath( "CompressedFiles/ab5cde4fbbf82fb6_6a9d6d4c6015616877b77865209c5064" );
 
-    std::string resourceData;
+	std::string resourceData;
 
-    EXPECT_TRUE( ResourceTools::GetLocalFileData( resourcePath, resourceData ) );
+	EXPECT_TRUE( ResourceTools::GetLocalFileData( resourcePath, resourceData ) );
 
-    std::string uncompressedData;
+	std::string uncompressedData;
 
-    EXPECT_TRUE( ResourceTools::GZipUncompressData( resourceData, uncompressedData ) );
+	EXPECT_TRUE( ResourceTools::GZipUncompressData( resourceData, uncompressedData ) );
 
-    // Calculate the checksum to check it
+	// Calculate the checksum to check it
 	std::string checksum;
 
-    EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( uncompressedData, checksum ) );
+	EXPECT_TRUE( ResourceTools::GenerateMd5Checksum( uncompressedData, checksum ) );
 
-    // Save the file
+	// Save the file
 	std::filesystem::path resourcePathDest = "GZipOut/ab/ab5cde4fbbf82fb6_6a9d6d4c6015616877b77865209c5064";
 
 	EXPECT_TRUE( ResourceTools::SaveFile( resourcePathDest, uncompressedData ) );
@@ -458,18 +455,17 @@ TEST_F( ResourceToolsTest, CreateApplyPatch )
 
 	std::string patched = "";
 	// Apply the patch to before
-	ASSERT_TRUE(  ResourceTools::ApplyPatch( before, patch, patched ) );
+	ASSERT_TRUE( ResourceTools::ApplyPatch( before, patch, patched ) );
 
 	// After patching before, it should be exactly the same as after.
 	ASSERT_EQ( patched, after );
-
 }
 
 TEST_F( ResourceToolsTest, CreateApplyPatchFile )
 {
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
-	std::filesystem::path testDataPath(testDataPathStr);
+	std::filesystem::path testDataPath( testDataPathStr );
 
 	std::filesystem::path before_src = testDataPath / "Patch" / "PreviousBuildResources" / "introMovie.txt";
 	std::filesystem::path after_src = testDataPath / "Patch" / "NextBuildResources" / "introMovie.txt";
@@ -477,7 +473,7 @@ TEST_F( ResourceToolsTest, CreateApplyPatchFile )
 	std::filesystem::path tempDir = std::filesystem::temp_directory_path() / "CarbonResources";
 
 	std::filesystem::path patch = tempDir / "introMovie.patch";
-	std::filesystem::path before = tempDir /  "introMovie.txt";
+	std::filesystem::path before = tempDir / "introMovie.txt";
 
 	std::filesystem::create_directories( tempDir );
 
@@ -490,7 +486,7 @@ TEST_F( ResourceToolsTest, CreateApplyPatchFile )
 
 	std::string patched = "";
 	// Apply the patch to before
-	ASSERT_TRUE(  ResourceTools::ApplyPatchFile( before, patch ) );
+	ASSERT_TRUE( ResourceTools::ApplyPatchFile( before, patch ) );
 
 	std::string beforeChecksum;
 	std::string beforeData;
@@ -510,13 +506,13 @@ TEST_F( ResourceToolsTest, ApplyPatchFileChunked )
 {
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
-	std::filesystem::path testDataPath(testDataPathStr);
+	std::filesystem::path testDataPath( testDataPathStr );
 
 	std::filesystem::path before_src = testDataPath / "Patch" / "PreviousBuildResources" / "introMovie.txt";
 	std::filesystem::path after_src = testDataPath / "Patch" / "NextBuildResources" / "introMovie.txt";
 
 	std::filesystem::path patch = std::filesystem::temp_directory_path() / "CarbonResources" / "introMovie.patch";
-	std::filesystem::path before = std::filesystem::temp_directory_path() / "CarbonResources" /  "introMovie.txt";
+	std::filesystem::path before = std::filesystem::temp_directory_path() / "CarbonResources" / "introMovie.txt";
 
 	std::filesystem::remove( before );
 	std::filesystem::remove( patch );
@@ -530,11 +526,11 @@ TEST_F( ResourceToolsTest, ApplyPatchFileChunked )
 	ResourceTools::BundleStreamIn chunkStream( chunkSize );
 	std::string patchData;
 
-	EXPECT_TRUE(ResourceTools::GetLocalFileData( patch, patchData ));
+	EXPECT_TRUE( ResourceTools::GetLocalFileData( patch, patchData ) );
 
-	EXPECT_TRUE(chunkStream << patchData);
+	EXPECT_TRUE( chunkStream << patchData );
 	// Apply the patch to before
-	ASSERT_TRUE(  ResourceTools::ApplyPatchFileChunked( before, chunkStream ) );
+	ASSERT_TRUE( ResourceTools::ApplyPatchFileChunked( before, chunkStream ) );
 
 
 	std::string beforeChecksum;
@@ -553,12 +549,12 @@ TEST_F( ResourceToolsTest, ApplyPatchFileChunked )
 
 TEST_F( ResourceToolsTest, RollingChecksum )
 {
-	std::string data("01234asdf567asdf89");
-	ResourceTools::RollingChecksum first = ResourceTools::GenerateRollingAdlerChecksum(data, 0, 5);
-	ResourceTools::RollingChecksum second = ResourceTools::GenerateRollingAdlerChecksum(data, 5, 9);
-	ResourceTools::RollingChecksum third = ResourceTools::GenerateRollingAdlerChecksum(data, 9, 12);
-	ResourceTools::RollingChecksum fourth = ResourceTools::GenerateRollingAdlerChecksum(data, 12, 16);
-	ResourceTools::RollingChecksum fifth = ResourceTools::GenerateRollingAdlerChecksum(data, 16, 18);
+	std::string data( "01234asdf567asdf89" );
+	ResourceTools::RollingChecksum first = ResourceTools::GenerateRollingAdlerChecksum( data, 0, 5 );
+	ResourceTools::RollingChecksum second = ResourceTools::GenerateRollingAdlerChecksum( data, 5, 9 );
+	ResourceTools::RollingChecksum third = ResourceTools::GenerateRollingAdlerChecksum( data, 9, 12 );
+	ResourceTools::RollingChecksum fourth = ResourceTools::GenerateRollingAdlerChecksum( data, 12, 16 );
+	ResourceTools::RollingChecksum fifth = ResourceTools::GenerateRollingAdlerChecksum( data, 16, 18 );
 
 	ASSERT_NE( first.checksum, second.checksum );
 	ASSERT_NE( first.checksum, third.checksum );
@@ -570,11 +566,11 @@ TEST_F( ResourceToolsTest, RollingChecksum )
 	ASSERT_NE( third.checksum, fifth.checksum );
 	ASSERT_NE( fourth.checksum, fifth.checksum );
 
-	ResourceTools::RollingChecksum previous = ResourceTools::GenerateRollingAdlerChecksum(data, 0, 4);
+	ResourceTools::RollingChecksum previous = ResourceTools::GenerateRollingAdlerChecksum( data, 0, 4 );
 	for( int i = 1; i < 12; ++i )
 	{
-		ResourceTools::RollingChecksum fromScratch = ResourceTools::GenerateRollingAdlerChecksum(data, i, i + 4);
-		ResourceTools::RollingChecksum incremental = ResourceTools::GenerateRollingAdlerChecksum(data, i, i + 4, previous);
+		ResourceTools::RollingChecksum fromScratch = ResourceTools::GenerateRollingAdlerChecksum( data, i, i + 4 );
+		ResourceTools::RollingChecksum incremental = ResourceTools::GenerateRollingAdlerChecksum( data, i, i + 4, previous );
 		ASSERT_EQ( fromScratch.alpha, incremental.alpha );
 		ASSERT_EQ( fromScratch.beta, incremental.beta );
 		ASSERT_EQ( fromScratch.checksum, incremental.checksum );
@@ -584,9 +580,9 @@ TEST_F( ResourceToolsTest, RollingChecksum )
 
 TEST_F( ResourceToolsTest, FindMatchingChunksEverythingMatches )
 {
-	std::string source("0123456789");
-	std::string destination("0123456789");
-	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks(source, destination);
+	std::string source( "0123456789" );
+	std::string destination( "0123456789" );
+	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks( source, destination );
 	ASSERT_EQ( 1, result.size() );
 	auto match = result.front();
 	ASSERT_EQ( match.sourceOffset, 0 );
@@ -596,9 +592,9 @@ TEST_F( ResourceToolsTest, FindMatchingChunksEverythingMatches )
 
 TEST_F( ResourceToolsTest, FindMatchingChunksShorterDestination )
 {
-	std::string source("0123456789");
-	std::string destination("01234");
-	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks(source, destination);
+	std::string source( "0123456789" );
+	std::string destination( "01234" );
+	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks( source, destination );
 	ASSERT_EQ( 1, result.size() );
 	auto match = result.front();
 	ASSERT_EQ( match.sourceOffset, 0 );
@@ -608,9 +604,9 @@ TEST_F( ResourceToolsTest, FindMatchingChunksShorterDestination )
 
 TEST_F( ResourceToolsTest, FindMatchingChunksShorterSource )
 {
-	std::string source("01234");
-	std::string destination("0123456789");
-	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks(source, destination);
+	std::string source( "01234" );
+	std::string destination( "0123456789" );
+	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks( source, destination );
 	ASSERT_EQ( 1, result.size() );
 	auto match = result.front();
 	ASSERT_EQ( match.sourceOffset, 0 );
@@ -620,9 +616,9 @@ TEST_F( ResourceToolsTest, FindMatchingChunksShorterSource )
 
 TEST_F( ResourceToolsTest, FindMatchingChunksInString )
 {
-	std::string source("abc3456ij");
-	std::string destination("0123456789");
-	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks(source, destination);
+	std::string source( "abc3456ij" );
+	std::string destination( "0123456789" );
+	std::list<ResourceTools::ChunkMatch> result = ResourceTools::FindMatchingChunks( source, destination );
 	ASSERT_EQ( 1, result.size() );
 	auto match = result.front();
 	ASSERT_EQ( match.sourceOffset, 3 );
@@ -634,27 +630,27 @@ TEST_F( ResourceToolsTest, FindMatchingChunkInFile )
 {
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
-	std::filesystem::path testDataPath(testDataPathStr);
-    std::filesystem::path introMovieFilePath = testDataPath / "ResourcesOnBranch" / "introMovie.txt";
+	std::filesystem::path testDataPath( testDataPathStr );
+	std::filesystem::path introMovieFilePath = testDataPath / "ResourcesOnBranch" / "introMovie.txt";
 	std::string data;
 	ResourceTools::GetLocalFileData( introMovieFilePath, data );
 
 	size_t offset;
 
 	std::string notInFile = "Once upon a time, in a galaxy far, far away...";
-	ASSERT_FALSE(ResourceTools::FindMatchingChunk( notInFile, introMovieFilePath, offset ) );
+	ASSERT_FALSE( ResourceTools::FindMatchingChunk( notInFile, introMovieFilePath, offset ) );
 
 	std::string startOfFile = "TIME";
-	ASSERT_TRUE(ResourceTools::FindMatchingChunk( startOfFile, introMovieFilePath, offset ) );
+	ASSERT_TRUE( ResourceTools::FindMatchingChunk( startOfFile, introMovieFilePath, offset ) );
 	ASSERT_EQ( offset, 0 );
 
 	std::string early = "introseq.blue";
-	ASSERT_TRUE(ResourceTools::FindMatchingChunk( early, introMovieFilePath, offset ) );
+	ASSERT_TRUE( ResourceTools::FindMatchingChunk( early, introMovieFilePath, offset ) );
 	ASSERT_EQ( offset, data.find( early ) );
 
 	// Find the last 20 bytes of the file.
 	std::string final = data.substr( data.size() - 20 );
-	ASSERT_TRUE(ResourceTools::FindMatchingChunk( final, introMovieFilePath, offset ) );
+	ASSERT_TRUE( ResourceTools::FindMatchingChunk( final, introMovieFilePath, offset ) );
 	ASSERT_EQ( offset, data.size() - 20 );
 }
 
@@ -662,12 +658,12 @@ TEST_F( ResourceToolsTest, CountMatchingChunks )
 {
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
-	std::filesystem::path testDataPath(testDataPathStr);
+	std::filesystem::path testDataPath( testDataPathStr );
 	std::filesystem::path introMovieFilePath = testDataPath / "Patch" / "previousBuildResources" / "introMoviePrefixed.txt";
 	std::filesystem::path introMoviePatchedFilePath = testDataPath / "Patch" / "nextBuildResources" / "introMoviePrefixed.txt";
 
-	const size_t CHUNK_SIZE{500};
-	const size_t PREFIX_SIZE{308};
+	const size_t CHUNK_SIZE{ 500 };
+	const size_t PREFIX_SIZE{ 308 };
 	ASSERT_EQ( ResourceTools::CountMatchingChunks( introMovieFilePath, 0, introMoviePatchedFilePath, 0, CHUNK_SIZE ), 0 );
 	ASSERT_EQ( ResourceTools::CountMatchingChunks( introMovieFilePath, 0, introMoviePatchedFilePath, PREFIX_SIZE, CHUNK_SIZE ), 19 );
 	ASSERT_EQ( ResourceTools::CountMatchingChunks( introMovieFilePath, CHUNK_SIZE, introMoviePatchedFilePath, CHUNK_SIZE + PREFIX_SIZE, 500 ), 18 );
@@ -677,8 +673,8 @@ TEST_F( ResourceToolsTest, GenerateChunkIndex )
 {
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
-	std::filesystem::path testDataPath(testDataPathStr);
-    std::filesystem::path introMovieFilePath = testDataPath / "ResourcesOnBranch" / "introMovie.txt";
+	std::filesystem::path testDataPath( testDataPathStr );
+	std::filesystem::path introMovieFilePath = testDataPath / "ResourcesOnBranch" / "introMovie.txt";
 	std::string data;
 	ResourceTools::GetLocalFileData( introMovieFilePath, data );
 
@@ -695,25 +691,25 @@ TEST_F( ResourceToolsTest, GenerateChunkIndex )
 	std::string notInFile = "Once upon a time, in a galaxy far, far away...";
 	ResourceTools::ChunkIndex notInFileIndex( introMovieFilePath, static_cast<uint32_t>( notInFile.size() ), indexFolder );
 	notInFileIndex.Generate();
-	ASSERT_FALSE(notInFileIndex.FindMatchingChunk( notInFile, offset ));
+	ASSERT_FALSE( notInFileIndex.FindMatchingChunk( notInFile, offset ) );
 
 	std::string startOfFile = "TIME";
 	ResourceTools::ChunkIndex startOfFileIndex( introMovieFilePath, static_cast<uint32_t>( startOfFile.size() ), indexFolder );
 	startOfFileIndex.Generate();
-	ASSERT_TRUE(startOfFileIndex.FindMatchingChunk( startOfFile, offset ) );
+	ASSERT_TRUE( startOfFileIndex.FindMatchingChunk( startOfFile, offset ) );
 	ASSERT_EQ( offset, 0 );
 
 	std::string early = "introseq.blue";
 	ResourceTools::ChunkIndex earlyIndex( introMovieFilePath, static_cast<uint32_t>( early.size() ), indexFolder );
 	earlyIndex.Generate();
-	ASSERT_TRUE(earlyIndex.FindMatchingChunk( early, offset ) );
+	ASSERT_TRUE( earlyIndex.FindMatchingChunk( early, offset ) );
 	ASSERT_EQ( offset, data.find( early ) );
 
 	// Find the last 20 bytes of the file.
 	std::string final = data.substr( data.size() - 20 );
 	ResourceTools::ChunkIndex finalIndex( introMovieFilePath, static_cast<uint32_t>( final.size() ), indexFolder );
 	finalIndex.Generate();
-	ASSERT_TRUE(finalIndex.FindMatchingChunk( final, offset ) );
+	ASSERT_TRUE( finalIndex.FindMatchingChunk( final, offset ) );
 	ASSERT_EQ( offset, data.size() - 20 );
 }
 
@@ -721,8 +717,8 @@ TEST_F( ResourceToolsTest, GenerateChunkIndexWithFilter )
 {
 	const char* testDataPathStr = TEST_DATA_BASE_PATH;
 	ASSERT_TRUE( testDataPathStr );
-	std::filesystem::path testDataPath(testDataPathStr);
-    std::filesystem::path introMovieFilePath = testDataPath / "ResourcesOnBranch" / "introMovie.txt";
+	std::filesystem::path testDataPath( testDataPathStr );
+	std::filesystem::path introMovieFilePath = testDataPath / "ResourcesOnBranch" / "introMovie.txt";
 	std::string data;
 	ResourceTools::GetLocalFileData( introMovieFilePath, data );
 
@@ -739,13 +735,13 @@ TEST_F( ResourceToolsTest, GenerateChunkIndexWithFilter )
 	ResourceTools::ChunkIndex notInFileIndex( introMovieFilePath, static_cast<uint32_t>( notInFile.size() ), indexFolder );
 	notInFileIndex.GenerateChecksumFilter( introMovieFilePath );
 	notInFileIndex.Generate();
-	ASSERT_FALSE(notInFileIndex.FindMatchingChunk( notInFile, offset ));
+	ASSERT_FALSE( notInFileIndex.FindMatchingChunk( notInFile, offset ) );
 
 	std::string startOfFile = "TIME";
 	ResourceTools::ChunkIndex startOfFileIndex( introMovieFilePath, static_cast<uint32_t>( startOfFile.size() ), indexFolder );
 	startOfFileIndex.GenerateChecksumFilter( introMovieFilePath );
 	startOfFileIndex.Generate();
-	ASSERT_TRUE(startOfFileIndex.FindMatchingChunk( startOfFile, offset ) );
+	ASSERT_TRUE( startOfFileIndex.FindMatchingChunk( startOfFile, offset ) );
 	ASSERT_EQ( offset, 0 );
 
 	// Find a chunk early on in the file, that should be
@@ -754,7 +750,7 @@ TEST_F( ResourceToolsTest, GenerateChunkIndexWithFilter )
 	ResourceTools::ChunkIndex earlyIndex( introMovieFilePath, static_cast<uint32_t>( early.size() ), indexFolder );
 	earlyIndex.GenerateChecksumFilter( introMovieFilePath );
 	earlyIndex.Generate();
-	ASSERT_TRUE(earlyIndex.FindMatchingChunk( early, offset ) );
+	ASSERT_TRUE( earlyIndex.FindMatchingChunk( early, offset ) );
 	ASSERT_EQ( data.substr( offset, 10 ), early );
 
 	// Find the last whole chunk in the file.
@@ -762,7 +758,7 @@ TEST_F( ResourceToolsTest, GenerateChunkIndexWithFilter )
 	ResourceTools::ChunkIndex finalIndex( introMovieFilePath, 20, indexFolder );
 	finalIndex.GenerateChecksumFilter( introMovieFilePath );
 	finalIndex.Generate();
-	ASSERT_TRUE(finalIndex.FindMatchingChunk( final, offset ) );
+	ASSERT_TRUE( finalIndex.FindMatchingChunk( final, offset ) );
 	ASSERT_EQ( offset, data.size() - 31 );
 }
 
@@ -775,8 +771,8 @@ TEST_F( ResourceToolsTest, CalculateBinaryOperationMacOS )
 	std::filesystem::path testDataPath = TEST_DATA_BASE_PATH;
 	std::filesystem::path textFilePath = testDataPath / "resourcesOnBranch" / "introMovie.txt";
 	std::filesystem::path nonexistantFilePath = testDataPath / "resourcesOnBranch" / "thisFileDoesNotExist.txt";
-	ASSERT_EQ(33188, ResourceTools::CalculateBinaryOperation(textFilePath));
-	ASSERT_EQ(0, ResourceTools::CalculateBinaryOperation(nonexistantFilePath));
+	ASSERT_EQ( 33188, ResourceTools::CalculateBinaryOperation( textFilePath ) );
+	ASSERT_EQ( 0, ResourceTools::CalculateBinaryOperation( nonexistantFilePath ) );
 }
 #elif WIN32
 TEST_F( ResourceToolsTest, CalculateBinaryOperationWindows )
@@ -787,30 +783,30 @@ TEST_F( ResourceToolsTest, CalculateBinaryOperationWindows )
 	std::filesystem::path testDataPath = TEST_DATA_BASE_PATH;
 	std::filesystem::path textFilePath = testDataPath / "resourcesOnBranch" / "introMovie.txt";
 	std::filesystem::path nonexistantFilePath = testDataPath / "resourcesOnBranch" / "thisFileDoesNotExist.txt";
-	std::filesystem::path binaryFilePath = std::filesystem::temp_directory_path() / "CarbonResources" /  "binary.exe";
-	std::ofstream binaryFile(binaryFilePath);
+	std::filesystem::path binaryFilePath = std::filesystem::temp_directory_path() / "CarbonResources" / "binary.exe";
+	std::ofstream binaryFile( binaryFilePath );
 	binaryFile.close();
-	ASSERT_EQ(33279, ResourceTools::CalculateBinaryOperation(binaryFilePath));
-	ASSERT_EQ(33206, ResourceTools::CalculateBinaryOperation(textFilePath));
-	ASSERT_EQ(0, ResourceTools::CalculateBinaryOperation(nonexistantFilePath));
+	ASSERT_EQ( 33279, ResourceTools::CalculateBinaryOperation( binaryFilePath ) );
+	ASSERT_EQ( 33206, ResourceTools::CalculateBinaryOperation( textFilePath ) );
+	ASSERT_EQ( 0, ResourceTools::CalculateBinaryOperation( nonexistantFilePath ) );
 }
 #endif
 
 TEST_F( ResourceToolsTest, GzipStreams )
 {
 	std::string outbuffer;
-	ResourceTools::GzipCompressionStream stream(&outbuffer);
+	ResourceTools::GzipCompressionStream stream( &outbuffer );
 	stream.Start();
 	ResourceTools::FileDataStreamIn fileStreamIn( 50 );
 	std::filesystem::path testDataPath = TEST_DATA_BASE_PATH;
 	std::filesystem::path testFile = testDataPath / "resourcesOnBranch" / "introMovie.txt";
-	fileStreamIn.StartRead(testFile);
+	fileStreamIn.StartRead( testFile );
 	ResourceTools::Md5ChecksumStream originalMd5Stream;
 
-	while (!fileStreamIn.IsFinished())
+	while( !fileStreamIn.IsFinished() )
 	{
 		std::string fileData;
-		ASSERT_TRUE(fileStreamIn >> fileData);
+		ASSERT_TRUE( fileStreamIn >> fileData );
 		std::string compressedData;
 		originalMd5Stream << fileData;
 
@@ -820,7 +816,7 @@ TEST_F( ResourceToolsTest, GzipStreams )
 
 
 	std::string uncompressedData;
-	ResourceTools::GzipDecompressionStream decompressionStream(&uncompressedData);
+	ResourceTools::GzipDecompressionStream decompressionStream( &uncompressedData );
 	decompressionStream.Start();
 	EXPECT_TRUE( decompressionStream << &outbuffer );
 	EXPECT_TRUE( decompressionStream.Finish() );

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -2,7 +2,9 @@
 
 #include "CliTestFixture.h"
 
-struct ResourcesCliTest : public CliTestFixture{};
+struct ResourcesCliTest : public CliTestFixture
+{
+};
 
 TEST_F( ResourcesCliTest, RunWithoutArguments )
 {
@@ -12,8 +14,8 @@ TEST_F( ResourcesCliTest, RunWithoutArguments )
 
 	int res = RunCli( arguments, output );
 
-    // Expect 4 which indicates failed with no command specified
-    ASSERT_EQ( res, 4 );
+	// Expect 4 which indicates failed with no command specified
+	ASSERT_EQ( res, 4 );
 }
 
 TEST_F( ResourcesCliTest, RunWithNonesenseArguments )
@@ -22,11 +24,11 @@ TEST_F( ResourcesCliTest, RunWithNonesenseArguments )
 
 	std::vector<std::string> arguments;
 
-    arguments.push_back( "Nonesense" );
+	arguments.push_back( "Nonesense" );
 
 	int res = RunCli( arguments, output );
 
-    // Expect 3 which indicates failed due to invalid operation
+	// Expect 3 which indicates failed due to invalid operation
 	ASSERT_EQ( res, 3 );
 }
 
@@ -40,7 +42,7 @@ TEST_F( ResourcesCliTest, RunCreateGroupWithNoArguments )
 
 	int res = RunCli( arguments, output );
 
-    // Expect 2 which failed due to invalid operation arguments
+	// Expect 2 which failed due to invalid operation arguments
 	ASSERT_EQ( res, 2 );
 }
 
@@ -54,7 +56,7 @@ TEST_F( ResourcesCliTest, RunCreatePatchWithNoArguments )
 
 	int res = RunCli( arguments, output );
 
-    // Expect 2 which failed due to invalid operation arguments
+	// Expect 2 which failed due to invalid operation arguments
 	ASSERT_EQ( res, 2 );
 }
 
@@ -68,7 +70,7 @@ TEST_F( ResourcesCliTest, RunCreateBundleWithNoArguments )
 
 	int res = RunCli( arguments, output );
 
-    // Expect 2 which failed due to invalid operation arguments
+	// Expect 2 which failed due to invalid operation arguments
 	ASSERT_EQ( res, 2 );
 }
 
@@ -84,7 +86,7 @@ TEST_F( ResourcesCliTest, RunApplyPatchWithNoArguments )
 
 	int res = RunCli( arguments, output );
 
-    // Expect 2 which failed due to invalid operation arguments
+	// Expect 2 which failed due to invalid operation arguments
 	ASSERT_EQ( res, 2 );
 }
 
@@ -98,7 +100,7 @@ TEST_F( ResourcesCliTest, RunUnpackBundleWithNoArguments )
 
 	int res = RunCli( arguments, output );
 
-    // Expect 2 which failed due to invalid operation arguments
+	// Expect 2 which failed due to invalid operation arguments
 	ASSERT_EQ( res, 2 );
 }
 
@@ -119,9 +121,8 @@ TEST_F( ResourcesCliTest, CreateOperationWithInvalidInput )
 
 	int res = RunCli( arguments, output );
 
-    // Expect return 1 indicating failed during valid operation
+	// Expect return 1 indicating failed during valid operation
 	ASSERT_EQ( res, 1 );
-
 }
 
 #endif
@@ -145,16 +146,16 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectory )
 
 	int res = RunCli( arguments, output );
 
-    ASSERT_EQ( res, 0 );
+	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
-    EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
 }
 
 TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
@@ -180,16 +181,16 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
 
 	int res = RunCli( arguments, output );
 
-    ASSERT_EQ( res, 0 );
+	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.csv" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.csv" );
 #elif __APPLE__
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.csv" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.csv" );
 #else
 #error Unsupported platform
 #endif
-    EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.csv" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.csv" ) );
 }
 
 TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithPrefix )
@@ -221,22 +222,22 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithP
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindowsPrefixed.csv" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindowsPrefixed.csv" );
 #elif __APPLE__
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOSPrefixed.csv" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOSPrefixed.csv" );
 #else
 #error Unsupported platform
 #endif
-    EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroupPrefixed.csv" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroupPrefixed.csv" ) );
 }
 
 TEST_F( ResourcesCliTest, CreateBundle )
 {
 	std::string output;
 
-    std::vector<std::string> arguments;
+	std::vector<std::string> arguments;
 
-    arguments.push_back( "create-bundle" );
+	arguments.push_back( "create-bundle" );
 
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "3" );
@@ -249,7 +250,7 @@ TEST_F( ResourcesCliTest, CreateBundle )
 	arguments.push_back( "--bundle-resourcegroup-relative-path" );
 	arguments.push_back( "BundleResourceGroup.yaml" );
 
-    arguments.push_back( "--bundle-resourcegroup-destination-path" );
+	arguments.push_back( "--bundle-resourcegroup-destination-path" );
 	arguments.push_back( "BundleOut/" );
 
 	arguments.push_back( "--bundle-resourcegroup-destination-type" );
@@ -261,7 +262,7 @@ TEST_F( ResourcesCliTest, CreateBundle )
 	arguments.push_back( "--chunk-destination-type" );
 	arguments.push_back( "LOCAL_CDN" );
 
-	arguments.push_back( "--chunk-size");
+	arguments.push_back( "--chunk-size" );
 	arguments.push_back( "1000" );
 
 
@@ -302,7 +303,7 @@ TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResourceIgnoreOnResourceNotF
 
 	arguments.push_back( resourceGroupAfterRemovePath.string() );
 
-    arguments.push_back( "--ignore-missing-resources" );
+	arguments.push_back( "--ignore-missing-resources" );
 
 	int res = RunCli( arguments, output );
 
@@ -367,7 +368,6 @@ TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResource )
 	int res = RunCli( arguments, output );
 
 	EXPECT_EQ( res, 1 );
-
 }
 
 TEST_F( ResourcesCliTest, RemoveResources )
@@ -381,25 +381,25 @@ TEST_F( ResourcesCliTest, RemoveResources )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "3" );
 
-    std::string resourceGroupPath = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
+	std::string resourceGroupPath = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
 
 	arguments.push_back( resourceGroupPath );
 
-    std::string resourcesToRemoveFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourcesToRemoveList.txt" ).string();
+	std::string resourcesToRemoveFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourcesToRemoveList.txt" ).string();
 
 	arguments.push_back( resourcesToRemoveFile );
 
-    arguments.push_back( "--output-resource-group-path" );
+	arguments.push_back( "--output-resource-group-path" );
 
 	std::filesystem::path resourceGroupAfterRemovePath = "RemoveResource/ResourceGroup.yaml";
 
 	arguments.push_back( resourceGroupAfterRemovePath.string() );
 
-    int res = RunCli( arguments, output );
+	int res = RunCli( arguments, output );
 
 	EXPECT_EQ( res, 0 );
 
-    // Check output matches expected
+	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, resourceGroupAfterRemovePath ) );
@@ -424,11 +424,11 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
 
 	arguments.push_back( diffResourceGroupPath );
 
-    arguments.push_back( "--diff-output-path" );
+	arguments.push_back( "--diff-output-path" );
 
-    std::filesystem::path outputPath = "DiffWithTwoAdditions.txt";
+	std::filesystem::path outputPath = "DiffWithTwoAdditions.txt";
 
-    arguments.push_back( outputPath.string() );
+	arguments.push_back( outputPath.string() );
 
 	int res = RunCli( arguments, output );
 
@@ -437,7 +437,7 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
 	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "DiffGroups/ExpectedDiffWithAdditions.txt" );
 
-    EXPECT_TRUE( FileExists( goldFile ) );
+	EXPECT_TRUE( FileExists( goldFile ) );
 
 	EXPECT_TRUE( FileExists( outputPath ) );
 
@@ -476,7 +476,7 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoChanges )
 	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "DiffGroups/ExpectedDiffWithChanges.txt" );
 
-    EXPECT_TRUE( FileExists( goldFile ) );
+	EXPECT_TRUE( FileExists( goldFile ) );
 
 	EXPECT_TRUE( FileExists( outputPath ) );
 
@@ -515,9 +515,9 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoSubtractions )
 	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "DiffGroups/ExpectedDiffWithSubtractions.txt" );
 
-    EXPECT_TRUE( FileExists( goldFile ) );
+	EXPECT_TRUE( FileExists( goldFile ) );
 
-    EXPECT_TRUE( FileExists( outputPath ) );
+	EXPECT_TRUE( FileExists( outputPath ) );
 
 	EXPECT_TRUE( FilesMatch( goldFile, outputPath ) );
 }
@@ -533,25 +533,25 @@ TEST_F( ResourcesCliTest, MergeGroup )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "3" );
 
-    std::string baseResourceGroupPath = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/BaseResourceGroup.yaml" ).string();
+	std::string baseResourceGroupPath = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/BaseResourceGroup.yaml" ).string();
 
-    arguments.push_back( baseResourceGroupPath );
+	arguments.push_back( baseResourceGroupPath );
 
-    std::string mergeResourceGroupPath = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" ).string();
+	std::string mergeResourceGroupPath = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" ).string();
 
 	arguments.push_back( mergeResourceGroupPath );
 
-    arguments.push_back( "--merge-output-resource-group-path" );
+	arguments.push_back( "--merge-output-resource-group-path" );
 
-    std::filesystem::path mergedOutputPath = "Merge/mergedResourceGroup.yaml";
+	std::filesystem::path mergedOutputPath = "Merge/mergedResourceGroup.yaml";
 
-    arguments.push_back( mergedOutputPath.string() );
-    
-    int res = RunCli( arguments, output );
+	arguments.push_back( mergedOutputPath.string() );
+
+	int res = RunCli( arguments, output );
 
 	EXPECT_EQ( res, 0 );
 
-    // Check output matches expected
+	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/ExpectedMergedResourceGroup.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, mergedOutputPath ) );
@@ -581,15 +581,15 @@ TEST_F( ResourcesCliTest, CreatePatch )
 
 	std::string nextResourcesLocation = GetTestFileFileAbsolutePath( "Patch/NextBuildResources" ).string();
 
-	arguments.push_back( "--resource-source-base-path-next");
+	arguments.push_back( "--resource-source-base-path-next" );
 	arguments.push_back( nextResourcesLocation );
 
 	std::string previousResourcesLocation = GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ).string();
 
-	arguments.push_back( "--resource-source-base-path-previous");
+	arguments.push_back( "--resource-source-base-path-previous" );
 	arguments.push_back( previousResourcesLocation );
 
-	arguments.push_back( "--patch-resourcegroup-destination-path");
+	arguments.push_back( "--patch-resourcegroup-destination-path" );
 	arguments.push_back( "PatchOut" );
 
 	arguments.push_back( "--patch-destination-base-path" );
@@ -628,18 +628,18 @@ TEST_F( ResourcesCliTest, CreateGroup )
 
 	arguments.push_back( directoryIn );
 
-    arguments.push_back( "--output-file" );
+	arguments.push_back( "--output-file" );
 
-    std::string outputFilename = "ResourcesCliTestResourceGroup.yaml";
+	std::string outputFilename = "ResourcesCliTestResourceGroup.yaml";
 
-    arguments.push_back( outputFilename );
+	arguments.push_back( outputFilename );
 
 	int res = RunCli( arguments, output );
 
 	EXPECT_EQ( res, 0 );
 
-    // Check expected outcome
-    #if _WIN64
+// Check expected outcome
+#if _WIN64
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
@@ -666,42 +666,42 @@ TEST_F( ResourcesCliTest, ApplyPatch )
 
 	arguments.push_back( directoryIn );
 
-    arguments.push_back( "--patch-binaries-base-path" );
-    
-    std::string patchBinariesBasePath = GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches/" ).string();
-	
-    arguments.push_back( patchBinariesBasePath );
+	arguments.push_back( "--patch-binaries-base-path" );
 
-    arguments.push_back( "--resources-to-patch-base-path" );
-    
-    std::string resourcesToPatchBasePath = GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources/" ).string();
+	std::string patchBinariesBasePath = GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches/" ).string();
 
-    arguments.push_back( resourcesToPatchBasePath );
+	arguments.push_back( patchBinariesBasePath );
 
-    arguments.push_back( "--next-resources-base-path" );
+	arguments.push_back( "--resources-to-patch-base-path" );
 
-    std::string nextResourcesBasePath = GetTestFileFileAbsolutePath( "Patch/NextBuildResources/" ).string();
+	std::string resourcesToPatchBasePath = GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources/" ).string();
 
-    arguments.push_back( nextResourcesBasePath );
+	arguments.push_back( resourcesToPatchBasePath );
 
-    arguments.push_back( "--output-base-path" );
+	arguments.push_back( "--next-resources-base-path" );
 
-    std::string outputBasePath = "ApplyPatchOut";
+	std::string nextResourcesBasePath = GetTestFileFileAbsolutePath( "Patch/NextBuildResources/" ).string();
 
-    arguments.push_back( outputBasePath );
-    
-    if( std::filesystem::exists( outputBasePath ) )
+	arguments.push_back( nextResourcesBasePath );
+
+	arguments.push_back( "--output-base-path" );
+
+	std::string outputBasePath = "ApplyPatchOut";
+
+	arguments.push_back( outputBasePath );
+
+	if( std::filesystem::exists( outputBasePath ) )
 	{
 		std::filesystem::remove_all( outputBasePath );
 	}
 
-    std::filesystem::copy( resourcesToPatchBasePath, outputBasePath );
+	std::filesystem::copy( resourcesToPatchBasePath, outputBasePath );
 
 	int res = RunCli( arguments, output );
 
 	EXPECT_EQ( res, 0 );
 
-    // Check expected outcome
+	// Check expected outcome
 	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/NextBuildResources" );
 	EXPECT_TRUE( DirectoryIsSubset( outputBasePath, goldDirectory ) );
 }
@@ -721,15 +721,15 @@ TEST_F( ResourcesCliTest, UnpackBundle )
 
 	arguments.push_back( directoryIn );
 
-    arguments.push_back( "--chunk-source-base-path" );
+	arguments.push_back( "--chunk-source-base-path" );
 
-    std::string chunkSourceBasePath = GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ).string();
+	std::string chunkSourceBasePath = GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ).string();
 
-    arguments.push_back( chunkSourceBasePath );
+	arguments.push_back( chunkSourceBasePath );
 
-    arguments.push_back( "--resource-destination-type" );
+	arguments.push_back( "--resource-destination-type" );
 
-    arguments.push_back( "LOCAL_RELATIVE" );
+	arguments.push_back( "LOCAL_RELATIVE" );
 
 	int res = RunCli( arguments, output );
 

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -10,7 +10,9 @@
 
 #include <FileDataStreamOut.h>
 
-struct ResourcesLibraryTest : public ResourcesTestFixture{};
+struct ResourcesLibraryTest : public ResourcesTestFixture
+{
+};
 
 // Import ResourceGroup V0.0.0
 // Export should output as V0.1.0
@@ -22,17 +24,17 @@ TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_0_0_To_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-    importParams.filename = GetTestFileFileAbsolutePath( "Indicies/binaryFileIndex_v0_0_0.txt" );
+	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/binaryFileIndex_v0_0_0.txt" );
 
-	EXPECT_EQ(binaryResourceGroup.ImportFromFile( importParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( binaryResourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = "resPath/BinaryResourceGroup_v0_1_0.yaml";
+	exportParams.filename = "resPath/BinaryResourceGroup_v0_1_0.yaml";
 
-	EXPECT_EQ(binaryResourceGroup.ExportToFile( exportParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( binaryResourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
 
-    std::filesystem::path goldStandardFilename = GetTestFileFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
+	std::filesystem::path goldStandardFilename = GetTestFileFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
 
 	EXPECT_TRUE( FilesMatch( exportParams.filename, goldStandardFilename ) );
 }
@@ -44,20 +46,20 @@ TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-    importParams.filename = GetTestFileFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
+	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
 
-	EXPECT_EQ(binaryResourceGroup.ImportFromFile( importParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( binaryResourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = "resPath/BinaryResourceGroup_v0_1_0.yaml";
+	exportParams.filename = "resPath/BinaryResourceGroup_v0_1_0.yaml";
 
-	EXPECT_EQ(binaryResourceGroup.ExportToFile( exportParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( binaryResourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	EXPECT_TRUE( FilesMatch( importParams.filename, exportParams.filename ) );
 }
 
-// Import ResourceGroup V0.0.0 
+// Import ResourceGroup V0.0.0
 // Export should output as V0.1.0
 // This is the only instance that exporting a file of a lower version results in a version bump
 TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0 )
@@ -66,17 +68,17 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-    importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0.txt" );
+	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0.txt" );
 
-	EXPECT_EQ(resourceGroup.ImportFromFile( importParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = "resPath/ResourceGroup_v0_1_0.yaml";
+	exportParams.filename = "resPath/ResourceGroup_v0_1_0.yaml";
 
-	EXPECT_EQ(resourceGroup.ExportToFile( exportParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
 
-    std::filesystem::path goldStandardFilename = GetTestFileFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
+	std::filesystem::path goldStandardFilename = GetTestFileFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
 
 	EXPECT_TRUE( FilesMatch( exportParams.filename, goldStandardFilename ) );
 }
@@ -86,7 +88,7 @@ TEST_F( ResourcesLibraryTest, ImportEmptyResourceGroup )
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 	importParams.filename = GetTestFileFileAbsolutePath( "ResourceGroups/EmptyResourceGroup.yaml" );
-	EXPECT_EQ(resourceGroup.ImportFromFile( importParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 }
 
 TEST_F( ResourcesLibraryTest, ImportResourceGroupWithOutOfBoundsBinaryOperation )
@@ -97,15 +99,15 @@ TEST_F( ResourcesLibraryTest, ImportResourceGroupWithOutOfBoundsBinaryOperation 
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_INPUT );
 }
 
-void CreateEmptyResourceGroupWithMissingParameter(std::filesystem::path emptyResourceGroupPath, std::filesystem::path outPath, const std::string& missingTagName)
+void CreateEmptyResourceGroupWithMissingParameter( std::filesystem::path emptyResourceGroupPath, std::filesystem::path outPath, const std::string& missingTagName )
 {
 	std::filesystem::path testDataFolder( TEST_DATA_BASE_PATH );
 	std::ifstream fileIn( emptyResourceGroupPath );
 	create_directories( outPath.parent_path() );
-	std::ofstream fileOut( outPath, std::ios::out);
+	std::ofstream fileOut( outPath, std::ios::out );
 	ASSERT_TRUE( fileOut.is_open() );
 	std::string line;
-	while(std::getline( fileIn, line ))
+	while( std::getline( fileIn, line ) )
 	{
 		std::string formattedTag = missingTagName + ":";
 		std::string startOfLine = line.substr( 0, missingTagName.size() + 1 );
@@ -118,7 +120,7 @@ void CreateEmptyResourceGroupWithMissingParameter(std::filesystem::path emptyRes
 
 CarbonResources::Result AttemptImportResourceGroupMissingParameter( const std::string& tag, std::filesystem::path emptyResourceGroupPath )
 {
-	std::filesystem::path outPath(std::filesystem::current_path() / "ResourceGroups" / ("Missing" + tag + ".yaml"));
+	std::filesystem::path outPath( std::filesystem::current_path() / "ResourceGroups" / ( "Missing" + tag + ".yaml" ) );
 	CreateEmptyResourceGroupWithMissingParameter( emptyResourceGroupPath, outPath, tag );
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
@@ -159,7 +161,6 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadInvalidCsv )
 	// Try and load group but fail to parse csv
 	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_NONESENSE.txt" );
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_INPUT );
-
 }
 
 TEST_F( ResourcesLibraryTest, ResourceGroupLoadCsvWithInvalidCompressedSizeField )
@@ -182,7 +183,6 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadEmptyCsv )
 	// Try and load group, results in success but empty list
 	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_EMPTY.txt" );
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
-
 }
 
 TEST_F( ResourcesLibraryTest, ResourceGroupLoadNonexistantFileFails )
@@ -248,15 +248,15 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-    importParams.filename = GetTestFileFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
+	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
 
-	EXPECT_EQ(resourceGroup.ImportFromFile( importParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = "resPath/ResourceGroup_v0_1_0.yaml";
+	exportParams.filename = "resPath/ResourceGroup_v0_1_0.yaml";
 
-	EXPECT_EQ(resourceGroup.ExportToFile( exportParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	EXPECT_TRUE( FilesMatch( importParams.filename, exportParams.filename ) );
 }
@@ -273,9 +273,9 @@ TEST_F( ResourcesLibraryTest, UnpackBundle )
 	EXPECT_EQ( bundleResourceGroup.ImportFromFile( importParamsPrevious ).type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Unpack the bundle
+	// Unpack the bundle
 	CarbonResources::BundleUnpackParams bundleUnpackParams;
-	
+
 	bundleUnpackParams.chunkSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
 
 	bundleUnpackParams.chunkSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ) };
@@ -289,8 +289,6 @@ TEST_F( ResourcesLibraryTest, UnpackBundle )
 	EXPECT_TRUE( DirectoryIsSubset( GetTestFileFileAbsolutePath( "Bundle/Res" ), "UnpackBundleOut" ) );
 
 	EXPECT_TRUE( std::filesystem::exists( "UnpackBundleOut/ResourceGroup.yaml" ) );
-
-
 }
 
 TEST_F( ResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
@@ -308,7 +306,7 @@ TEST_F( ResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
 	// Unpack the bundle
 	CarbonResources::BundleUnpackParams bundleUnpackParams;
 
-	bundleUnpackParams.chunkSourceSettings.sourceType = CarbonResources::ResourceSourceType::REMOTE_CDN;    // source is LOCAL_CDN
+	bundleUnpackParams.chunkSourceSettings.sourceType = CarbonResources::ResourceSourceType::REMOTE_CDN; // source is LOCAL_CDN
 
 	bundleUnpackParams.chunkSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ) };
 
@@ -316,9 +314,8 @@ TEST_F( ResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
 
 	bundleUnpackParams.resourceDestinationSettings.basePath = "UnpackBundleOut/";
 
-    // Should fail
+	// Should fail
 	EXPECT_EQ( bundleResourceGroup.Unpack( bundleUnpackParams ).type, CarbonResources::ResultType::FAILED_TO_OPEN_FILE );
-
 }
 
 TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
@@ -329,18 +326,18 @@ TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 	importParams.filename = GetTestFileFileAbsolutePath( "Bundle/resfileindexShort.txt" );
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 
-    // Create a bundle from the ResourceGroup
+	// Create a bundle from the ResourceGroup
 	CarbonResources::BundleCreateParams bundleCreateParams;
-    bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+	bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
 	bundleCreateParams.resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
 	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
-    bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
-    bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::REMOTE_CDN;
-    bundleCreateParams.chunkDestinationSettings.basePath = "UnpackRemoteBundleAsLocal/Chunks";
-    bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
+	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::REMOTE_CDN;
+	bundleCreateParams.chunkDestinationSettings.basePath = "UnpackRemoteBundleAsLocal/Chunks";
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = "UnpackRemoteBundleAsLocal";
-    bundleCreateParams.chunkSize = 1000000000;
-	EXPECT_EQ(resourceGroup.CreateBundle( bundleCreateParams ).type,CarbonResources::ResultType::SUCCESS);
+	bundleCreateParams.chunkSize = 1000000000;
+	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	// Load the bundle file
 	CarbonResources::BundleResourceGroup bundleResourceGroup;
@@ -348,7 +345,7 @@ TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 	importParamsPrevious.filename = "UnpackRemoteBundleAsLocal/BundleResourceGroup.yaml";
 	EXPECT_EQ( bundleResourceGroup.ImportFromFile( importParamsPrevious ).type, CarbonResources::ResultType::SUCCESS );
 
-    // Attempt to unpack the bundle
+	// Attempt to unpack the bundle
 	CarbonResources::BundleUnpackParams bundleUnpackParams;
 	bundleUnpackParams.chunkSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
 	bundleUnpackParams.chunkSourceSettings.basePaths = { "UnpackRemoteBundleAsLocal/Chunks/" };
@@ -393,7 +390,6 @@ TEST_F( ResourcesLibraryTest, CreateBundleWithZeroChunkSize )
 	bundleCreateParams.chunkSize = 0;
 
 	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::INVALID_CHUNK_SIZE );
-
 }
 
 TEST_F( ResourcesLibraryTest, CreateBundle )
@@ -408,32 +404,31 @@ TEST_F( ResourcesLibraryTest, CreateBundle )
 	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Create a bundle from the ResourceGroup
+	// Create a bundle from the ResourceGroup
 	CarbonResources::BundleCreateParams bundleCreateParams;
 
-    bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+	bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
 
 	bundleCreateParams.resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
 
 	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-    bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
 
-    bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
+	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
-    bundleCreateParams.chunkDestinationSettings.basePath = "CreateBundleOut";
+	bundleCreateParams.chunkDestinationSettings.basePath = "CreateBundleOut";
 
-    bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
 	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = "resPath";
 
-    bundleCreateParams.chunkSize = 1000;
+	bundleCreateParams.chunkSize = 1000;
 
-	EXPECT_EQ(resourceGroup.CreateBundle( bundleCreateParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 
-	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroup.yaml" , GetTestFileFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" ) ) );
+	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroup.yaml", GetTestFileFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" ) ) );
 	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileFileAbsolutePath( "CreateBundle/CreateBundleOut" ) ) );
-
 }
 
 TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
@@ -496,9 +491,9 @@ TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
 
 	EXPECT_EQ( bundleResourceGroup.Unpack( bundleUnpackParams ).type, CarbonResources::ResultType::SUCCESS );
 
-	EXPECT_TRUE( DirectoryIsSubset( bundleCreateParams.resourceSourceSettings.basePaths.at(0), bundleUnpackParams.resourceDestinationSettings.basePath ) );
+	EXPECT_TRUE( DirectoryIsSubset( bundleCreateParams.resourceSourceSettings.basePaths.at( 0 ), bundleUnpackParams.resourceDestinationSettings.basePath ) );
 
-    std::filesystem::path unpackedGroupPath = bundleUnpackParams.resourceDestinationSettings.basePath / "ResourceGroup.yaml";
+	std::filesystem::path unpackedGroupPath = bundleUnpackParams.resourceDestinationSettings.basePath / "ResourceGroup.yaml";
 
 	EXPECT_TRUE( std::filesystem::exists( unpackedGroupPath ) );
 }
@@ -508,33 +503,33 @@ TEST_F( ResourcesLibraryTest, ApplyPatch )
 	// Load the patch file
 	CarbonResources::PatchResourceGroup patchResourceGroup;
 
-    CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
+	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-    importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
+	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
 
 	EXPECT_EQ( patchResourceGroup.ImportFromFile( importParamsPrevious ).type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Apply the patch
+	// Apply the patch
 	CarbonResources::PatchApplyParams patchApplyParams;
 
-    patchApplyParams.nextBuildResourcesSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+	patchApplyParams.nextBuildResourcesSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
 	patchApplyParams.nextBuildResourcesSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/NextBuildResources/" ) };
 
-    patchApplyParams.patchBinarySourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
+	patchApplyParams.patchBinarySourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
 
-    patchApplyParams.patchBinarySourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches/" ) };
+	patchApplyParams.patchBinarySourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches/" ) };
 
-    patchApplyParams.resourcesToPatchSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+	patchApplyParams.resourcesToPatchSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-    patchApplyParams.resourcesToPatchSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources/" ) };
+	patchApplyParams.resourcesToPatchSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources/" ) };
 
-    patchApplyParams.resourcesToPatchDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+	patchApplyParams.resourcesToPatchDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
-    patchApplyParams.resourcesToPatchDestinationSettings.basePath = "ApplyPatchOut";
+	patchApplyParams.resourcesToPatchDestinationSettings.basePath = "ApplyPatchOut";
 
-    patchApplyParams.temporaryFilePath = "tempFile.resource";
+	patchApplyParams.temporaryFilePath = "tempFile.resource";
 
 	if( std::filesystem::exists( patchApplyParams.resourcesToPatchDestinationSettings.basePath ) )
 	{
@@ -543,12 +538,11 @@ TEST_F( ResourcesLibraryTest, ApplyPatch )
 
 	std::filesystem::copy( patchApplyParams.resourcesToPatchSourceSettings.basePaths[0], patchApplyParams.resourcesToPatchDestinationSettings.basePath );
 
-    EXPECT_EQ(patchResourceGroup.Apply( patchApplyParams ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( patchResourceGroup.Apply( patchApplyParams ).type, CarbonResources::ResultType::SUCCESS );
 
-    // Check Expected Outcome
+	// Check Expected Outcome
 	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/NextBuildResources" );
-	EXPECT_TRUE( DirectoryIsSubset( patchApplyParams.resourcesToPatchDestinationSettings.basePath , goldDirectory ));
-
+	EXPECT_TRUE( DirectoryIsSubset( patchApplyParams.resourcesToPatchDestinationSettings.basePath, goldDirectory ) );
 }
 TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 {
@@ -603,68 +597,66 @@ TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 	EXPECT_EQ( resourceGroupLatest.CreatePatch( patchCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	// Check expected outcome
-
 }
 
 TEST_F( ResourcesLibraryTest, CreatePatch )
 {
-    // Previous ResourceGroup
+	// Previous ResourceGroup
 	CarbonResources::ResourceGroup resourceGroupPrevious;
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-    importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
+	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
 
-	EXPECT_EQ(resourceGroupPrevious.ImportFromFile( importParamsPrevious ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroupPrevious.ImportFromFile( importParamsPrevious ).type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Latest ResourceGroup
+	// Latest ResourceGroup
 	CarbonResources::ResourceGroup resourceGroupLatest;
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsLatest;
 
-    importParamsLatest.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
+	importParamsLatest.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
 
-	EXPECT_EQ(resourceGroupLatest.ImportFromFile( importParamsLatest ).type,CarbonResources::ResultType::SUCCESS);
+	EXPECT_EQ( resourceGroupLatest.ImportFromFile( importParamsLatest ).type, CarbonResources::ResultType::SUCCESS );
 
-    // Create a patch from the subtraction index
+	// Create a patch from the subtraction index
 	CarbonResources::PatchCreateParams patchCreateParams;
 
-    patchCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+	patchCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
 
-    patchCreateParams.resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
+	patchCreateParams.resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
 
-    patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-    patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ) };
 
-    patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+	patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-    patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileFileAbsolutePath( "Patch/NextBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileFileAbsolutePath( "Patch/NextBuildResources" ) };
 
-    patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
+	patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
-    patchCreateParams.resourcePatchBinaryDestinationSettings.basePath = "SharedCache";
+	patchCreateParams.resourcePatchBinaryDestinationSettings.basePath = "SharedCache";
 
-    patchCreateParams.resourcePatchResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+	patchCreateParams.resourcePatchResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
-    patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath = "resPath";
+	patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath = "resPath";
 
-    patchCreateParams.patchFileRelativePathPrefix = "Patches/Patch";
+	patchCreateParams.patchFileRelativePathPrefix = "Patches/Patch";
 
-    patchCreateParams.previousResourceGroup = &resourceGroupPrevious;
+	patchCreateParams.previousResourceGroup = &resourceGroupPrevious;
 
-    patchCreateParams.maxInputFileChunkSize = 50000000;
-    
-	EXPECT_EQ(resourceGroupLatest.CreatePatch( patchCreateParams ).type,CarbonResources::ResultType::SUCCESS);
+	patchCreateParams.maxInputFileChunkSize = 50000000;
 
-    // Check expected outcome
+	EXPECT_EQ( resourceGroupLatest.CreatePatch( patchCreateParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	// Check expected outcome
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
 	EXPECT_TRUE( FilesMatch( goldFile, patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath / "PatchResourceGroup.yaml" ) );
 
 	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches" );
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
-    
 }
 
 TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )
@@ -718,7 +710,6 @@ TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )
 	patchCreateParams.maxInputFileChunkSize = 0;
 
 	EXPECT_EQ( resourceGroupLatest.CreatePatch( patchCreateParams ).type, CarbonResources::ResultType::INVALID_CHUNK_SIZE );
-
 }
 
 TEST_F( ResourcesLibraryTest, ApplyPatchWithChunking )
@@ -822,7 +813,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchWithChunking )
 	EXPECT_TRUE( FilesMatch( goldFile, patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath / "PatchResourceGroup_previousBuild_latestBuild.yaml" ) );
 
 	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "PatchWithInputChunk/LocalCDNPatches" );
-	EXPECT_TRUE( DirectoryIsSubset(  goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
+	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
 }
 
 TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
@@ -842,13 +833,13 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
 	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
 
 #if _WIN64
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-    std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
-    EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
+	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
 TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryOutputPathIsInvalid )
@@ -866,7 +857,6 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryOutputPathIsInvali
 	exportParams.filename = "///";
 
 	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::FAILED_TO_SAVE_FILE );
-
 }
 
 TEST_F( ResourcesLibraryTest, CreateResourceGroupFailsWithInvalidInputDirectory )
@@ -877,12 +867,12 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFailsWithInvalidInputDirectory 
 
 	createResourceGroupParams.directory = "INVALID_PATH";
 
-	EXPECT_EQ( resourceGroup.CreateFromDirectory( createResourceGroupParams ).type, CarbonResources::ResultType::INPUT_DIRECTORY_DOESNT_EXIST);
+	EXPECT_EQ( resourceGroup.CreateFromDirectory( createResourceGroupParams ).type, CarbonResources::ResultType::INPUT_DIRECTORY_DOESNT_EXIST );
 }
 
 TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 {
-    // Load base group
+	// Load base group
 	CarbonResources::ResourceGroup baseResourceGroup;
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
@@ -894,8 +884,8 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 	EXPECT_EQ( importFromFileResult.type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Load group with additions
-    CarbonResources::ResourceGroup resourceGroupWithAdditions;
+	// Load group with additions
+	CarbonResources::ResourceGroup resourceGroupWithAdditions;
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParamsWithAdditions;
 
@@ -906,27 +896,26 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 	EXPECT_EQ( importFromFileResultAdditions.type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Perform diff
-    CarbonResources::ResourceGroupDiffAgainstGroupParams diffAgainstGroupParams;
+	// Perform diff
+	CarbonResources::ResourceGroupDiffAgainstGroupParams diffAgainstGroupParams;
 
-    diffAgainstGroupParams.resourceGroupToDiffAgainst = &baseResourceGroup;
+	diffAgainstGroupParams.resourceGroupToDiffAgainst = &baseResourceGroup;
 
-    std::vector<std::filesystem::path> additions;
+	std::vector<std::filesystem::path> additions;
 
-    std::vector<std::filesystem::path> subtractions;
+	std::vector<std::filesystem::path> subtractions;
 
-    diffAgainstGroupParams.additions = &additions;
+	diffAgainstGroupParams.additions = &additions;
 
-    diffAgainstGroupParams.subtractions = &subtractions;
+	diffAgainstGroupParams.subtractions = &subtractions;
 
-    CarbonResources::Result diffResult = resourceGroupWithAdditions.DiffAgainstGroup( diffAgainstGroupParams );
+	CarbonResources::Result diffResult = resourceGroupWithAdditions.DiffAgainstGroup( diffAgainstGroupParams );
 
-    EXPECT_EQ( diffResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( diffResult.type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Test the result
+	// Test the result
 	EXPECT_EQ( additions.size(), 2 );
-
 }
 
 TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoChanges )
@@ -1035,42 +1024,42 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive )
 
 	CarbonResources::Result importFromFileResult = resourceGroup.ImportFromFile( importFromFileParams );
 
-    EXPECT_EQ( importFromFileResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( importFromFileResult.type, CarbonResources::ResultType::SUCCESS );
 
-    // Load merge group
-    CarbonResources::ResourceGroup resourceGroupToMerge;
+	// Load merge group
+	CarbonResources::ResourceGroup resourceGroupToMerge;
 
-    CarbonResources::ResourceGroupImportFromFileParams mergeImportFromFileParams;
+	CarbonResources::ResourceGroupImportFromFileParams mergeImportFromFileParams;
 
-    mergeImportFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" );
+	mergeImportFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" );
 
-    CarbonResources::Result mergeImportFromFileResult = resourceGroupToMerge.ImportFromFile( mergeImportFromFileParams );
+	CarbonResources::Result mergeImportFromFileResult = resourceGroupToMerge.ImportFromFile( mergeImportFromFileParams );
 
-    EXPECT_EQ( mergeImportFromFileResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( mergeImportFromFileResult.type, CarbonResources::ResultType::SUCCESS );
 
-    // Merge resource groups
+	// Merge resource groups
 	CarbonResources::ResourceGroup mergedResourceGroup;
 
 	CarbonResources::ResourceGroupMergeParams mergeParams;
 
-    mergeParams.resourceGroupToMerge = &resourceGroupToMerge;
+	mergeParams.resourceGroupToMerge = &resourceGroupToMerge;
 
-    mergeParams.mergedResourceGroup = &mergedResourceGroup;
+	mergeParams.mergedResourceGroup = &mergedResourceGroup;
 
 	CarbonResources::Result mergeResult = resourceGroup.Merge( mergeParams );
 
-    EXPECT_EQ( mergeResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( mergeResult.type, CarbonResources::ResultType::SUCCESS );
 
-    // Export the merged result
+	// Export the merged result
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = "Merge/mergedResourceGroup.yaml";
+	exportParams.filename = "Merge/mergedResourceGroup.yaml";
 
 	CarbonResources::Result exportResult = mergedResourceGroup.ExportToFile( exportParams );
 
-    EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
 
-    // Check output matches expected
+	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/ExpectedMergedResourceGroup.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
@@ -1168,7 +1157,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
 
 	exportParams.filename = "Merge/mergedResourceGroup.txt";
 
-    exportParams.outputDocumentVersion = CarbonResources::Version{ 0, 0, 0 };
+	exportParams.outputDocumentVersion = CarbonResources::Version{ 0, 0, 0 };
 
 	CarbonResources::Result exportResult = mergedResourceGroup.ExportToFile( exportParams );
 
@@ -1221,7 +1210,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
 
 	exportParams.filename = "Merge/mergedResourceGroup.txt";
 
-    exportParams.outputDocumentVersion = CarbonResources::Version{ 0, 0, 0 };
+	exportParams.outputDocumentVersion = CarbonResources::Version{ 0, 0, 0 };
 
 	CarbonResources::Result exportResult = mergedResourceGroup.ExportToFile( exportParams );
 
@@ -1237,44 +1226,42 @@ TEST_F( ResourcesLibraryTest, RemoveResource )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 
-    // Import ResourceGroup
-    CarbonResources::ResourceGroupImportFromFileParams importParams;
+	// Import ResourceGroup
+	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-    importParams.filename = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" );
+	importParams.filename = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" );
 
-    CarbonResources::Result importResult = resourceGroup.ImportFromFile( importParams );
+	CarbonResources::Result importResult = resourceGroup.ImportFromFile( importParams );
 
-    EXPECT_EQ( importResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( importResult.type, CarbonResources::ResultType::SUCCESS );
 
-    // Remove resource B.txt
+	// Remove resource B.txt
 	CarbonResources::ResourceGroupRemoveResourcesParams removeParams;
 
-    std::vector<std::filesystem::path> resourcesToRemove;
+	std::vector<std::filesystem::path> resourcesToRemove;
 
-    resourcesToRemove.push_back( "B.txt" );
+	resourcesToRemove.push_back( "B.txt" );
 
-    removeParams.resourcesToRemove = &resourcesToRemove;
+	removeParams.resourcesToRemove = &resourcesToRemove;
 
-    removeParams.errorIfResourceNotFound = true;
+	removeParams.errorIfResourceNotFound = true;
 
 	CarbonResources::Result removeResult = resourceGroup.RemoveResources( removeParams );
 
-    EXPECT_EQ( removeResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( removeResult.type, CarbonResources::ResultType::SUCCESS );
 
-    // Export the ResourceGroup
+	// Export the ResourceGroup
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
-    exportParams.filename = "RemoveResource/ResourceGroup.yaml";
+	exportParams.filename = "RemoveResource/ResourceGroup.yaml";
 
 	CarbonResources::Result exportResult = resourceGroup.ExportToFile( exportParams );
 
-    EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
+	EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
 
 
-    // Check output matches expected
+	// Check output matches expected
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
-
-
 }

--- a/tests/src/ResourcesTestFixture.cpp
+++ b/tests/src/ResourcesTestFixture.cpp
@@ -14,12 +14,10 @@
 
 void ResourcesTestFixture::SetUp()
 {
-
 }
 
 void ResourcesTestFixture::TearDown()
 {
-	
 }
 
 bool ResourcesTestFixture::FileExists( const std::filesystem::path& filePath )
@@ -29,40 +27,40 @@ bool ResourcesTestFixture::FileExists( const std::filesystem::path& filePath )
 
 bool ResourcesTestFixture::FilesMatch( const std::filesystem::path& file1Path, const std::filesystem::path& file2Path )
 {
-    // Open files generate data checksums and compare
+	// Open files generate data checksums and compare
 
-    // File 1
+	// File 1
 	std::ifstream inputStream1;
 
 	inputStream1.open( file1Path, std::ios::in | std::ios::binary );
 
-    if (!inputStream1)
-    {
+	if( !inputStream1 )
+	{
 		return false;
-    }
+	}
 
-    std::stringstream ss1;
+	std::stringstream ss1;
 
-    ss1 << inputStream1.rdbuf();
+	ss1 << inputStream1.rdbuf();
 
-    std::string file1Data = ss1.str();
+	std::string file1Data = ss1.str();
 
-    inputStream1.close();
+	inputStream1.close();
 
-    std::string file1Checksum = "";
+	std::string file1Checksum = "";
 
-    bool result1 = ResourceTools::GenerateMd5Checksum( file1Data, file1Checksum );
+	bool result1 = ResourceTools::GenerateMd5Checksum( file1Data, file1Checksum );
 
 
-    // File 2
-    std::ifstream inputStream2;
+	// File 2
+	std::ifstream inputStream2;
 
-	inputStream2.open( file2Path, std::ios::in | std::ios::binary ); 
+	inputStream2.open( file2Path, std::ios::in | std::ios::binary );
 
-    if (!inputStream2)
-    {
+	if( !inputStream2 )
+	{
 		return false;
-    }
+	}
 
 	std::stringstream ss2;
 
@@ -72,12 +70,11 @@ bool ResourcesTestFixture::FilesMatch( const std::filesystem::path& file1Path, c
 
 	inputStream2.close();
 
-    std::string file2Checksum = "";
+	std::string file2Checksum = "";
 
 	bool result2 = ResourceTools::GenerateMd5Checksum( file2Data, file2Checksum );
 
-    return file1Checksum == file2Checksum;
-    
+	return file1Checksum == file2Checksum;
 }
 
 bool ResourcesTestFixture::DirectoryIsSubset( const std::filesystem::path& dir1, const std::filesystem::path& dir2 )
@@ -98,7 +95,7 @@ bool ResourcesTestFixture::DirectoryIsSubset( const std::filesystem::path& dir1,
 
 std::filesystem::path ResourcesTestFixture::GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath )
 {
-    std::filesystem::path basePath( TEST_DATA_BASE_PATH );
+	std::filesystem::path basePath( TEST_DATA_BASE_PATH );
 
-    return basePath / relativePath;
+	return basePath / relativePath;
 }

--- a/tests/src/ResourcesTestFixture.h
+++ b/tests/src/ResourcesTestFixture.h
@@ -16,11 +16,11 @@ struct ResourcesTestFixture : public ::testing::Test
 
 	void TearDown();
 
-    std::filesystem::path GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath );
+	std::filesystem::path GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath );
 
-    bool FileExists( const std::filesystem::path& filePath);
+	bool FileExists( const std::filesystem::path& filePath );
 
-    bool FilesMatch( const std::filesystem::path& file1Path, const std::filesystem::path& file2Path );
+	bool FilesMatch( const std::filesystem::path& file1Path, const std::filesystem::path& file2Path );
 
 	bool DirectoryIsSubset( const std::filesystem::path& dir1, const std::filesystem::path& dir2 ); // Test that all files in dir1 exist in dir2, and the contents of the files in both directories are the same.
 };

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,36 +8,36 @@ find_package(CURL CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
 set(SRC_FILES
-    include/BundleStreamIn.h
-    include/BundleStreamOut.h
-    include/ChunkIndex.h
-    include/CompressedFileDataStreamOut.h
-    include/Downloader.h
-    include/FileDataStreamIn.h
-    include/FileDataStreamOut.h
-    include/GzipCompressionStream.h
-    include/GzipDecompressionStream.h
-    include/Md5ChecksumStream.h
-    include/Patching.h
-    include/ResourceTools.h
-    include/RollingChecksum.h
-    include/ScopedFile.h
-    include/StatusCallback.h
+        include/BundleStreamIn.h
+        include/BundleStreamOut.h
+        include/ChunkIndex.h
+        include/CompressedFileDataStreamOut.h
+        include/Downloader.h
+        include/FileDataStreamIn.h
+        include/FileDataStreamOut.h
+        include/GzipCompressionStream.h
+        include/GzipDecompressionStream.h
+        include/Md5ChecksumStream.h
+        include/Patching.h
+        include/ResourceTools.h
+        include/RollingChecksum.h
+        include/ScopedFile.h
+        include/StatusCallback.h
 
-    src/BundleStreamIn.cpp
-    src/BundleStreamOut.cpp
-    src/ChunkIndex.cpp
-    src/CompressedFileDataStreamOut.cpp
-    src/Downloader.cpp
-    src/FileDataStreamIn.cpp
-    src/FileDataStreamOut.cpp
-    src/GzipCompressionStream.cpp
-    src/GzipDecompressionStream.cpp
-    src/Md5ChecksumStream.cpp
-    src/ResourceTools.cpp
-    src/ScopedFile.cpp
-    src/Patching.cpp
-    src/RollingChecksum.cpp
+        src/BundleStreamIn.cpp
+        src/BundleStreamOut.cpp
+        src/ChunkIndex.cpp
+        src/CompressedFileDataStreamOut.cpp
+        src/Downloader.cpp
+        src/FileDataStreamIn.cpp
+        src/FileDataStreamOut.cpp
+        src/GzipCompressionStream.cpp
+        src/GzipDecompressionStream.cpp
+        src/Md5ChecksumStream.cpp
+        src/ResourceTools.cpp
+        src/ScopedFile.cpp
+        src/Patching.cpp
+        src/RollingChecksum.cpp
 )
 
 add_library(resources-tools STATIC ${SRC_FILES})
@@ -50,9 +50,9 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
         FILES ${_SOURCES}
 )
 
-if(WIN32)
+if (WIN32)
     target_compile_definitions(resources-tools PRIVATE NOMINMAX) # Do not define min/max macros.
-endif()
+endif ()
 
 target_link_libraries(resources-tools PRIVATE cryptopp::cryptopp CURL::libcurl ZLIB::ZLIB static_bsdiff)
 

--- a/tools/include/BundleStreamIn.h
+++ b/tools/include/BundleStreamIn.h
@@ -9,39 +9,38 @@
 namespace ResourceTools
 {
 
-    struct GetFile
-    {
-		uintmax_t fileSize = 0;
+struct GetFile
+{
+	uintmax_t fileSize = 0;
 
-        std::string* data = nullptr;
-    };
+	std::string* data = nullptr;
+};
 
-    class BundleStreamIn
-	{
-	public:
-		BundleStreamIn( uintmax_t chunkSize );
+class BundleStreamIn
+{
+public:
+	BundleStreamIn( uintmax_t chunkSize );
 
-		~BundleStreamIn();
+	~BundleStreamIn();
 
-        uintmax_t GetCacheSize();
+	uintmax_t GetCacheSize();
 
-		uintmax_t GetChunkSize() const;
+	uintmax_t GetChunkSize() const;
 
-		bool ReadBytes( size_t n, std::string& data );
+	bool ReadBytes( size_t n, std::string& data );
 
-		bool operator<<( const std::string& chunkData );
+	bool operator<<( const std::string& chunkData );
 
-		bool operator>>( GetFile& fileData );
+	bool operator>>( GetFile& fileData );
 
 
-	private:
+private:
+	uintmax_t m_chunkSize;
 
-        uintmax_t m_chunkSize;
+	std::string m_cache;
 
-		std::string m_cache;
-
-        uintmax_t m_dataReadOfCurrentFile;
-	};
+	uintmax_t m_dataReadOfCurrentFile;
+};
 
 
 }

--- a/tools/include/BundleStreamOut.h
+++ b/tools/include/BundleStreamOut.h
@@ -14,59 +14,59 @@
 namespace ResourceTools
 {
 
-    struct GetChunk
-	{
-    	std::shared_ptr<ResourceTools::FileDataStreamIn> uncompressedChunkIn;
+struct GetChunk
+{
+	std::shared_ptr<ResourceTools::FileDataStreamIn> uncompressedChunkIn;
 
-    	std::shared_ptr<ResourceTools::FileDataStreamIn> compressedChunkIn;
+	std::shared_ptr<ResourceTools::FileDataStreamIn> compressedChunkIn;
 
-        bool clearCache{false};
+	bool clearCache{ false };
 
-    	bool outOfChunks{false};
-	};
+	bool outOfChunks{ false };
+};
 
-    class BundleStreamOut
-    {
-	public:
-		BundleStreamOut( uintmax_t chunkSize, std::filesystem::path outputDirectory );
+class BundleStreamOut
+{
+public:
+	BundleStreamOut( uintmax_t chunkSize, std::filesystem::path outputDirectory );
 
-		~BundleStreamOut();
+	~BundleStreamOut();
 
-        bool operator<<( std::shared_ptr<ResourceTools::FileDataStreamIn> streamIn );
+	bool operator<<( std::shared_ptr<ResourceTools::FileDataStreamIn> streamIn );
 
-        // Outputs chunks
-		bool operator>>( GetChunk& data );
+	// Outputs chunks
+	bool operator>>( GetChunk& data );
 
-		bool Flush();
+	bool Flush();
 
-    private:
-		bool AddChunkFilesToGetChunk( GetChunk& data );
+private:
+	bool AddChunkFilesToGetChunk( GetChunk& data );
 
-		bool InitializeOutputStreams();
+	bool InitializeOutputStreams();
 
-		std::vector<std::shared_ptr<ResourceTools::ScopedFile>> m_chunkFiles;
+	std::vector<std::shared_ptr<ResourceTools::ScopedFile>> m_chunkFiles;
 
-		uintmax_t m_chunkSize;
+	uintmax_t m_chunkSize;
 
-        std::string m_cache;
+	std::string m_cache;
 
-        std::string m_uncompressedData;
+	std::string m_uncompressedData;
 
-		std::string m_compressedData;
+	std::string m_compressedData;
 
-		std::unique_ptr<GzipCompressionStream> m_compressionStream;
+	std::unique_ptr<GzipCompressionStream> m_compressionStream;
 
-		std::unique_ptr<ResourceTools::FileDataStreamOut> m_compressedOut;
+	std::unique_ptr<ResourceTools::FileDataStreamOut> m_compressedOut;
 
-		std::unique_ptr<ResourceTools::FileDataStreamOut> m_uncompressedOut;
+	std::unique_ptr<ResourceTools::FileDataStreamOut> m_uncompressedOut;
 
-		std::filesystem::path m_outputDirectory;
+	std::filesystem::path m_outputDirectory;
 
-		uint32_t m_chunksCreated{0};
+	uint32_t m_chunksCreated{ 0 };
 
-		uint32_t m_chunksExported{0};
-    };
- 
+	uint32_t m_chunksExported{ 0 };
+};
+
 }
 
 #endif // BundleStreamOut_H

--- a/tools/include/ChunkIndex.h
+++ b/tools/include/ChunkIndex.h
@@ -14,12 +14,13 @@ namespace ResourceTools
 class ChunkIndex
 {
 public:
-	ChunkIndex( std::filesystem::path fileToIndex, uint32_t chunkSize, const std::filesystem::path& indexFolder, StatusCallback statusCallback=nullptr );
+	ChunkIndex( std::filesystem::path fileToIndex, uint32_t chunkSize, const std::filesystem::path& indexFolder, StatusCallback statusCallback = nullptr );
 	~ChunkIndex();
 	bool Generate();
 	bool FindChunkOffsets( uint32_t chunk, std::vector<size_t>& offsets );
 	bool FindMatchingChunk( const std::string& chunk, size_t& chunkOffset );
 	bool GenerateChecksumFilter( const std::filesystem::path& targetFile );
+
 private:
 	std::filesystem::path GenerateIndexPath();
 	bool Flush( std::vector<std::pair<uint32_t, uint32_t>>& index );

--- a/tools/include/CompressedFileDataStreamOut.h
+++ b/tools/include/CompressedFileDataStreamOut.h
@@ -15,28 +15,26 @@
 namespace ResourceTools
 {
 
-    class CompressedFileDataStreamOut : public FileDataStreamOut
-	{
-	public:
+class CompressedFileDataStreamOut : public FileDataStreamOut
+{
+public:
+	CompressedFileDataStreamOut();
 
-		CompressedFileDataStreamOut( );
+	virtual ~CompressedFileDataStreamOut();
 
-		virtual ~CompressedFileDataStreamOut();
+	bool StartWrite( std::filesystem::path filepath ) override;
 
-        bool StartWrite( std::filesystem::path filepath ) override;
+	virtual bool Finish() override;
 
-        virtual bool Finish() override;
+	bool operator<<( const std::string& data );
 
-        bool operator<<( const std::string& data );
+private:
+	std::string m_compressionBuffer;
 
-	private:
+	std::unique_ptr<GzipCompressionStream> m_compressionStream;
+};
 
-        std::string m_compressionBuffer;
 
-        std::unique_ptr<GzipCompressionStream> m_compressionStream;
-	};
-
-    
 }
 
 #endif // CompressedFileDataStreamOut_H

--- a/tools/include/Downloader.h
+++ b/tools/include/Downloader.h
@@ -9,15 +9,16 @@
 
 namespace ResourceTools
 {
-	// Utility class for downloading files.
-	// Reuse is encouraged for multiple downloads, but do not share across threads.
-	class Downloader
-	{
-	public:
-		Downloader();
-		~Downloader();
-		bool DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds );
-	private:
-		CURL* m_curlHandle{ nullptr };
-	};
+// Utility class for downloading files.
+// Reuse is encouraged for multiple downloads, but do not share across threads.
+class Downloader
+{
+public:
+	Downloader();
+	~Downloader();
+	bool DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds );
+
+private:
+	CURL* m_curlHandle{ nullptr };
+};
 }

--- a/tools/include/FileDataStreamIn.h
+++ b/tools/include/FileDataStreamIn.h
@@ -11,46 +11,45 @@
 namespace ResourceTools
 {
 
-    class FileDataStreamIn
-	{
-	public:
-		FileDataStreamIn( uintmax_t chunkSize = -1 );
+class FileDataStreamIn
+{
+public:
+	FileDataStreamIn( uintmax_t chunkSize = -1 );
 
-		~FileDataStreamIn();
+	~FileDataStreamIn();
 
-        void Finish();
+	void Finish();
 
-        bool IsFinished();
+	bool IsFinished();
 
-        bool StartRead( std::filesystem::path filepath );
+	bool StartRead( std::filesystem::path filepath );
 
-    	std::filesystem::path GetPath();
+	std::filesystem::path GetPath();
 
-        size_t GetCurrentPosition();
+	size_t GetCurrentPosition();
 
-		bool ReadBytes( size_t n, std::string& data );
+	bool ReadBytes( size_t n, std::string& data );
 
-    	void Seek( size_t position );
+	void Seek( size_t position );
 
-        size_t Size();
+	size_t Size();
 
-		bool operator>>( std::string& data );
+	bool operator>>( std::string& data );
 
 
-	private:
+private:
+	bool m_readInProgress;
 
-		bool m_readInProgress;
+	uintmax_t m_chunkSize;
 
-		uintmax_t m_chunkSize;
+	std::ifstream m_inputStream;
 
-        std::ifstream m_inputStream;
+	size_t m_currentPosition;
 
-        size_t m_currentPosition;
+	size_t m_fileSize;
 
-        size_t m_fileSize;
-
-    	std::filesystem::path m_path;
-	};
+	std::filesystem::path m_path;
+};
 
 }
 

--- a/tools/include/FileDataStreamOut.h
+++ b/tools/include/FileDataStreamOut.h
@@ -11,33 +11,33 @@
 namespace ResourceTools
 {
 
-    class FileDataStreamOut
-	{
-	public:
-		FileDataStreamOut( );
+class FileDataStreamOut
+{
+public:
+	FileDataStreamOut();
 
-		virtual ~FileDataStreamOut();
+	virtual ~FileDataStreamOut();
 
-		virtual bool Finish();
+	virtual bool Finish();
 
-		bool IsFinished();
+	bool IsFinished();
 
-		virtual bool StartWrite( std::filesystem::path filepath );
+	virtual bool StartWrite( std::filesystem::path filepath );
 
-		bool operator<<( const std::string& data );
+	bool operator<<( const std::string& data );
 
-        size_t GetFileSize();
+	size_t GetFileSize();
 
 
-	private:
-		bool m_writeInProgress;
+private:
+	bool m_writeInProgress;
 
-		std::ofstream m_outputStream;
+	std::ofstream m_outputStream;
 
-		size_t m_fileSize;
-	};
+	size_t m_fileSize;
+};
 
-    
+
 }
 
 #endif // FileDataStreamOut_H

--- a/tools/include/GzipCompressionStream.h
+++ b/tools/include/GzipCompressionStream.h
@@ -9,29 +9,28 @@
 
 namespace ResourceTools
 {
-    class GzipCompressionStream
-	{
-	public:
-		GzipCompressionStream( std::string* out);
+class GzipCompressionStream
+{
+public:
+	GzipCompressionStream( std::string* out );
 
-		~GzipCompressionStream();
+	~GzipCompressionStream();
 
-        bool Start();
+	bool Start();
 
-		bool operator<<( const std::string* toCompress );
+	bool operator<<( const std::string* toCompress );
 
-        bool Finish();
+	bool Finish();
 
 
-	private:
+private:
+	bool m_compressionInProgress;
+	z_stream m_stream;
+	std::string m_buffer;
+	std::string* m_out;
 
-        bool m_compressionInProgress;
-        z_stream m_stream;
-    	std::string m_buffer;
-    	std::string* m_out;
-
-    	bool ProcessBuffer( bool finish );
-	};
+	bool ProcessBuffer( bool finish );
+};
 
 
 }

--- a/tools/include/GzipDecompressionStream.h
+++ b/tools/include/GzipDecompressionStream.h
@@ -9,29 +9,28 @@
 
 namespace ResourceTools
 {
-    class GzipDecompressionStream
-	{
-	public:
-		GzipDecompressionStream( std::string* out);
+class GzipDecompressionStream
+{
+public:
+	GzipDecompressionStream( std::string* out );
 
-		~GzipDecompressionStream();
+	~GzipDecompressionStream();
 
-        bool Start();
+	bool Start();
 
-		bool operator<<( std::string* toDecompress );
+	bool operator<<( std::string* toDecompress );
 
-        bool Finish();
+	bool Finish();
 
 
-	private:
+private:
+	bool m_decompressionInProgress;
+	z_stream m_stream;
+	std::string m_buffer;
+	std::string* m_out;
 
-        bool m_decompressionInProgress;
-        z_stream m_stream;
-    	std::string m_buffer;
-    	std::string* m_out;
-
-    	bool ProcessBuffer( bool finish );
-	};
+	bool ProcessBuffer( bool finish );
+};
 
 
 }

--- a/tools/include/Md5ChecksumStream.h
+++ b/tools/include/Md5ChecksumStream.h
@@ -9,41 +9,38 @@
 
 namespace CryptoPP
 {
-    class HexEncoder;
+class HexEncoder;
 
-    namespace Weak1
-    {
-	    class MD5;
-    }
+namespace Weak1
+{
+class MD5;
+}
 }
 
 namespace ResourceTools
 {
 
-    class Md5ChecksumStream
-	{
-	public:
-		Md5ChecksumStream();
+class Md5ChecksumStream
+{
+public:
+	Md5ChecksumStream();
 
-		~Md5ChecksumStream();
+	~Md5ChecksumStream();
 
-        bool FinishAndRetrieve(std::string& checksum);
-		
-		bool operator<<( const std::string& data );
+	bool FinishAndRetrieve( std::string& checksum );
 
-    private:
+	bool operator<<( const std::string& data );
 
-        void Finish();
+private:
+	void Finish();
 
-	private:
+private:
+	std::stringstream m_ss;
 
-		std::stringstream m_ss;
+	CryptoPP::HexEncoder* m_encoder;
 
-        CryptoPP::HexEncoder* m_encoder;
-
-        CryptoPP::Weak1::MD5* m_hash;
-
-	};
+	CryptoPP::Weak1::MD5* m_hash;
+};
 
 
 }

--- a/tools/include/ResourceTools.h
+++ b/tools/include/ResourceTools.h
@@ -12,12 +12,12 @@
 
 namespace CryptoPP
 {
-    class HexEncoder;
+class HexEncoder;
 
-    namespace Weak1
-    {
-	    class MD5;
-    }
+namespace Weak1
+{
+class MD5;
+}
 }
 
 
@@ -25,38 +25,38 @@ namespace CryptoPP
 namespace ResourceTools
 {
 
-	class BundleStreamOut;
+class BundleStreamOut;
 
-	struct ChunkMatch
-	{
-		uint64_t sourceOffset;
-		uint64_t destinationOffset;
-		uint64_t length;
-	};
+struct ChunkMatch
+{
+	uint64_t sourceOffset;
+	uint64_t destinationOffset;
+	uint64_t length;
+};
 
-	bool GenerateMd5Checksum( const std::filesystem::path& path, std::string& checksum );
+bool GenerateMd5Checksum( const std::filesystem::path& path, std::string& checksum );
 
-    bool GenerateMd5Checksum( const std::string& data, std::string& checksum );
+bool GenerateMd5Checksum( const std::string& data, std::string& checksum );
 
-	bool Md5ChecksumMatches( const std::filesystem::path& path, std::string& checksum );
+bool Md5ChecksumMatches( const std::filesystem::path& path, std::string& checksum );
 
-    bool GenerateFowlerNollVoChecksum( const std::string& input, std::string& checksum );
+bool GenerateFowlerNollVoChecksum( const std::string& input, std::string& checksum );
 
-	std::list<ChunkMatch> FindMatchingChunks( const std::string& source, std::string& destination );
+std::list<ChunkMatch> FindMatchingChunks( const std::string& source, std::string& destination );
 
-    bool FindMatchingChunk( const std::string& chunk, std::filesystem::path filePath, size_t& chunkOffset );
+bool FindMatchingChunk( const std::string& chunk, std::filesystem::path filePath, size_t& chunkOffset );
 
-	size_t CountMatchingChunks( const std::filesystem::path& fileA, size_t offsetA, std::filesystem::path fileB, size_t offsetB, size_t chunkSize );
+size_t CountMatchingChunks( const std::filesystem::path& fileA, size_t offsetA, std::filesystem::path fileB, size_t offsetB, size_t chunkSize );
 
-    bool GetLocalFileData( const std::filesystem::path& filepath, std::string& data );
+bool GetLocalFileData( const std::filesystem::path& filepath, std::string& data );
 
-    bool GZipCompressData( const std::string& dataToCompress, std::string& compressedData );
+bool GZipCompressData( const std::string& dataToCompress, std::string& compressedData );
 
-    bool GZipUncompressData( const std::string& dataToUncompress, std::string& uncompressedData );
+bool GZipUncompressData( const std::string& dataToUncompress, std::string& uncompressedData );
 
-    bool SaveFile( const std::filesystem::path& path, const std::string& data );
+bool SaveFile( const std::filesystem::path& path, const std::string& data );
 
-    unsigned int CalculateBinaryOperation( const std::filesystem::path& path );
+unsigned int CalculateBinaryOperation( const std::filesystem::path& path );
 }
 
 #endif // ResourceTools_H

--- a/tools/include/ScopedFile.h
+++ b/tools/include/ScopedFile.h
@@ -9,16 +9,16 @@
 
 namespace ResourceTools
 {
-    class ScopedFile
-	{
-	public:
-		ScopedFile( std::filesystem::path location );
+class ScopedFile
+{
+public:
+	ScopedFile( std::filesystem::path location );
 
-		~ScopedFile();
+	~ScopedFile();
 
-	private:
-		std::filesystem::path m_location;
-	}; 
+private:
+	std::filesystem::path m_location;
+};
 }
 
 #endif // ScopedFile_H

--- a/tools/src/BundleStreamIn.cpp
+++ b/tools/src/BundleStreamIn.cpp
@@ -5,82 +5,81 @@
 
 namespace ResourceTools
 {
-  
-  BundleStreamIn::BundleStreamIn( uintmax_t chunkSize ) :
-	  m_chunkSize(chunkSize),
-	  m_dataReadOfCurrentFile( 0 )
-  {
-  }
 
-  BundleStreamIn ::~BundleStreamIn()
-  {
-  }
+BundleStreamIn::BundleStreamIn( uintmax_t chunkSize ) :
+	m_chunkSize( chunkSize ),
+	m_dataReadOfCurrentFile( 0 )
+{
+}
 
-  uintmax_t BundleStreamIn::GetCacheSize()
-  {
-	  return m_cache.size();
-  }
+BundleStreamIn ::~BundleStreamIn()
+{
+}
 
-  bool BundleStreamIn::operator<<( const std::string& dataData )
-  {
-	  m_cache.append( dataData );
+uintmax_t BundleStreamIn::GetCacheSize()
+{
+	return m_cache.size();
+}
 
-	  return true;
-  }
+bool BundleStreamIn::operator<<( const std::string& dataData )
+{
+	m_cache.append( dataData );
 
-  bool BundleStreamIn::operator>>( GetFile& fileData )
-  {
-	  size_t cacheSize = m_cache.size();
+	return true;
+}
 
-	  if( cacheSize == 0 )
-	  {
-		  // No data in cache
-		  return false;
-	  }
+bool BundleStreamIn::operator>>( GetFile& fileData )
+{
+	size_t cacheSize = m_cache.size();
 
-	  
-	   std::string& dataRef = *fileData.data;
+	if( cacheSize == 0 )
+	{
+		// No data in cache
+		return false;
+	}
 
-        if( ( m_dataReadOfCurrentFile + m_chunkSize ) >= fileData.fileSize )
-        {
-			uintmax_t remainingDataSize = fileData.fileSize - m_dataReadOfCurrentFile;
 
-		    dataRef = m_cache.substr( 0, remainingDataSize );
+	std::string& dataRef = *fileData.data;
 
-            m_cache.erase( 0, remainingDataSize );
+	if( ( m_dataReadOfCurrentFile + m_chunkSize ) >= fileData.fileSize )
+	{
+		uintmax_t remainingDataSize = fileData.fileSize - m_dataReadOfCurrentFile;
 
-            m_dataReadOfCurrentFile = 0;
-        }
-        else
-        {
-		    dataRef = m_cache.substr( 0, m_chunkSize );
+		dataRef = m_cache.substr( 0, remainingDataSize );
 
-		    m_cache.erase( 0, m_chunkSize );
+		m_cache.erase( 0, remainingDataSize );
 
-            m_dataReadOfCurrentFile += m_chunkSize;
-        }
+		m_dataReadOfCurrentFile = 0;
+	}
+	else
+	{
+		dataRef = m_cache.substr( 0, m_chunkSize );
 
-        return true;
-	  
-  }
+		m_cache.erase( 0, m_chunkSize );
 
-  uintmax_t BundleStreamIn::GetChunkSize() const
-  {
-	  return m_chunkSize;
-  }
+		m_dataReadOfCurrentFile += m_chunkSize;
+	}
 
-  bool BundleStreamIn::ReadBytes( size_t n, std::string& out )
-  {
-	  if( m_cache.size() < n )
-	  {
-		  return false;
-	  }
+	return true;
+}
 
-  	  out = m_cache.substr( 0, n );
+uintmax_t BundleStreamIn::GetChunkSize() const
+{
+	return m_chunkSize;
+}
 
-  	  m_cache.erase( 0, n );
+bool BundleStreamIn::ReadBytes( size_t n, std::string& out )
+{
+	if( m_cache.size() < n )
+	{
+		return false;
+	}
 
-	  return true;
-  }
+	out = m_cache.substr( 0, n );
+
+	m_cache.erase( 0, n );
+
+	return true;
+}
 
 }

--- a/tools/src/BundleStreamOut.cpp
+++ b/tools/src/BundleStreamOut.cpp
@@ -15,7 +15,6 @@ BundleStreamOut::BundleStreamOut( uintmax_t chunkSize, std::filesystem::path out
 
 BundleStreamOut::~BundleStreamOut()
 {
-
 }
 
 std::filesystem::path RawFilename( std::filesystem::path outputDirectory, uint32_t chunkNumber )

--- a/tools/src/CompressedFileDataStreamOut.cpp
+++ b/tools/src/CompressedFileDataStreamOut.cpp
@@ -5,83 +5,83 @@
 namespace ResourceTools
 {
 
-  CompressedFileDataStreamOut::CompressedFileDataStreamOut( )
-  {
-  }
+CompressedFileDataStreamOut::CompressedFileDataStreamOut()
+{
+}
 
-  CompressedFileDataStreamOut::~CompressedFileDataStreamOut()
-  {
-  }
+CompressedFileDataStreamOut::~CompressedFileDataStreamOut()
+{
+}
 
-  bool CompressedFileDataStreamOut::StartWrite( std::filesystem::path filepath )
-  {
-      if (m_compressionStream)
-      {
-		  return false;
-      }
+bool CompressedFileDataStreamOut::StartWrite( std::filesystem::path filepath )
+{
+	if( m_compressionStream )
+	{
+		return false;
+	}
 
-	  m_compressionStream = std::make_unique<GzipCompressionStream>( &m_compressionBuffer );
-      
-      if (!m_compressionStream->Start())
-      {
-		  return false;
-      }
+	m_compressionStream = std::make_unique<GzipCompressionStream>( &m_compressionBuffer );
 
-      return FileDataStreamOut::StartWrite( filepath );
-  }
+	if( !m_compressionStream->Start() )
+	{
+		return false;
+	}
 
-  bool CompressedFileDataStreamOut::Finish()
-  {
-      if (!m_compressionStream)
-      {
-		  return false;
-      }
+	return FileDataStreamOut::StartWrite( filepath );
+}
 
-      if (!m_compressionStream->Finish())
-      {
-		  return false;
-      }
+bool CompressedFileDataStreamOut::Finish()
+{
+	if( !m_compressionStream )
+	{
+		return false;
+	}
 
-      if( m_compressionBuffer.size() > 0 )
-	  {
-          if (!FileDataStreamOut::operator<<(m_compressionBuffer))
-          {
-			  return false;
-          }
-	  }
+	if( !m_compressionStream->Finish() )
+	{
+		return false;
+	}
+
+	if( m_compressionBuffer.size() > 0 )
+	{
+		if( !FileDataStreamOut::operator<<( m_compressionBuffer ) )
+		{
+			return false;
+		}
+	}
 
 
-      m_compressionStream.reset();
+	m_compressionStream.reset();
 
-      m_compressionBuffer.clear();
+	m_compressionBuffer.clear();
 
-      return FileDataStreamOut::Finish();
-  }
+	return FileDataStreamOut::Finish();
+}
 
-  bool CompressedFileDataStreamOut::operator << ( const std::string& data )
-  {
-	  if( !m_compressionStream )
-	  {
-		  return false;
-	  }
+bool CompressedFileDataStreamOut::operator<<( const std::string& data )
+{
+	if( !m_compressionStream )
+	{
+		return false;
+	}
 
-      if (!m_compressionStream->operator<<(&data))
-      {
-		  return false;
-      }
+	if( !m_compressionStream->operator<<( &data ) )
+	{
+		return false;
+	}
 
-      if (m_compressionBuffer.size() > 0)
-      {
-          if (!FileDataStreamOut::operator<<(m_compressionBuffer))
-          {
-			  return false;
-          }
+	if( m_compressionBuffer.size() > 0 )
+	{
+		if( !FileDataStreamOut::operator<<( m_compressionBuffer ) )
+		{
+			return false;
+		}
 
-          m_compressionBuffer.clear();
-      }
+		m_compressionBuffer.clear();
+	}
 
-      return true;
-  }
+	return true;
+}
 
 
 }

--- a/tools/src/Downloader.cpp
+++ b/tools/src/Downloader.cpp
@@ -18,7 +18,7 @@ std::set<int> s_curl_retry_errors{
 };
 
 // Retry curl operation for up to 2 minutes.
-std::chrono::seconds RETRY_PERIOD_SECONDS{120};
+std::chrono::seconds RETRY_PERIOD_SECONDS{ 120 };
 
 bool InitializeCurl()
 {
@@ -83,8 +83,8 @@ bool Downloader::DownloadFile( const std::string& url, const std::filesystem::pa
 	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEDATA, &out );
 	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEFUNCTION, WriteToFileStreamCallback );
 	curl_easy_setopt( m_curlHandle, CURLOPT_ACCEPT_ENCODING, "gzip" );
-	CURLcode cc{CURLE_OK};
-	std::chrono::seconds sleepSeconds{1};
+	CURLcode cc{ CURLE_OK };
+	std::chrono::seconds sleepSeconds{ 1 };
 	auto startTime = std::chrono::steady_clock::now();
 	do
 	{

--- a/tools/src/FileDataStreamIn.cpp
+++ b/tools/src/FileDataStreamIn.cpp
@@ -4,135 +4,133 @@
 
 namespace ResourceTools
 {
-  
-  FileDataStreamIn::FileDataStreamIn( uintmax_t chunkSize /*= -1*/ ) :
-	  m_chunkSize( chunkSize ),
-	  m_fileSize(0),
-	  m_currentPosition(0)
-  {
-	  
-  }
 
-  FileDataStreamIn::~FileDataStreamIn()
-  {
-      if (m_readInProgress)
-      {
-		  Finish();
-      }
-  }
+FileDataStreamIn::FileDataStreamIn( uintmax_t chunkSize /*= -1*/ ) :
+	m_chunkSize( chunkSize ),
+	m_fileSize( 0 ),
+	m_currentPosition( 0 )
+{
+}
 
-  void FileDataStreamIn::Finish()
-  {
-	  m_readInProgress = false;
+FileDataStreamIn::~FileDataStreamIn()
+{
+	if( m_readInProgress )
+	{
+		Finish();
+	}
+}
 
-	  m_inputStream.close();
-  }
+void FileDataStreamIn::Finish()
+{
+	m_readInProgress = false;
 
-  bool FileDataStreamIn::IsFinished()
-  {
-	  return !m_readInProgress;
-  }
+	m_inputStream.close();
+}
 
-  std::filesystem::path FileDataStreamIn::GetPath()
-  {
-	  return m_path;
-  }
+bool FileDataStreamIn::IsFinished()
+{
+	return !m_readInProgress;
+}
 
-  size_t FileDataStreamIn::GetCurrentPosition()
-  {
-	  return m_currentPosition;
-  }
+std::filesystem::path FileDataStreamIn::GetPath()
+{
+	return m_path;
+}
 
-  size_t FileDataStreamIn::Size()
-  {
-	  return m_fileSize;
-  }
+size_t FileDataStreamIn::GetCurrentPosition()
+{
+	return m_currentPosition;
+}
 
-  bool FileDataStreamIn::ReadBytes( size_t readSize, std::string& out )
-  {
-	  if( ( m_currentPosition + readSize ) > m_fileSize )
-	  {
-		  return false;
-	  }
-	  out.resize( readSize );
-	  if( !m_inputStream.read( out.data(), static_cast<std::streamsize>( readSize ) ) )
-	  {
-		  return false;
-	  }
-	  m_currentPosition += readSize;
-	  if( m_currentPosition == m_fileSize )
-	  {
-		  Finish();
-	  }
-	  return true;
-  }
+size_t FileDataStreamIn::Size()
+{
+	return m_fileSize;
+}
 
-  void FileDataStreamIn::Seek( size_t position )
-  {
-	  m_inputStream.seekg( static_cast<std::streamoff>( position ) );
-  	  m_currentPosition = position;
-  }
+bool FileDataStreamIn::ReadBytes( size_t readSize, std::string& out )
+{
+	if( ( m_currentPosition + readSize ) > m_fileSize )
+	{
+		return false;
+	}
+	out.resize( readSize );
+	if( !m_inputStream.read( out.data(), static_cast<std::streamsize>( readSize ) ) )
+	{
+		return false;
+	}
+	m_currentPosition += readSize;
+	if( m_currentPosition == m_fileSize )
+	{
+		Finish();
+	}
+	return true;
+}
 
-  bool FileDataStreamIn::StartRead( std::filesystem::path filepath )
-  {
-      m_inputStream.open( filepath, std::ios::in | std::ios::binary );
+void FileDataStreamIn::Seek( size_t position )
+{
+	m_inputStream.seekg( static_cast<std::streamoff>( position ) );
+	m_currentPosition = position;
+}
 
-      if( !m_inputStream )
-	  {
-		  return false;
-	  }
+bool FileDataStreamIn::StartRead( std::filesystem::path filepath )
+{
+	m_inputStream.open( filepath, std::ios::in | std::ios::binary );
 
-	  m_path = filepath;
+	if( !m_inputStream )
+	{
+		return false;
+	}
 
-      m_inputStream.seekg( 0, std::ios::end );
+	m_path = filepath;
 
-      m_currentPosition = 0;
+	m_inputStream.seekg( 0, std::ios::end );
 
-      m_fileSize = m_inputStream.tellg();
+	m_currentPosition = 0;
 
-      m_inputStream.seekg( 0, std::ios::beg );
+	m_fileSize = m_inputStream.tellg();
 
-      m_readInProgress = true;
+	m_inputStream.seekg( 0, std::ios::beg );
 
-	  return true;
-      
-  }
+	m_readInProgress = true;
 
-  bool FileDataStreamIn::operator>>( std::string& data )
-  {
-      if (!m_readInProgress)
-      {
-		  return false;
-      }
+	return true;
+}
 
-      // If -1 is passed as chunk size then read entire file
-      if (m_chunkSize == -1)
-      {
-		  m_chunkSize = m_fileSize;
-      }
+bool FileDataStreamIn::operator>>( std::string& data )
+{
+	if( !m_readInProgress )
+	{
+		return false;
+	}
 
-	  uintmax_t readSize = m_chunkSize;
+	// If -1 is passed as chunk size then read entire file
+	if( m_chunkSize == -1 )
+	{
+		m_chunkSize = m_fileSize;
+	}
 
-      if( ( m_currentPosition + readSize ) > m_fileSize )
-      {
-		  readSize = m_fileSize - std::min(m_fileSize, m_currentPosition);
-      }
+	uintmax_t readSize = m_chunkSize;
 
-	  data.resize( readSize );
+	if( ( m_currentPosition + readSize ) > m_fileSize )
+	{
+		readSize = m_fileSize - std::min( m_fileSize, m_currentPosition );
+	}
 
-      if( !m_inputStream.read( data.data(), readSize ) )
-      {
-		  return false;
-      }
+	data.resize( readSize );
 
-      m_currentPosition += readSize;
+	if( !m_inputStream.read( data.data(), readSize ) )
+	{
+		return false;
+	}
 
-      if (m_currentPosition == m_fileSize)
-      {
-		  Finish();
-      }
+	m_currentPosition += readSize;
 
-      return true;
-  }
+	if( m_currentPosition == m_fileSize )
+	{
+		Finish();
+	}
+
+	return true;
+}
 
 }

--- a/tools/src/FileDataStreamOut.cpp
+++ b/tools/src/FileDataStreamOut.cpp
@@ -5,93 +5,93 @@
 namespace ResourceTools
 {
 
-  FileDataStreamOut::FileDataStreamOut( ) :
-	  m_fileSize( 0 ),
-      m_writeInProgress(false)
-  {
-  }
+FileDataStreamOut::FileDataStreamOut() :
+	m_fileSize( 0 ),
+	m_writeInProgress( false )
+{
+}
 
-  FileDataStreamOut::~FileDataStreamOut()
-  {
-	  if( m_writeInProgress )
-	  {
-		  Finish();
-	  }
-  }
+FileDataStreamOut::~FileDataStreamOut()
+{
+	if( m_writeInProgress )
+	{
+		Finish();
+	}
+}
 
-  bool FileDataStreamOut::Finish()
-  {
-	  m_writeInProgress = false;
+bool FileDataStreamOut::Finish()
+{
+	m_writeInProgress = false;
 
-	  m_outputStream.close();
+	m_outputStream.close();
 
-      return true;
-  }
+	return true;
+}
 
-  bool FileDataStreamOut::IsFinished()
-  {
-	  return !m_writeInProgress;
-  }
+bool FileDataStreamOut::IsFinished()
+{
+	return !m_writeInProgress;
+}
 
-  bool FileDataStreamOut::StartWrite( std::filesystem::path filepath )
-  {
-	  // Creates directories if required
-	  std::filesystem::path directory = filepath.parent_path();
+bool FileDataStreamOut::StartWrite( std::filesystem::path filepath )
+{
+	// Creates directories if required
+	std::filesystem::path directory = filepath.parent_path();
 
-	  if( directory != "" )
-	  {
-		  try
-		  {
-			  if( !std::filesystem::exists( directory ) )
-			  {
-				  std::filesystem::create_directories( directory );
-			  }
+	if( directory != "" )
+	{
+		try
+		{
+			if( !std::filesystem::exists( directory ) )
+			{
+				std::filesystem::create_directories( directory );
+			}
 
-			  if( !std::filesystem::exists( directory ) )
-			  {
-				  return false;
-			  }
-		  }
-		  catch( std::filesystem::filesystem_error& )
-		  {
-			  return false;
-		  }
-	  }
+			if( !std::filesystem::exists( directory ) )
+			{
+				return false;
+			}
+		}
+		catch( std::filesystem::filesystem_error& )
+		{
+			return false;
+		}
+	}
 
-	  m_outputStream.open( filepath, std::ios::out | std::ios::binary );
+	m_outputStream.open( filepath, std::ios::out | std::ios::binary );
 
-	  if( !m_outputStream )
-	  {
-		  return false;
-	  }
+	if( !m_outputStream )
+	{
+		return false;
+	}
 
-	  m_fileSize = 0;
+	m_fileSize = 0;
 
-      m_writeInProgress = true;
+	m_writeInProgress = true;
 
-	  return true;
-  }
+	return true;
+}
 
-  bool FileDataStreamOut::operator<<( const std::string& data )
-  {
-	  if( !m_writeInProgress )
-	  {
-		  return false;
-	  }
+bool FileDataStreamOut::operator<<( const std::string& data )
+{
+	if( !m_writeInProgress )
+	{
+		return false;
+	}
 
-	  if( !m_outputStream.write( data.data(), data.size() ) )
-	  {
-		  return false;
-	  }
+	if( !m_outputStream.write( data.data(), data.size() ) )
+	{
+		return false;
+	}
 
-	  m_fileSize += data.size();
+	m_fileSize += data.size();
 
-	  return true;
-  }
+	return true;
+}
 
-  size_t FileDataStreamOut::GetFileSize()
-  {
-	  return m_fileSize;
-  }
+size_t FileDataStreamOut::GetFileSize()
+{
+	return m_fileSize;
+}
 
 }

--- a/tools/src/GzipCompressionStream.cpp
+++ b/tools/src/GzipCompressionStream.cpp
@@ -6,99 +6,97 @@
 
 namespace ResourceTools
 {
-  
-  GzipCompressionStream::GzipCompressionStream( std::string* out ):
+
+GzipCompressionStream::GzipCompressionStream( std::string* out ) :
 	m_compressionInProgress( false ),
 	m_out( out )
-  {
+{
+}
 
-  }
+GzipCompressionStream ::~GzipCompressionStream()
+{
+}
 
-  GzipCompressionStream ::~GzipCompressionStream()
-  {
+bool GzipCompressionStream::Start()
+{
 
-  }
+	m_stream.zalloc = Z_NULL;
 
-  bool GzipCompressionStream::Start( )
-  {
-	  
-	  m_stream.zalloc = Z_NULL;
+	m_stream.zfree = Z_NULL;
 
-	  m_stream.zfree = Z_NULL;
+	m_stream.opaque = Z_NULL;
 
-	  m_stream.opaque = Z_NULL;
+	int windowBits = MAX_WBITS | 16; // 16 is a magic bit flag to specify GZip compression format.
 
-	  int windowBits = MAX_WBITS | 16; // 16 is a magic bit flag to specify GZip compression format.
+	int ret = deflateInit2( &m_stream, Z_BEST_COMPRESSION, Z_DEFLATED, windowBits, 8, Z_DEFAULT_STRATEGY );
 
-	  int ret = deflateInit2( &m_stream, Z_BEST_COMPRESSION, Z_DEFLATED, windowBits, 8, Z_DEFAULT_STRATEGY );
+	if( ret != Z_OK )
+	{
+		return false;
+	}
 
-	  if( ret != Z_OK )
-	  {
-		  return false;
-	  }
+	m_compressionInProgress = true;
 
-      m_compressionInProgress = true;
+	return true;
+}
 
-      return true;
-  }
+bool GzipCompressionStream::ProcessBuffer( bool finish )
+{
+	constexpr size_t CHUNK = 16384; // 16kb
+	int ret = Z_OK;
+	unsigned char outbuffer[CHUNK];
+	int flush{ Z_NO_FLUSH };
+	while( ret == Z_OK && ( finish || !m_buffer.empty() ) )
+	{
+		size_t available = m_buffer.size();
+		m_stream.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( m_buffer.c_str() ) );
+		m_stream.avail_in = static_cast<uInt>( available );
+		m_stream.next_out = outbuffer;
+		m_stream.avail_out = CHUNK;
+		if( finish && m_buffer.size() <= CHUNK )
+		{
+			flush = Z_FINISH;
+		}
+		uLong alreadyIn = m_stream.total_in;
+		uLong alreadyOut = m_stream.total_out;
+		ret = deflate( &m_stream, flush );
+		uLong outBytes = m_stream.total_out - alreadyOut;
+		uLong inBytes = m_stream.total_in - alreadyIn;
+		m_out->append( std::string( reinterpret_cast<const char*>( outbuffer ), outBytes ) );
+		m_buffer = m_buffer.substr( inBytes );
+	}
 
-  bool GzipCompressionStream::ProcessBuffer( bool finish )
-  {
-  	constexpr size_t CHUNK = 16384; // 16kb
-  	int ret = Z_OK;
-  	unsigned char outbuffer[CHUNK];
-  	int flush{Z_NO_FLUSH};
-  	while( ret == Z_OK && ( finish || !m_buffer.empty() ) )
-  	{
-  		size_t available = m_buffer.size();
-  		m_stream.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( m_buffer.c_str() ) );
-  		m_stream.avail_in = static_cast<uInt>( available );
-  		m_stream.next_out = outbuffer;
-  		m_stream.avail_out = CHUNK;
-  		if( finish && m_buffer.size() <= CHUNK )
-  		{
-  			flush = Z_FINISH;
-  		}
-  		uLong alreadyIn = m_stream.total_in;
-  		uLong alreadyOut = m_stream.total_out;
-  		ret = deflate( &m_stream, flush );
-  		uLong outBytes = m_stream.total_out - alreadyOut;
-  		uLong inBytes = m_stream.total_in - alreadyIn;
-  		m_out->append( std::string( reinterpret_cast<const char*>( outbuffer ), outBytes ) );
-  		m_buffer = m_buffer.substr( inBytes );
-  	}
+	if( ret != Z_OK && ret != Z_STREAM_END )
+	{
+		deflateEnd( &m_stream );
+		return false;
+	}
+	return true;
+}
 
-  	if( ret != Z_OK && ret != Z_STREAM_END )
-  	{
-  		deflateEnd( &m_stream );
-  		return false;
-  	}
-  	return true;
-  }
+bool GzipCompressionStream::operator<<( const std::string* toCompress )
+{
+	if( !m_compressionInProgress )
+	{
+		return false;
+	}
 
-  bool GzipCompressionStream::operator<<( const std::string* toCompress )
-  {
-      if (!m_compressionInProgress)
-      {
-		  return false;
-      }
+	m_buffer.append( *toCompress );
 
-  	  m_buffer.append( *toCompress );
+	return ProcessBuffer( false );
+}
 
-      return ProcessBuffer( false );
-  }
+bool GzipCompressionStream::Finish()
+{
+	if( !m_compressionInProgress )
+	{
+		return false;
+	}
 
-  bool GzipCompressionStream::Finish()
-  {
-	  if( !m_compressionInProgress )
-	  {
-		  return false;
-	  }
+	ProcessBuffer( true );
 
-  	  ProcessBuffer( true );
+	m_compressionInProgress = false;
 
-      m_compressionInProgress = false;
-
-	  return deflateEnd( &m_stream ) == Z_OK;
-  }
+	return deflateEnd( &m_stream ) == Z_OK;
+}
 }

--- a/tools/src/GzipDecompressionStream.cpp
+++ b/tools/src/GzipDecompressionStream.cpp
@@ -90,6 +90,5 @@ bool GzipDecompressionStream::Finish()
 	m_decompressionInProgress = false;
 
 	return inflateEnd( &m_stream ) == Z_OK;
-	;
 }
 }

--- a/tools/src/GzipDecompressionStream.cpp
+++ b/tools/src/GzipDecompressionStream.cpp
@@ -8,89 +8,88 @@ constexpr int CHUNK = 16384; // 16kb
 
 namespace ResourceTools
 {
-  
-  GzipDecompressionStream::GzipDecompressionStream( std::string* out ):
+
+GzipDecompressionStream::GzipDecompressionStream( std::string* out ) :
 	m_decompressionInProgress( false ),
 	m_out( out )
-  {
+{
+}
 
-  }
+GzipDecompressionStream ::~GzipDecompressionStream()
+{
+}
 
-  GzipDecompressionStream ::~GzipDecompressionStream()
-  {
-
-  }
-
-  bool GzipDecompressionStream::Start( )
-  {
-  	m_stream.zalloc = Z_NULL;
-  	m_stream.zfree = Z_NULL;
-  	m_stream.opaque = Z_NULL;
-  	m_stream.avail_in = 0;
-  	m_stream.next_in = Z_NULL;
-  	int ret = inflateInit2( &m_stream, 16 | MAX_WBITS );
-  	if( ret != Z_OK )
-  	{
-  		return false;
-  	}
+bool GzipDecompressionStream::Start()
+{
+	m_stream.zalloc = Z_NULL;
+	m_stream.zfree = Z_NULL;
+	m_stream.opaque = Z_NULL;
+	m_stream.avail_in = 0;
+	m_stream.next_in = Z_NULL;
+	int ret = inflateInit2( &m_stream, 16 | MAX_WBITS );
+	if( ret != Z_OK )
+	{
+		return false;
+	}
 	m_decompressionInProgress = true;
-  	return true;
-  }
+	return true;
+}
 
-  bool GzipDecompressionStream::ProcessBuffer( bool finish )
-  {
-  	constexpr size_t CHUNK = 16384; // 16kb
-  	int ret = Z_OK;
-  	unsigned char outbuffer[CHUNK];
-  	int flush{Z_NO_FLUSH};
+bool GzipDecompressionStream::ProcessBuffer( bool finish )
+{
+	constexpr size_t CHUNK = 16384; // 16kb
+	int ret = Z_OK;
+	unsigned char outbuffer[CHUNK];
+	int flush{ Z_NO_FLUSH };
 	size_t uIntMax = std::numeric_limits<uInt>::max();
-	size_t index{0};
+	size_t index{ 0 };
 
-  	while( ret == Z_OK && ( finish || index < m_buffer.size() ) )
-  	{
-  		m_stream.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( m_buffer.c_str() + index ) );
-  		m_stream.avail_in = static_cast<uInt>( std::min( m_buffer.size() - index, uIntMax ) );
-  		m_stream.next_out = outbuffer;
-  		m_stream.avail_out = CHUNK;
+	while( ret == Z_OK && ( finish || index < m_buffer.size() ) )
+	{
+		m_stream.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( m_buffer.c_str() + index ) );
+		m_stream.avail_in = static_cast<uInt>( std::min( m_buffer.size() - index, uIntMax ) );
+		m_stream.next_out = outbuffer;
+		m_stream.avail_out = CHUNK;
 		auto alreadyOut = m_stream.total_out;
-  		auto alreadyIn = m_stream.total_in;
-  		ret = inflate( &m_stream, Z_NO_FLUSH );
-  		m_out->append( std::string( reinterpret_cast<const char*>( outbuffer ), m_stream.total_out - alreadyOut ) );
-  		index += m_stream.total_in - alreadyIn;
-  	}
+		auto alreadyIn = m_stream.total_in;
+		ret = inflate( &m_stream, Z_NO_FLUSH );
+		m_out->append( std::string( reinterpret_cast<const char*>( outbuffer ), m_stream.total_out - alreadyOut ) );
+		index += m_stream.total_in - alreadyIn;
+	}
 	m_buffer.clear();
 
-  	if( ret != Z_OK && ret != Z_STREAM_END )
-  	{
-  		inflateEnd( &m_stream );
-  		return false;
-  	}
-  	return true;
-  }
+	if( ret != Z_OK && ret != Z_STREAM_END )
+	{
+		inflateEnd( &m_stream );
+		return false;
+	}
+	return true;
+}
 
-  bool GzipDecompressionStream::operator<<( std::string* toDecompress )
-  {
-      if (!m_decompressionInProgress)
-      {
-		  return false;
-      }
+bool GzipDecompressionStream::operator<<( std::string* toDecompress )
+{
+	if( !m_decompressionInProgress )
+	{
+		return false;
+	}
 
-  	  m_buffer.append( *toDecompress );
+	m_buffer.append( *toDecompress );
 
-      return ProcessBuffer( false );
-  }
+	return ProcessBuffer( false );
+}
 
-  bool GzipDecompressionStream::Finish()
-  {
-	  if( !m_decompressionInProgress )
-	  {
-		  return false;
-	  }
+bool GzipDecompressionStream::Finish()
+{
+	if( !m_decompressionInProgress )
+	{
+		return false;
+	}
 
-  	  ProcessBuffer( true );
+	ProcessBuffer( true );
 
-      m_decompressionInProgress = false;
+	m_decompressionInProgress = false;
 
-	  return inflateEnd( &m_stream ) == Z_OK;;
-  }
+	return inflateEnd( &m_stream ) == Z_OK;
+	;
+}
 }

--- a/tools/src/Md5ChecksumStream.cpp
+++ b/tools/src/Md5ChecksumStream.cpp
@@ -9,75 +9,75 @@
 
 namespace ResourceTools
 {
- 
-  Md5ChecksumStream::Md5ChecksumStream()
-  {
-      m_encoder = new CryptoPP::HexEncoder( new CryptoPP::FileSink( m_ss ), false );
 
-      m_hash = new CryptoPP::Weak1::MD5();
-  }
+Md5ChecksumStream::Md5ChecksumStream()
+{
+	m_encoder = new CryptoPP::HexEncoder( new CryptoPP::FileSink( m_ss ), false );
 
-  Md5ChecksumStream::~Md5ChecksumStream()
-  {
-	  Finish();
-  }
+	m_hash = new CryptoPP::Weak1::MD5();
+}
 
-  void Md5ChecksumStream::Finish()
-  {
-      if (m_encoder)
-      {
-		  delete m_encoder;
+Md5ChecksumStream::~Md5ChecksumStream()
+{
+	Finish();
+}
 
-          m_encoder = nullptr;
-      }
-	  
-      if (m_hash)
-      {
-		  delete m_hash;
+void Md5ChecksumStream::Finish()
+{
+	if( m_encoder )
+	{
+		delete m_encoder;
 
-          m_hash = nullptr;
-      }
+		m_encoder = nullptr;
+	}
 
-      return;
-  }
+	if( m_hash )
+	{
+		delete m_hash;
+
+		m_hash = nullptr;
+	}
+
+	return;
+}
 
 
-  bool Md5ChecksumStream::operator<<( const std::string& data )
-  {
-      if (!m_hash)
-      {
-		  return false;
-      }
+bool Md5ChecksumStream::operator<<( const std::string& data )
+{
+	if( !m_hash )
+	{
+		return false;
+	}
 
-	  m_hash->Update( (const CryptoPP::byte*)data.data(), data.size() );
+	m_hash->Update( (const CryptoPP::byte*)data.data(), data.size() );
 
-	  return true;
-  }
+	return true;
+}
 
-  bool Md5ChecksumStream::FinishAndRetrieve( std::string& checksum )
-  {
-      if (!m_hash || !m_encoder)
-      {
-		  return false;
-      }
+bool Md5ChecksumStream::FinishAndRetrieve( std::string& checksum )
+{
+	if( !m_hash || !m_encoder )
+	{
+		return false;
+	}
 
-	  std::string digest;
+	std::string digest;
 
-	  digest.resize( m_hash->DigestSize() );
+	digest.resize( m_hash->DigestSize() );
 
-	  m_hash->Final( (CryptoPP::byte*)&digest[0] );
+	m_hash->Final( (CryptoPP::byte*)&digest[0] );
 
-	  CryptoPP::StringSource stringSource( digest, true, new CryptoPP::Redirector( *m_encoder ) );
+	CryptoPP::StringSource stringSource( digest, true, new CryptoPP::Redirector( *m_encoder ) );
 
-	  checksum = m_ss.str();
+	checksum = m_ss.str();
 
-	  while( checksum.size() < 32 )
-	  {
-		  checksum = "0" + checksum;
-	  }
+	while( checksum.size() < 32 )
+	{
+		checksum = "0" + checksum;
+	}
 
-      Finish();
-  	  return true;
-  }
+	Finish();
+	return true;
+}
 
 }

--- a/tools/src/Patching.cpp
+++ b/tools/src/Patching.cpp
@@ -30,11 +30,10 @@ int bs_write( struct bsdiff_stream* stream, const void* buffer, size_t size, enu
 	return 0;
 }
 
-int bs_read_chunked(const struct bspatch_stream * stream, void * buffer,
-				 size_t length, enum bspatch_stream_type type)
+int bs_read_chunked( const struct bspatch_stream* stream, void* buffer, size_t length, enum bspatch_stream_type type )
 {
-	ResourceTools::PatchData* spd = reinterpret_cast<ResourceTools::PatchData*>(stream->opaque);
-	ResourceTools::BundleStreamIn * cs = spd->m_data;
+	ResourceTools::PatchData* spd = reinterpret_cast<ResourceTools::PatchData*>( stream->opaque );
+	ResourceTools::BundleStreamIn* cs = spd->m_data;
 
 	size_t remaining = length;
 	std::string out;
@@ -51,7 +50,7 @@ int bs_read_chunked(const struct bspatch_stream * stream, void * buffer,
 		remaining -= toRead;
 	}
 
-	if(out.size() < length)
+	if( out.size() < length )
 	{
 		return -1;
 	}
@@ -59,169 +58,168 @@ int bs_read_chunked(const struct bspatch_stream * stream, void * buffer,
 	return 0;
 }
 
-int bs_read(const struct bspatch_stream * stream, void * buffer,
-				 size_t length, enum bspatch_stream_type type)
+int bs_read( const struct bspatch_stream* stream, void* buffer, size_t length, enum bspatch_stream_type type )
 {
 	std::string* sp = reinterpret_cast<std::string*>( stream->opaque );
-	if(sp->size() < length)
+	if( sp->size() < length )
 	{
 		return -1;
 	}
 	memcpy( buffer, sp->c_str(), length );
-	sp->erase( 0, length  );
+	sp->erase( 0, length );
 	return 0;
 }
 
 namespace ResourceTools
 {
-bool ApplyPatch(const std::string& data, const std::string& patchData, std::string& out)
-  {
-  	if( patchData.size() < BSDIFF_HEADER_SIZE )
-  	{
-  		return false;
-  	}
-  	if( memcmp( patchData.data(), BSDIFF_HEADER_STR, BSDIFF_HEADER_TEXT_SIZE ) != 0 )
-  	{
-  		return false;
-  	}
-  	bspatch_stream stream;
-  	uint64_t targetLength = *reinterpret_cast<uint64_t*>(const_cast<char*>(patchData.c_str() + BSDIFF_HEADER_TEXT_SIZE));
-  	out.resize( targetLength );
+bool ApplyPatch( const std::string& data, const std::string& patchData, std::string& out )
+{
+	if( patchData.size() < BSDIFF_HEADER_SIZE )
+	{
+		return false;
+	}
+	if( memcmp( patchData.data(), BSDIFF_HEADER_STR, BSDIFF_HEADER_TEXT_SIZE ) != 0 )
+	{
+		return false;
+	}
+	bspatch_stream stream;
+	uint64_t targetLength = *reinterpret_cast<uint64_t*>( const_cast<char*>( patchData.c_str() + BSDIFF_HEADER_TEXT_SIZE ) );
+	out.resize( targetLength );
 
-  	auto readString = std::string(patchData.c_str() + BSDIFF_HEADER_SIZE, patchData.size() - BSDIFF_HEADER_SIZE);
-  	stream.opaque = &readString;
-  	stream.read = bs_read;
+	auto readString = std::string( patchData.c_str() + BSDIFF_HEADER_SIZE, patchData.size() - BSDIFF_HEADER_SIZE );
+	stream.opaque = &readString;
+	stream.read = bs_read;
 
-  	int result = bspatch( reinterpret_cast<const uint8_t*>( data.c_str() ), data.size(), reinterpret_cast<uint8_t*>( const_cast<char*>( out.c_str() ) ), targetLength, &stream );
-  	if( result != 0 )
-  	{
-  		return false;
-  	}
-  	return true;
-  }
+	int result = bspatch( reinterpret_cast<const uint8_t*>( data.c_str() ), data.size(), reinterpret_cast<uint8_t*>( const_cast<char*>( out.c_str() ) ), targetLength, &stream );
+	if( result != 0 )
+	{
+		return false;
+	}
+	return true;
+}
 
-bool ApplyPatchChunked(const std::string& data, ResourceTools::BundleStreamIn& patchData, std::string& out)
-  {
-  	bspatch_stream stream;
-  	std::string headerBytes;
-  	if(!patchData.ReadBytes( BSDIFF_HEADER_TEXT_SIZE, headerBytes ))
-  	{
-  		return false;
-  	}
-  	if( memcmp( headerBytes.c_str(), BSDIFF_HEADER_STR, BSDIFF_HEADER_TEXT_SIZE ) != 0 )
-  	{
-  		return false;
-  	}
-  	std::string targetLengthBytes;
-  	if(!patchData.ReadBytes( BSDIFF_SIZE_ENCODING_SIZE, targetLengthBytes ) )
-  	{
-  		return false;
-  	}
-
-  	uint64_t targetLength = *reinterpret_cast<uint64_t*>(const_cast<char*>(targetLengthBytes.c_str()));
-  	out.resize( targetLength );
-
-  	PatchData spd(&patchData, out.data(), targetLength);
-  	stream.opaque = &spd;
-  	stream.read = bs_read_chunked;
-
-  	int result = bspatch( (uint8_t*)data.c_str(), data.size(), (uint8_t*)out.c_str(), targetLength, &stream );
-  	if( result != 0 )
-  	{
-  		return false;
-  	}
-  	return true;
-  }
-
-  bool CreatePatch(const std::string& previousData, const std::string& latestData, std::string& patchData)
-  {
-  	bsdiff_stream stream;
-  	stream.opaque = &patchData;
-  	stream.malloc = bs_alloc;
-  	stream.free = bs_free;
-  	stream.write = bs_write;
-  	int result = bsdiff( reinterpret_cast<const uint8_t*>(previousData.c_str()), previousData.size(), reinterpret_cast<const uint8_t*>( latestData.c_str() ), latestData.size(), &stream );
-  	if( result != 0 )
-  	{
-  		return false;
-  	}
-  	char sizeEncodedInHeader[8];
-  	uint64_t size = latestData.size();
-  	memcpy( sizeEncodedInHeader, &size, sizeof size );
-  	patchData = std::string(BSDIFF_HEADER_STR, 16) + std::string( sizeEncodedInHeader, 8 ) + patchData;
-
-  	return true;
-  }
-
-  bool ApplyPatchFile( std::filesystem::path target, std::filesystem::path patch )
-  {
-  	  std::string targetData;
-  	  if( !GetLocalFileData( target, targetData ) )
-  	  {
-	  	  return false;
-  	  }
-	  std::string patchData;
-	  if( !GetLocalFileData( patch, patchData ) )
-	  {
-		  return false;
-	  }
-  	  std::string outData;
-  	  if( !ApplyPatch( targetData, patchData, outData ) )
-  	  {
-	  	  return false;
-  	  }
-  	  if( !SaveFile( target, outData ) )
-  	  {
-	  	  return false;
-  	  }
-	  return true;
-  }
-
-  bool ApplyPatchFileChunked( std::filesystem::path target, BundleStreamIn& patch )
-  {
-	  std::string targetData;
-	  if( !GetLocalFileData( target, targetData ) )
-	  {
-		  return false;
-	  }
-	  std::string patchData;
-	  std::string outData;
-	  if( !ApplyPatchChunked( targetData, patch, outData ) )
-	  {
-		  return false;
-	  }
-	  if( !SaveFile( target, outData ) )
-	  {
-		  return false;
-	  }
-	  return true;
-  }
-
-
-bool CreatePatchFile(std::filesystem::path before, std::filesystem::path after, std::filesystem::path patch)
-  {
-  	std::string beforeData;
-  	std::string afterData;
-  	std::string patchData;
-
-  	if( !GetLocalFileData(before, beforeData) )
-  	{
-  		return false;
-  	}
-  	if( !GetLocalFileData(after, afterData) )
-  	{
-  		return false;
-  	}
-
-  	if(!CreatePatch( beforeData, afterData, patchData ))
-  	{
-  		return false;
-  	}
-	if(!SaveFile( patch, patchData ))
+bool ApplyPatchChunked( const std::string& data, ResourceTools::BundleStreamIn& patchData, std::string& out )
+{
+	bspatch_stream stream;
+	std::string headerBytes;
+	if( !patchData.ReadBytes( BSDIFF_HEADER_TEXT_SIZE, headerBytes ) )
+	{
+		return false;
+	}
+	if( memcmp( headerBytes.c_str(), BSDIFF_HEADER_STR, BSDIFF_HEADER_TEXT_SIZE ) != 0 )
+	{
+		return false;
+	}
+	std::string targetLengthBytes;
+	if( !patchData.ReadBytes( BSDIFF_SIZE_ENCODING_SIZE, targetLengthBytes ) )
 	{
 		return false;
 	}
 
-  	return true;
-  }
+	uint64_t targetLength = *reinterpret_cast<uint64_t*>( const_cast<char*>( targetLengthBytes.c_str() ) );
+	out.resize( targetLength );
+
+	PatchData spd( &patchData, out.data(), targetLength );
+	stream.opaque = &spd;
+	stream.read = bs_read_chunked;
+
+	int result = bspatch( (uint8_t*)data.c_str(), data.size(), (uint8_t*)out.c_str(), targetLength, &stream );
+	if( result != 0 )
+	{
+		return false;
+	}
+	return true;
+}
+
+bool CreatePatch( const std::string& previousData, const std::string& latestData, std::string& patchData )
+{
+	bsdiff_stream stream;
+	stream.opaque = &patchData;
+	stream.malloc = bs_alloc;
+	stream.free = bs_free;
+	stream.write = bs_write;
+	int result = bsdiff( reinterpret_cast<const uint8_t*>( previousData.c_str() ), previousData.size(), reinterpret_cast<const uint8_t*>( latestData.c_str() ), latestData.size(), &stream );
+	if( result != 0 )
+	{
+		return false;
+	}
+	char sizeEncodedInHeader[8];
+	uint64_t size = latestData.size();
+	memcpy( sizeEncodedInHeader, &size, sizeof size );
+	patchData = std::string( BSDIFF_HEADER_STR, 16 ) + std::string( sizeEncodedInHeader, 8 ) + patchData;
+
+	return true;
+}
+
+bool ApplyPatchFile( std::filesystem::path target, std::filesystem::path patch )
+{
+	std::string targetData;
+	if( !GetLocalFileData( target, targetData ) )
+	{
+		return false;
+	}
+	std::string patchData;
+	if( !GetLocalFileData( patch, patchData ) )
+	{
+		return false;
+	}
+	std::string outData;
+	if( !ApplyPatch( targetData, patchData, outData ) )
+	{
+		return false;
+	}
+	if( !SaveFile( target, outData ) )
+	{
+		return false;
+	}
+	return true;
+}
+
+bool ApplyPatchFileChunked( std::filesystem::path target, BundleStreamIn& patch )
+{
+	std::string targetData;
+	if( !GetLocalFileData( target, targetData ) )
+	{
+		return false;
+	}
+	std::string patchData;
+	std::string outData;
+	if( !ApplyPatchChunked( targetData, patch, outData ) )
+	{
+		return false;
+	}
+	if( !SaveFile( target, outData ) )
+	{
+		return false;
+	}
+	return true;
+}
+
+
+bool CreatePatchFile( std::filesystem::path before, std::filesystem::path after, std::filesystem::path patch )
+{
+	std::string beforeData;
+	std::string afterData;
+	std::string patchData;
+
+	if( !GetLocalFileData( before, beforeData ) )
+	{
+		return false;
+	}
+	if( !GetLocalFileData( after, afterData ) )
+	{
+		return false;
+	}
+
+	if( !CreatePatch( beforeData, afterData, patchData ) )
+	{
+		return false;
+	}
+	if( !SaveFile( patch, patchData ) )
+	{
+		return false;
+	}
+
+	return true;
+}
 }

--- a/tools/src/ResourceTools.cpp
+++ b/tools/src/ResourceTools.cpp
@@ -23,8 +23,8 @@
 namespace ResourceTools
 {
 
-  bool GenerateMd5Checksum( const std::filesystem::path& path, std::string& checksum )
-  {
+bool GenerateMd5Checksum( const std::filesystem::path& path, std::string& checksum )
+{
 	ResourceTools::Md5ChecksumStream md5Stream;
 	ResourceTools::FileDataStreamIn fileDataIn;
 	if( !fileDataIn.StartRead( path ) )
@@ -38,463 +38,465 @@ namespace ResourceTools
 	}
 	md5Stream.FinishAndRetrieve( checksum );
 	return true;
-  }
+}
 
-  bool Md5ChecksumMatches( const std::filesystem::path& path, std::string& checksum )
-  {
-  	std::string otherChecksum;
-  	if( !GenerateMd5Checksum( path, otherChecksum ) )
-  	{
-  		return false;
-  	}
-  	return otherChecksum == checksum;
-  }
+bool Md5ChecksumMatches( const std::filesystem::path& path, std::string& checksum )
+{
+	std::string otherChecksum;
+	if( !GenerateMd5Checksum( path, otherChecksum ) )
+	{
+		return false;
+	}
+	return otherChecksum == checksum;
+}
 
-  bool GenerateMd5Checksum( const std::string& data, std::string& checksum )
-  {
-	  Md5ChecksumStream md5ChecksumStream;
+bool GenerateMd5Checksum( const std::string& data, std::string& checksum )
+{
+	Md5ChecksumStream md5ChecksumStream;
 
-      md5ChecksumStream << data;
+	md5ChecksumStream << data;
 
-      if (md5ChecksumStream.FinishAndRetrieve(checksum))
-      {
-		  return true;
-      }
-      else
-      {
-		  return false;
-      }
+	if( md5ChecksumStream.FinishAndRetrieve( checksum ) )
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
 
-  }
+bool GenerateFowlerNollVoChecksum( const std::string& input, std::string& checksum )
+{
+	unsigned long long offset_bias = 14695981039346656037U;
 
-  bool GenerateFowlerNollVoChecksum(const std::string& input, std::string& checksum)
-  {
-	  unsigned long long offset_bias = 14695981039346656037U;
+	unsigned long long prime = 1099511628211;
 
-	  unsigned long long prime = 1099511628211;
+	unsigned long long hash = offset_bias;
 
-	  unsigned long long hash = offset_bias;
+	const char* data = input.data();
 
-      const char* data = input.data();
+	for( int i = 0; i < input.size(); i++ )
+	{
+		hash = ( hash * prime ) & 0xffffffffffffffff;
 
-	  for( int i = 0; i < input.size(); i++ )
-	  {
-		  hash = ( hash * prime ) & 0xffffffffffffffff;
+		hash = ( hash ^ data[i] ) & 0xffffffffffffffff;
+	}
 
-		  hash = ( hash ^ data[i] ) & 0xffffffffffffffff;
-	  }
+	std::ostringstream ss;
 
-	  std::ostringstream ss;
+	ss << std::hex << hash;
 
-	  ss << std::hex << hash;
+	checksum = ss.str();
 
-	  checksum = ss.str();
+	//Pad with zeros to get to correct size
+	while( checksum.size() < 16 )
+	{
+		checksum = "0" + checksum;
+	}
 
-	  //Pad with zeros to get to correct size
-	  while( checksum.size() < 16 )
-	  {
-		  checksum = "0" + checksum;
-	  }
+	return true;
+}
 
-	  return true;
-  }
+std::list<ChunkMatch> FindMatchingChunks( const std::string& source, std::string& destination )
+{
+	std::list<ChunkMatch> result;
 
- std::list<ChunkMatch> FindMatchingChunks( const std::string& source, std::string& destination )
-  {
-	  std::list<ChunkMatch> result;
+	uint32_t window = 4; // The amount of bytes to use for the checksum.
 
-	  uint32_t window = 4; // The amount of bytes to use for the checksum.
+	if( destination.size() < window || source.size() < window )
+	{
+		// Not much to find here. Let's not bother.
+		return result;
+	}
 
-	  if( destination.size() < window || source.size() < window )
-	  {
-		  // Not much to find here. Let's not bother.
-		  return result;
-	  }
+	uint32_t start = 0;
+	uint32_t end = window;
 
-	  uint32_t start = 0;
-	  uint32_t end = window;
+	RollingChecksum sourceStartChecksum = GenerateRollingAdlerChecksum( source, 0, window );
+	while( end < destination.size() )
+	{
+		ChunkMatch match;
+		match.sourceOffset = 0;
+		match.destinationOffset = start;
+		match.length = 0;
 
-	  RollingChecksum sourceStartChecksum = GenerateRollingAdlerChecksum( source, 0, window );
-	  while( end < destination.size() )
-	  {
-		  ChunkMatch match;
-		  match.sourceOffset = 0;
-		  match.destinationOffset = start;
-		  match.length = 0;
+		RollingChecksum destinationChecksum = GenerateRollingAdlerChecksum( destination, start, end );
 
-		  RollingChecksum destinationChecksum = GenerateRollingAdlerChecksum( destination, start, end );
+		uint32_t length = 0;
+		uint32_t maxLength = 0;
+		match.length = 0;
+		uint32_t sourceStart = 0;
+		uint32_t sourceEnd = sourceStart + window;
+		RollingChecksum rollingDestinationChecksum = destinationChecksum;
+		RollingChecksum rollingSourceChecksum = sourceStartChecksum;
+		uint32_t sourceMatchStart = sourceStart;
+		while( sourceEnd <= source.size() && end + length <= destination.size() )
+		{
+			if( length )
+			{
+				rollingDestinationChecksum = GenerateRollingAdlerChecksum( destination, start + length, end + length, rollingDestinationChecksum );
+			}
+			else
+			{
+				rollingDestinationChecksum = destinationChecksum;
+			}
+			if( sourceStart )
+			{
+				rollingSourceChecksum = GenerateRollingAdlerChecksum( source, sourceStart, sourceEnd, rollingSourceChecksum );
+			}
+			else
+			{
+				rollingSourceChecksum = sourceStartChecksum;
+			}
+			if( rollingDestinationChecksum.checksum == rollingSourceChecksum.checksum )
+			{
+				if( !length )
+				{
+					sourceMatchStart = sourceStart;
+				}
+				++length;
+				if( length > maxLength )
+				{
+					maxLength = length;
+					match.length = length + window - 1;
+					match.sourceOffset = sourceMatchStart;
+					match.destinationOffset = start;
+				}
+			}
+			else
+			{
+				length = 0;
+			}
+			++sourceStart;
+			++sourceEnd;
+		}
+		if( maxLength )
+		{
+			bool subsumed = false;
+			for( auto it = result.rbegin(); it != result.rend(); it++ )
+			{
+				if( match.destinationOffset - it->destinationOffset > match.length )
+				{
+					break;
+				}
+				int64_t delta = match.destinationOffset - it->destinationOffset;
+				if( it->length >= delta + match.length )
+				{
+					subsumed = true;
+					break;
+				}
+			}
+			if( !subsumed )
+			{
+				result.push_back( match );
+			}
+		}
+		++start;
+		++end;
+	}
+	return result;
+}
 
-		  uint32_t length = 0;
-		  uint32_t maxLength = 0;
-		  match.length = 0;
-		  uint32_t sourceStart = 0;
-		  uint32_t sourceEnd = sourceStart + window;
-		  RollingChecksum rollingDestinationChecksum = destinationChecksum;
-		  RollingChecksum rollingSourceChecksum = sourceStartChecksum;
-	  	  uint32_t sourceMatchStart = sourceStart;
-		  while( sourceEnd <= source.size() && end + length <= destination.size() )
-		  {
-			  if( length )
-			  {
-				  rollingDestinationChecksum = GenerateRollingAdlerChecksum( destination, start + length, end + length, rollingDestinationChecksum );
-			  }
-			  else
-			  {
-				  rollingDestinationChecksum = destinationChecksum;
-			  }
-		  	  if(sourceStart)
-		  	  {
-			  	  rollingSourceChecksum = GenerateRollingAdlerChecksum( source, sourceStart, sourceEnd, rollingSourceChecksum );
-		  	  }
-			  else
-			  {
-			  	rollingSourceChecksum = sourceStartChecksum;
-			  }
-			  if( rollingDestinationChecksum.checksum == rollingSourceChecksum.checksum )
-			  {
-			  	  if(!length)
-			  	  {
-			  	  	sourceMatchStart = sourceStart;
-			  	  }
-				  ++length;
-				  if( length > maxLength )
-				  {
-					  maxLength = length;
-					  match.length = length + window - 1;
-					  match.sourceOffset = sourceMatchStart;
-					  match.destinationOffset = start;
-				  }
-			  }
-		  	  else
-		  	  {
-			  	  length = 0;
-		  	  }
-			  ++sourceStart;
-			  ++sourceEnd;
-		  }
-		  if( maxLength )
-		  {
-			  bool subsumed = false;
-			  for( auto it = result.rbegin(); it != result.rend(); it++ )
-			  {
-				  if( match.destinationOffset - it->destinationOffset > match.length  )
-				  {
-					  break;
-				  }
-				  int64_t delta = match.destinationOffset - it->destinationOffset;
-				  if( it->length >= delta + match.length )
-				  {
-					  subsumed = true;
-					  break;
-				  }
-			  }
-			  if( !subsumed )
-			  {
-				  result.push_back( match );
-			  }
-		  }
-		  ++start;
-		  ++end;
-	  }
-	  return result;
-  }
+bool FindMatchingChunk( const std::string& chunk, std::filesystem::path filePath, size_t& chunkOffset )
+{
+	if( chunk.size() > std::numeric_limits<uint32_t>::max() )
+	{
+		return false;
+	}
+	uint32_t chunkSize = static_cast<uint32_t>( chunk.size() );
+	FileDataStreamIn stream( chunkSize );
+	stream.StartRead( filePath );
+	std::string backlog;
+	std::string fileData;
+	RollingChecksum chunkChecksum = GenerateRollingAdlerChecksum( chunk, 0, chunkSize );
+	RollingChecksum lastChecksum;
+	uint64_t fileOffset{ 0 };
+	uint32_t backlogOffset{ 0 };
+	while( stream >> fileData )
+	{
+		backlog += fileData;
+		while( backlogOffset + chunkSize <= backlog.size() )
+		{
+			if( backlogOffset == 0 )
+			{
+				lastChecksum = GenerateRollingAdlerChecksum( backlog, 0, chunkSize );
+			}
+			else
+			{
+				lastChecksum = GenerateRollingAdlerChecksum( backlog, backlogOffset, backlogOffset + chunkSize, lastChecksum );
+			}
+			if( lastChecksum.checksum == chunkChecksum.checksum )
+			{
+				// We have a potential match. Time to verify
+				std::string sourceMD5;
+				if( !ResourceTools::GenerateMd5Checksum( chunk, sourceMD5 ) )
+				{
+					++backlogOffset;
+					continue;
+				}
+				std::string matchingChunkMD5;
+				std::string matchStr = backlog.substr( backlogOffset, chunkSize );
+				if( !ResourceTools::GenerateMd5Checksum( matchStr, matchingChunkMD5 ) )
+				{
+					++backlogOffset;
+					continue;
+				}
+				if( sourceMD5 == matchingChunkMD5 )
+				{
+					// It's legit!
+					chunkOffset = backlogOffset + fileOffset;
+					return true;
+				}
+			}
+			++backlogOffset;
+		}
 
-  bool FindMatchingChunk( const std::string& chunk, std::filesystem::path filePath, size_t& chunkOffset )
-  {
-  	  if( chunk.size() > std::numeric_limits<uint32_t>::max() )
-  	  {
-	  	  return false;
-  	  }
-	  uint32_t chunkSize = static_cast<uint32_t>( chunk.size() );
-	  FileDataStreamIn stream( chunkSize );
-	  stream.StartRead( filePath );
-	  std::string backlog;
-	  std::string fileData;
-	  RollingChecksum chunkChecksum = GenerateRollingAdlerChecksum( chunk, 0, chunkSize );
-	  RollingChecksum lastChecksum;
-	  uint64_t fileOffset{ 0 };
-	  uint32_t backlogOffset{ 0 };
-	  while( stream >> fileData )
-	  {
-		  backlog += fileData;
-		  while( backlogOffset + chunkSize <= backlog.size() )
-		  {
-			  if( backlogOffset == 0 )
-			  {
-				  lastChecksum = GenerateRollingAdlerChecksum( backlog, 0, chunkSize );
-			  }
-			  else
-			  {
-				  lastChecksum = GenerateRollingAdlerChecksum( backlog, backlogOffset, backlogOffset + chunkSize, lastChecksum );
-			  }
-			  if( lastChecksum.checksum == chunkChecksum.checksum )
-			  {
-				  // We have a potential match. Time to verify
-				  std::string sourceMD5;
-				  if( !ResourceTools::GenerateMd5Checksum( chunk, sourceMD5 ) )
-				  {
-					  ++backlogOffset;
-					  continue;
-				  }
-				  std::string matchingChunkMD5;
-				  std::string matchStr = backlog.substr( backlogOffset, chunkSize );
-				  if( !ResourceTools::GenerateMd5Checksum( matchStr, matchingChunkMD5 ) )
-				  {
-					  ++backlogOffset;
-					  continue;
-				  }
-				  if( sourceMD5 == matchingChunkMD5 )
-				  {
-					  // It's legit!
-					  chunkOffset = backlogOffset + fileOffset;
-					  return true;
-				  }
-			  }
-			  ++backlogOffset;
-		  }
+		// Shrink fileData every now and then, but beware, we need to access start-1 for the rolling checksum.
+		if( backlogOffset > chunkSize + 1 )
+		{
+			backlogOffset -= chunkSize;
+			fileOffset += chunkSize;
+			backlog = backlog.substr( chunkSize );
+		}
+	}
+	return false;
+}
 
-		  // Shrink fileData every now and then, but beware, we need to access start-1 for the rolling checksum.
-		  if( backlogOffset > chunkSize + 1 )
-		  {
-			  backlogOffset -= chunkSize;
-			  fileOffset += chunkSize;
-			  backlog = backlog.substr( chunkSize );
-		  }
-	  }
-	  return false;
-  }
+size_t CountMatchingChunks( const std::filesystem::path& fileA, size_t offsetA, std::filesystem::path fileB, size_t offsetB, size_t chunkSize )
+{
+	size_t result{ 0 };
+	FileDataStreamIn streamA( chunkSize );
+	if( !streamA.StartRead( fileA ) )
+	{
+		return result;
+	}
+	streamA.Seek( offsetA );
 
-  size_t CountMatchingChunks( const std::filesystem::path& fileA, size_t offsetA, std::filesystem::path fileB, size_t offsetB, size_t chunkSize )
-  {
-  	size_t result{ 0 };
-  	FileDataStreamIn streamA( chunkSize );
-  	if(!streamA.StartRead( fileA ))
-  	{
-  		return result;
-  	}
-  	streamA.Seek( offsetA );
+	FileDataStreamIn streamB( chunkSize );
+	if( !streamB.StartRead( fileB ) )
+	{
+		return result;
+	}
+	streamB.Seek( offsetB );
 
-  	FileDataStreamIn streamB( chunkSize );
-  	if(!streamB.StartRead( fileB ))
-  	{
-  		return result;
-  	}
-  	streamB.Seek( offsetB );
+	std::string chunkA;
+	std::string chunkB;
 
-  	std::string chunkA;
-  	std::string chunkB;
+	std::string checksumA;
+	std::string checksumB;
 
-  	std::string checksumA;
-  	std::string checksumB;
-
-  	while( true )
-  	{
-  		if( !(streamA >> chunkA) || !(streamB >> chunkB) )
-  		{
-  			return result;
-  		}
-  		if( !ResourceTools::GenerateMd5Checksum( chunkA, checksumA ) )
-  		{
-  			return result;
-  		}
-  		if( !ResourceTools::GenerateMd5Checksum( chunkB, checksumB ) )
-  		{
-  			return result;
-  		}
-  		if( checksumA != checksumB )
-  		{
-  			break;
-  		}
-  		++result;
-  	}
+	while( true )
+	{
+		if( !( streamA >> chunkA ) || !( streamB >> chunkB ) )
+		{
+			return result;
+		}
+		if( !ResourceTools::GenerateMd5Checksum( chunkA, checksumA ) )
+		{
+			return result;
+		}
+		if( !ResourceTools::GenerateMd5Checksum( chunkB, checksumB ) )
+		{
+			return result;
+		}
+		if( checksumA != checksumB )
+		{
+			break;
+		}
+		++result;
+	}
 
 	return result;
-  }
+}
 
-  bool GetLocalFileData( const std::filesystem::path& filepath, std::string& data )
-  {
+bool GetLocalFileData( const std::filesystem::path& filepath, std::string& data )
+{
 
-      FileDataStreamIn fileDataStreamIn;
+	FileDataStreamIn fileDataStreamIn;
 
-      if (!fileDataStreamIn.StartRead(filepath))
-      {
-		  return false;
-      }
+	if( !fileDataStreamIn.StartRead( filepath ) )
+	{
+		return false;
+	}
 
-      if (!(fileDataStreamIn >> data))
-      {
-		  return false;
-      }
-      else
-      {
-		  return true;
-      }
+	if( !( fileDataStreamIn >> data ) )
+	{
+		return false;
+	}
+	else
+	{
+		return true;
+	}
+}
 
-  }
+bool GZipCompressData( const std::string& dataToCompress, std::string& compressedData )
+{
+	// Ensure the input is cleared prior to calculating compression
+	compressedData.clear();
 
-  bool GZipCompressData( const std::string& dataToCompress, std::string& compressedData )
-  {
-      // Ensure the input is cleared prior to calculating compression
-	  compressedData.clear();
+	z_stream strm;
+	constexpr int CHUNK = 16384; // 16kb
+	unsigned char out[CHUNK];
 
-	  z_stream strm;
-	  constexpr int CHUNK = 16384; // 16kb
-	  unsigned char out[CHUNK];
+	strm.zalloc = Z_NULL;
+	strm.zfree = Z_NULL;
+	strm.opaque = Z_NULL;
+	int windowBits = MAX_WBITS | 16; // 16 is a magic bit flag to specify GZip compression format.
+	int ret = deflateInit2( &strm, Z_BEST_COMPRESSION, Z_DEFLATED, windowBits, 8, Z_DEFAULT_STRATEGY );
+	if( ret != Z_OK )
+	{
+		return false;
+	}
 
-	  strm.zalloc = Z_NULL;
-	  strm.zfree = Z_NULL;
-	  strm.opaque = Z_NULL;
-	  int windowBits = MAX_WBITS | 16; // 16 is a magic bit flag to specify GZip compression format.
-	  int ret = deflateInit2( &strm, Z_BEST_COMPRESSION, Z_DEFLATED, windowBits, 8, Z_DEFAULT_STRATEGY );
-	  if( ret != Z_OK )
-	  {
-		  return false;
-	  }
+	strm.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( dataToCompress.c_str() ) );
+	strm.avail_in = static_cast<uInt>( dataToCompress.size() );
 
-	  strm.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( dataToCompress.c_str() ) );
-	  strm.avail_in = static_cast<uInt>( dataToCompress.size() );
+	do
+	{
+		strm.next_out = out;
+		strm.avail_out = CHUNK;
+		int flush = strm.avail_in <= CHUNK ? Z_FINISH : Z_NO_FLUSH;
+		ret = deflate( &strm, flush );
+		compressedData.append( std::string( reinterpret_cast<const char*>( out ), strm.total_out - compressedData.size() ) );
+	} while( ret == Z_OK );
 
-	  do
-	  {
-		  strm.next_out = out;
-		  strm.avail_out = CHUNK;
-		  int flush = strm.avail_in <= CHUNK ? Z_FINISH : Z_NO_FLUSH;
-		  ret = deflate( &strm, flush );
-		  compressedData.append( std::string( reinterpret_cast<const char*>( out ), strm.total_out - compressedData.size() ) );
-	  } while( ret == Z_OK );
+	if( ret != Z_STREAM_END )
+	{
+		deflateEnd( &strm );
+		return false;
+	}
+	return deflateEnd( &strm ) == Z_OK;
+}
 
-	  if( ret != Z_STREAM_END )
-	  {
-		  deflateEnd( &strm );
-		  return false;
-	  }
-	  return deflateEnd( &strm ) == Z_OK;
-  }
+bool GZipUncompressData( const std::string& dataToUncompress, std::string& uncompressedData )
+{
+	z_stream strm;
+	constexpr int CHUNK = 16384; // 16kb
+	unsigned char out[CHUNK];
 
-  bool GZipUncompressData( const std::string& dataToUncompress, std::string& uncompressedData )
-  {
-	  z_stream strm;
-	  constexpr int CHUNK = 16384; // 16kb
-	  unsigned char out[CHUNK];
+	strm.zalloc = Z_NULL;
+	strm.zfree = Z_NULL;
+	strm.opaque = Z_NULL;
+	strm.avail_in = 0;
+	strm.next_in = Z_NULL;
+	int ret = inflateInit2( &strm, 16 | MAX_WBITS );
+	if( ret != Z_OK )
+	{
+		return false;
+	}
 
-	  strm.zalloc = Z_NULL;
-	  strm.zfree = Z_NULL;
-	  strm.opaque = Z_NULL;
-	  strm.avail_in = 0;
-	  strm.next_in = Z_NULL;
-	  int ret = inflateInit2( &strm, 16 | MAX_WBITS );
-	  if( ret != Z_OK )
-	  {
-		  return false;
-	  }
+	strm.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( dataToUncompress.c_str() ) );
+	strm.avail_in = static_cast<uInt>( dataToUncompress.size() );
 
-	  strm.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( dataToUncompress.c_str() ) );
-	  strm.avail_in = static_cast<uInt>( dataToUncompress.size() );
+	do
+	{
+		strm.next_out = out;
+		strm.avail_out = CHUNK;
+		ret = inflate( &strm, Z_NO_FLUSH );
+		uncompressedData.append( std::string( reinterpret_cast<const char*>( out ), strm.total_out - uncompressedData.size() ) );
+	} while( ret == Z_OK );
 
-	  do
-	  {
-		  strm.next_out = out;
-		  strm.avail_out = CHUNK;
-		  ret = inflate( &strm, Z_NO_FLUSH );
-		  uncompressedData.append( std::string( reinterpret_cast<const char*>( out ), strm.total_out - uncompressedData.size() ) );
-	  } while( ret == Z_OK );
+	if( ret != Z_STREAM_END )
+	{
+		inflateEnd( &strm );
+		return false;
+	}
 
-	  if( ret != Z_STREAM_END )
-	  {
-		  inflateEnd( &strm );
-		  return false;
-	  }
+	return inflateEnd( &strm ) == Z_OK;
+}
 
-	  return inflateEnd( &strm ) == Z_OK;
-  }
+bool SaveFile( const std::filesystem::path& path, const std::string& data )
+{
+	FileDataStreamOut fileDataStreamOut;
 
-  bool SaveFile( const std::filesystem::path& path, const std::string& data )
-  {
-	  FileDataStreamOut fileDataStreamOut;
+	if( !fileDataStreamOut.StartWrite( path ) )
+	{
+		return false;
+	}
 
-      if (!fileDataStreamOut.StartWrite(path))
-      {
-		  return false;
-      }
-
-      if (!(fileDataStreamOut << data))
-      {
-		  return false;
-      }
-      else
-      {
-		  return true;
-      }
-
-  }
+	if( !( fileDataStreamOut << data ) )
+	{
+		return false;
+	}
+	else
+	{
+		return true;
+	}
+}
 
 #if __APPLE__
-  unsigned int CalculateBinaryOperation( const std::filesystem::path& path )
-  {
-  	  struct stat s;
-	  int err = lstat( path.c_str(), &s );
-  	  if(err)
-  	  {
-	  	  return 0;
-  	  }
-  	  return s.st_mode;
-  }
+unsigned int CalculateBinaryOperation( const std::filesystem::path& path )
+{
+	struct stat s;
+	int err = lstat( path.c_str(), &s );
+	if( err )
+	{
+		return 0;
+	}
+	return s.st_mode;
+}
 #elif WIN32
-int FileAttributesToMode(DWORD attr)
-  {
-  	int m = 0x8000; // Regular file, not a symlink or directory or anything.
-  	if (attr & FILE_ATTRIBUTE_READONLY) {
-  		m |= 0444;
-  	}
-  	else
-  	{
-  		m |= 0666;
-  	}
-  	return m;
-  }
+int FileAttributesToMode( DWORD attr )
+{
+	int m = 0x8000; // Regular file, not a symlink or directory or anything.
+	if( attr & FILE_ATTRIBUTE_READONLY )
+	{
+		m |= 0444;
+	}
+	else
+	{
+		m |= 0666;
+	}
+	return m;
+}
 
-void SetExecutableFlagByFileExtension(const wchar_t *path, BY_HANDLE_FILE_INFORMATION fileInfo, unsigned int &result) {
-  	const wchar_t *fileExtension = wcsrchr(path, '.');
-  	if (fileExtension) {
-  		if (_wcsicmp(fileExtension, L".exe") == 0 ||
-			  _wcsicmp(fileExtension, L".bat") == 0 ||
-			  _wcsicmp(fileExtension, L".cmd") == 0 ||
-			  _wcsicmp(fileExtension, L".com") == 0) {
-  			result |= 0111;
-			  }
-  	}
-  }
+void SetExecutableFlagByFileExtension( const wchar_t* path, BY_HANDLE_FILE_INFORMATION fileInfo, unsigned int& result )
+{
+	const wchar_t* fileExtension = wcsrchr( path, '.' );
+	if( fileExtension )
+	{
+		if( _wcsicmp( fileExtension, L".exe" ) == 0 ||
+			_wcsicmp( fileExtension, L".bat" ) == 0 ||
+			_wcsicmp( fileExtension, L".cmd" ) == 0 ||
+			_wcsicmp( fileExtension, L".com" ) == 0 )
+		{
+			result |= 0111;
+		}
+	}
+}
 
 unsigned int CalculateBinaryOperation( const std::filesystem::path& path )
 {
-  	HANDLE hFile;
-  	BY_HANDLE_FILE_INFORMATION fileInfo;
-  	DWORD access = FILE_READ_ATTRIBUTES;
-  	DWORD flags{0};
-  	unsigned int result{0};
-  	hFile = CreateFileW(path.wstring().c_str(), access, 0, nullptr, OPEN_EXISTING, flags, nullptr);
+	HANDLE hFile;
+	BY_HANDLE_FILE_INFORMATION fileInfo;
+	DWORD access = FILE_READ_ATTRIBUTES;
+	DWORD flags{ 0 };
+	unsigned int result{ 0 };
+	hFile = CreateFileW( path.wstring().c_str(), access, 0, nullptr, OPEN_EXISTING, flags, nullptr );
 
-  	if (hFile == INVALID_HANDLE_VALUE)
-  	{
-  		return 0;
-  	}
+	if( hFile == INVALID_HANDLE_VALUE )
+	{
+		return 0;
+	}
 
-  	FILE_BASIC_INFO basicInfo;
-  	if (!GetFileInformationByHandle(hFile, &fileInfo) || !GetFileInformationByHandleEx(hFile, FileBasicInfo, &basicInfo, sizeof(basicInfo)))
-  	{
-  		return 0;
-  	}
+	FILE_BASIC_INFO basicInfo;
+	if( !GetFileInformationByHandle( hFile, &fileInfo ) || !GetFileInformationByHandleEx( hFile, FileBasicInfo, &basicInfo, sizeof( basicInfo ) ) )
+	{
+		return 0;
+	}
 
-  	auto fileType = GetFileType(hFile);
-  	if (fileType != FILE_TYPE_DISK) {
-  		return 0;
-  	}
+	auto fileType = GetFileType( hFile );
+	if( fileType != FILE_TYPE_DISK )
+	{
+		return 0;
+	}
 
-  	result = FileAttributesToMode(fileInfo.dwFileAttributes);
-  	SetExecutableFlagByFileExtension(path.wstring().c_str(), fileInfo, result);
-  	CloseHandle(hFile);
-  	return result;
-  }
+	result = FileAttributesToMode( fileInfo.dwFileAttributes );
+	SetExecutableFlagByFileExtension( path.wstring().c_str(), fileInfo, result );
+	CloseHandle( hFile );
+	return result;
+}
 #endif
 
 }

--- a/tools/src/RollingChecksum.cpp
+++ b/tools/src/RollingChecksum.cpp
@@ -2,50 +2,50 @@
 
 #include "RollingChecksum.h"
 
-constexpr uint32_t ROLLING_CHECKSUM_MODULO{2 << 15};
+constexpr uint32_t ROLLING_CHECKSUM_MODULO{ 2 << 15 };
 
 namespace ResourceTools
 {
-  RollingChecksum GenerateRollingAdlerChecksum( const std::string& input, uint32_t start, uint32_t end )
-  {
-  	  uint32_t alpha = 0;
-  	  auto substring = input.substr( start, end-start );
-  	  for( auto c: substring )
-  	  {
-	  	  alpha += c;
-  	  }
-  	  alpha %= ROLLING_CHECKSUM_MODULO;
+RollingChecksum GenerateRollingAdlerChecksum( const std::string& input, uint32_t start, uint32_t end )
+{
+	uint32_t alpha = 0;
+	auto substring = input.substr( start, end - start );
+	for( auto c : substring )
+	{
+		alpha += c;
+	}
+	alpha %= ROLLING_CHECKSUM_MODULO;
 
-  	  uint32_t beta = 0;
-  	  for( uint32_t i = start; i < end; ++i )
-  	  {
-	  	  beta += (end - i) * substring[ i - start ];
-  	  }
-  	  beta %= ROLLING_CHECKSUM_MODULO;
+	uint32_t beta = 0;
+	for( uint32_t i = start; i < end; ++i )
+	{
+		beta += ( end - i ) * substring[i - start];
+	}
+	beta %= ROLLING_CHECKSUM_MODULO;
 
-  	  RollingChecksum rc;
-  	  rc.alpha = alpha;
-  	  rc.beta = beta;
-  	  rc.checksum = alpha + (beta * ROLLING_CHECKSUM_MODULO);
+	RollingChecksum rc;
+	rc.alpha = alpha;
+	rc.beta = beta;
+	rc.checksum = alpha + ( beta * ROLLING_CHECKSUM_MODULO );
 
-	  return rc;
-  }
+	return rc;
+}
 
-  RollingChecksum GenerateRollingAdlerChecksum( const std::string& input, uint32_t start, uint32_t end, RollingChecksum previous )
-  {
-  	  uint32_t alpha = previous.alpha - input[start - 1] + input[end - 1];
-  	  alpha %= ROLLING_CHECKSUM_MODULO;
+RollingChecksum GenerateRollingAdlerChecksum( const std::string& input, uint32_t start, uint32_t end, RollingChecksum previous )
+{
+	uint32_t alpha = previous.alpha - input[start - 1] + input[end - 1];
+	alpha %= ROLLING_CHECKSUM_MODULO;
 
-  	  uint32_t beta = previous.beta + alpha - (end - start) * input[start - 1];
-  	  beta %= ROLLING_CHECKSUM_MODULO;
+	uint32_t beta = previous.beta + alpha - ( end - start ) * input[start - 1];
+	beta %= ROLLING_CHECKSUM_MODULO;
 
-  	  RollingChecksum rc;
-  	  rc.alpha = alpha;
-  	  rc.beta = beta;
-  	  rc.checksum = alpha + (beta * ROLLING_CHECKSUM_MODULO);
+	RollingChecksum rc;
+	rc.alpha = alpha;
+	rc.beta = beta;
+	rc.checksum = alpha + ( beta * ROLLING_CHECKSUM_MODULO );
 
-	  return rc;
-  }
+	return rc;
+}
 
 
 }

--- a/tools/src/ScopedFile.cpp
+++ b/tools/src/ScopedFile.cpp
@@ -5,21 +5,20 @@
 
 namespace ResourceTools
 {
-	
-  ScopedFile::ScopedFile( std::filesystem::path location ) :
-	  m_location(location)
-  {
 
-  }
+ScopedFile::ScopedFile( std::filesystem::path location ) :
+	m_location( location )
+{
+}
 
-  ScopedFile::~ScopedFile()
-  {
-      if (std::filesystem::exists(m_location))
-      {
-          // Attempt to delete the temporary file
-		  std::filesystem::remove( m_location );
-      }
-  }
+ScopedFile::~ScopedFile()
+{
+	if( std::filesystem::exists( m_location ) )
+	{
+		// Attempt to delete the temporary file
+		std::filesystem::remove( m_location );
+	}
+}
 
 
 }


### PR DESCRIPTION
Make sure all files in the repo adhere to the specified .clang-format 

This is part of:
PLAT-9856
Makeing carbonengine/resources ready for open source.