### PR TITLE
Add ability to export resources when creating resource group from dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.30.1)
-project(resources VERSION 3.1.2)
+project(resources VERSION 3.2.0)
 
 include(cmake/CcpGlobalSettings.cmake)
 include(cmake/CcpTargetConfigurations.cmake)

--- a/cli/src/CreateResourceGroupCliOperation.h
+++ b/cli/src/CreateResourceGroupCliOperation.h
@@ -8,6 +8,8 @@
 
 #include "CliOperation.h"
 
+#include <ResourceGroup.h>
+
 class CreateResourceGroupCliOperation : public CliOperation
 {
 public:
@@ -16,8 +18,9 @@ public:
 	virtual bool Execute( std::string& returnErrorMessage ) const final;
 
 private:
-	void PrintStartBanner( const std::filesystem::path& inputDirectory, const std::filesystem::path& resourceGroupOutputDirectory, const std::string& version, const std::string& resourcePrefix, bool skipCompressionCalculation ) const;
-	bool CreateResourceGroup( const std::filesystem::path& inputDirectory, const std::filesystem::path& resourceGroupOutputFile, CarbonResources::Version documentVersion, const std::string& resourcePrefix, bool skipCompressionCalculation ) const;
+	void PrintStartBanner( CarbonResources::CreateResourceGroupFromDirectoryParams& createResourceGroupFromDirectoryParams, CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const;
+
+    bool CreateResourceGroup( CarbonResources::CreateResourceGroupFromDirectoryParams& createResourceGroupFromDirectoryParams, CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const;
 
 private:
 	std::string m_createResourceGroupPathArgumentId;
@@ -28,7 +31,13 @@ private:
 
 	std::string m_createResourceGroupResourcePrefixArgumentId;
 	
-    std::string m_createResourceGroupSkipCompressionCalculation;
+    std::string m_createResourceGroupSkipCompressionCalculationId;
+
+    std::string m_createResourceGroupExportResourcesId;
+
+    std::string m_createResourceGroupExportResourcesDestinationTypeId;
+		
+    std::string m_createResourceGroupExportResourcesDestinationPathId;
 };
 
 #endif // CreateResourceGroupCliOperation_H

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -196,14 +196,20 @@ struct ResourceGroupExportToFileParams
     *  Optional status function callback. Callback is triggered at key status update events.
     *  @var CreateResourceGroupFromDirectoryParams::resourcePrefix
     *  Resource prefix setting, e.g. res.
-    *  @var BundleCreateParams::calculateCompressions
+    *  @var CreateResourceGroupFromDirectoryParams::calculateCompressions
     *  Specifies if compression will be calculated for the generated bundle chunks
+    *  @var CreateResourceGroupFromDirectoryParams::exportResources
+    *  Specifies if resources will be exported
+    *  @see CreateResourceGroupFromDirectoryParams::exportResourcesDestinationSettings
+    *  @var CreateResourceGroupFromDirectoryParams::exportResourcesDestinationSettings
+    *  If export resources is set, specifies where the produced PatchResourceGroup will be saved.
+    *  @see CreateResourceGroupFromDirectoryParams::exportResources
     */
 struct CreateResourceGroupFromDirectoryParams
 {
 	std::filesystem::path directory = "";
 
-	uintmax_t resourceStreamThreshold = 10000000;
+	uintmax_t resourceStreamThreshold = 524288000;
 
 	Version outputDocumentVersion = S_DOCUMENT_VERSION;
 
@@ -212,6 +218,10 @@ struct CreateResourceGroupFromDirectoryParams
 	std::string resourcePrefix = "";
 
     bool calculateCompressions = true;
+
+    bool exportResources = false;
+
+    ResourceDestinationSettings exportResourcesDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "ExportedResources" };
 };
 
 /** @struct ResourceGroupMergeParams

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -155,7 +155,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectory )
 #else
 #error Unsupported platform
 #endif
-	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 }
 
 TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryExportResources )
@@ -196,7 +196,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryExportResources )
 #else
 #error Unsupported platform
 #endif
-	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 
     EXPECT_TRUE( DirectoryIsSubset( exportOutputPath, inputDirectory ) );
 }
@@ -232,7 +232,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryWithSkipCompression )
 #else
 #error Unsupported platform
 #endif
-	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 }
 
 TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
@@ -267,7 +267,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
 #else
 #error Unsupported platform
 #endif
-	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.csv" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 }
 
 TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithPrefix )
@@ -305,7 +305,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithP
 #else
 #error Unsupported platform
 #endif
-	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroupPrefixed.csv" ) );
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 }
 
 TEST_F( ResourcesCliTest, CreateBundle )

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -158,6 +158,83 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectory )
 	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
 }
 
+TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryExportResources )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-group" );
+
+	arguments.push_back( "--verbosity-level" );
+	arguments.push_back( "3" );
+
+    arguments.push_back( "--export-resources" );
+
+    arguments.push_back( "--export-resources-destination-type" );
+	arguments.push_back( "LOCAL_RELATIVE" );
+
+    arguments.push_back( "--export-resources-destination-path" );
+	std::string exportOutputPath = "ExportedResources";
+	arguments.push_back( exportOutputPath );
+
+	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	arguments.push_back( inputDirectory.string() );
+
+	arguments.push_back( "--output-file" );
+	std::filesystem::path outputFile = "GroupOut/ResourceGroup.yaml";
+	arguments.push_back( outputFile.string() );
+
+	int res = RunCli( arguments, output );
+
+	ASSERT_EQ( res, 0 );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
+
+    EXPECT_TRUE( DirectoryIsSubset( exportOutputPath, inputDirectory ) );
+}
+
+TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryWithSkipCompression )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-group" );
+
+	arguments.push_back( "--verbosity-level" );
+	arguments.push_back( "3" );
+
+    arguments.push_back( "--skip-compression" );
+
+	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	arguments.push_back( inputDirectory.string() );
+
+	arguments.push_back( "--output-file" );
+	std::filesystem::path outputFile = "GroupOut/ResourceGroup.yaml";
+	arguments.push_back( outputFile.string() );
+
+	int res = RunCli( arguments, output );
+
+	ASSERT_EQ( res, 0 );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, "GroupOut/ResourceGroup.yaml" ) );
+}
+
 TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
 {
 	std::string output;

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -841,6 +841,38 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
 
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryExportResources )
+{
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
+
+	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+
+    createResourceGroupParams.exportResources = true;
+
+    createResourceGroupParams.exportResourcesDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	EXPECT_EQ( resourceGroup.CreateFromDirectory( createResourceGroupParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
+
+	exportParams.filename = "ResourceGroups/ResourceGroup.yaml";
+
+	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
+
+    EXPECT_TRUE( DirectoryIsSubset( createResourceGroupParams.exportResourcesDestinationSettings.basePath, createResourceGroupParams.directory ) );
+}
+
 TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectorySkipCompression )
 {
 	CarbonResources::ResourceGroup resourceGroup;

--- a/tools/include/CompressedFileDataStreamOut.h
+++ b/tools/include/CompressedFileDataStreamOut.h
@@ -26,7 +26,7 @@ public:
 
 	virtual bool Finish() override;
 
-	bool operator<<( const std::string& data );
+	bool operator<<( const std::string& data ) override;
 
 private:
 	std::string m_compressionBuffer;

--- a/tools/include/FileDataStreamOut.h
+++ b/tools/include/FileDataStreamOut.h
@@ -24,7 +24,7 @@ public:
 
 	virtual bool StartWrite( std::filesystem::path filepath );
 
-	bool operator<<( const std::string& data );
+	virtual bool operator<<( const std::string& data );
 
 	size_t GetFileSize();
 


### PR DESCRIPTION
Allows resources that are to be included in a created resource group to be exported following the destination type rules. 

For example, the files can be outputted in REMOTE_CDN which will create exported resources follow compressed CDN style file structure.

Functionality is exposed through CLI.

Tests covering both lib and CLI included.

Docstrings updated.