### PR TITLE
Set CMake min version to 3.30.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
-cmake_minimum_required(VERSION 3.30)
-project(resources VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.30.1)
+project(resources VERSION 3.0.3)
 
 
 include(cmake/CcpGlobalSettings.cmake)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,8 +2,8 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 31,
-    "patch": 0
+    "minor": 30,
+    "patch": 1
   },
   "configurePresets": [
     {

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright © 2025 CCP ehf.
 
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.30)
 project(resources-cli VERSION 1.0.0)
 
 find_package(argparse CONFIG REQUIRED)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Copyright © 2025 CCP ehf.
 
-cmake_minimum_required(VERSION 3.30)
 project(resources-cli VERSION 1.0.0)
 
 find_package(argparse CONFIG REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Copyright © 2025 CCP ehf.
 
-cmake_minimum_required(VERSION 3.18)
-
 project(resources-test)
 
 find_package(CURL CONFIG REQUIRED)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright © 2025 CCP ehf.
 
-cmake_minimum_required(VERSION 3.31)
+cmake_minimum_required(VERSION 3.30)
 project(resources-tools VERSION 1.0.0)
 
 find_package(cryptopp CONFIG REQUIRED)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,5 @@
 # Copyright © 2025 CCP ehf.
 
-cmake_minimum_required(VERSION 3.30)
 project(resources-tools VERSION 1.0.0)
 
 find_package(cryptopp CONFIG REQUIRED)


### PR DESCRIPTION
Make sure mininum CMake version is the same across the whole project.
Setting it to 3.30.1 at the top/root level.