### PR TITLE
Upgrade vcpkg port versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.30.1)
-project(resources VERSION 3.1.0)
+project(resources VERSION 3.1.1)
 
 include(cmake/CcpGlobalSettings.cmake)
 include(cmake/CcpTargetConfigurations.cmake)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "git@github.com:carbonengine/vcpkg-registry.git",
-      "baseline": "addd8867a1553f4b7866bb7a36deb84bd59bd1f9",
+      "baseline": "318bb80ae975f20226d3e031eb9c70804fb717aa",
       "packages": ["carbon-*", "python3", "bsdiff-drake127"]
     }
   ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "git@github.com:carbonengine/vcpkg-registry.git",
-      "baseline": "318bb80ae975f20226d3e031eb9c70804fb717aa",
+      "baseline": "addd8867a1553f4b7866bb7a36deb84bd59bd1f9",
       "packages": ["carbon-*", "python3", "bsdiff-drake127"]
     }
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,12 +5,16 @@
       "version>=": "2.2#0"
     },
     {
-      "name": "curl",
-      "version>=": "8.11.1#1"
+      "name": "bsdiff-drake127",
+      "version>=": "4.3.3"
     },
     {
       "name": "cryptopp",
       "version>=": "8.9.0#1"
+    },
+    {
+      "name": "curl",
+      "version>=": "8.11.1#1"
     },
     {
       "name": "yaml-cpp",
@@ -19,38 +23,34 @@
     {
       "name": "zlib",
       "version>=": "1.3.1"
-    },
-    {
-      "name": "bsdiff-drake127",
-      "version>=": "4.3.3"
     }
   ],
   "default-features": [
     "tests"
   ],
   "features": {
-    "tests": {
-      "description": "Enable tests",
-      "dependencies": [
-        {
-          "name": "gtest",
-          "version>=": "1.15.2",
-          "host": true
-        },
-        {
-          "name": "tiny-process-library",
-          "version>=": "2.0.4#3",
-          "host": true
-        }
-      ]
-    },
     "docs": {
       "description": "Generate documentation",
       "dependencies": [
         {
           "name": "python3",
-          "version>=": "3.12.3",
-          "host": true
+          "host": true,
+          "version>=": "3.12.3"
+        }
+      ]
+    },
+    "tests": {
+      "description": "Enable tests",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "host": true,
+          "version>=": "1.15.2"
+        },
+        {
+          "name": "tiny-process-library",
+          "host": true,
+          "version>=": "2.0.4#3"
         }
       ]
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,11 +2,11 @@
   "dependencies": [
     {
       "name": "argparse",
-      "version>=": "2.2#0"
+      "version>=": "2.2"
     },
     {
       "name": "bsdiff-drake127",
-      "version>=": "4.3.3"
+      "version>=": "4.3.3#1"
     },
     {
       "name": "cryptopp",
@@ -35,7 +35,7 @@
         {
           "name": "python3",
           "host": true,
-          "version>=": "3.12.3"
+          "version>=": "3.12.3#1"
         }
       ]
     },
@@ -58,7 +58,7 @@
   "overrides": [
     {
       "name": "argparse",
-      "version": "2.2#0"
+      "version": "2.2"
     }
   ]
 }


### PR DESCRIPTION
- Update to lastest carbonengine/vcpkg-registry baseline
- Organize vcpkg.json file in alphabetical order
- Make use of port-version = 1 or:
  - python3
  - bsdiff-drake127
