### PR TITLE
Combine output static libraries into one for simplified consumption.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,57 @@ source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"
 
 set_target_properties(resources PROPERTIES OUTPUT_NAME "_resources")
 
+
+
+# Combine static libraries to single static for distribution
+# This is useful for consumers taht just want a simple single
+# file to link against
+
+if (WIN32)
+
+    set(RESOURCES_STANDALONE_LIB_NAME _resources_static_standalone.lib)
+
+    #requires lib.exe to be available msvc
+    add_custom_command(TARGET resources POST_BUILD
+        COMMAND lib.exe
+                /OUT:${RESOURCES_STANDALONE_LIB_NAME}
+                $<TARGET_FILE:resources>
+                $<TARGET_FILE:yaml-cpp::yaml-cpp>
+                $<TARGET_FILE:resources-tools-static-standalone>
+                /VERBOSE
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+
+elseif(APPLE)
+
+    set(RESOURCES_STANDALONE_LIB_NAME _resources_static_standalone.a)
+
+    #libtool -static -o new.a old1.a old2.a
+    add_custom_command(TARGET resources POST_BUILD
+        COMMAND libtool -static -o ${RESOURCES_STANDALONE_LIB_NAME}
+                $<TARGET_FILE:resources>
+                $<TARGET_FILE:yaml-cpp::yaml-cpp>
+                $<TARGET_FILE:resources-tools-static-standalone>
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+
+else()
+    message(FATAL_ERROR "Unsupported platform")
+
+endif()
+
+# Add library for static standalone
+# This is then used for CLI as a way for testing the library
+add_library(resources-static-standalone STATIC IMPORTED GLOBAL)
+add_dependencies(resources-static-standalone resources)
+
+set_target_properties(resources-static-standalone
+        PROPERTIES
+        IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCES_STANDALONE_LIB_NAME}
+        INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>;$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+        INTERFACE_COMPILE_DEFINITIONS CARBON_RESOURCES_STATIC
+        )
+
 add_subdirectory(cli)
 
 # Enable testing based on option set (on by default)
@@ -140,6 +191,10 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
                 ARCHIVE DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
                 RUNTIME DESTINATION bin/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
         )
+
+        # Copy the standalone static library
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCES_STANDALONE_LIB_NAME}
+            DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/)
     else ()
         # Install rule to ensure that our runtime and linker files are in the expected, platform-specific folders
         install(
@@ -150,6 +205,11 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
                 ARCHIVE DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
                 RUNTIME DESTINATION bin/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/
         )
+
+        # Copy the standalone static library
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCES_STANDALONE_LIB_NAME}
+            DESTINATION lib/${CCP_PLATFORM}/${CCP_ARCHITECTURE}/${CCP_TOOLSET}/)
+
         # Install rule for available public headers
         install(DIRECTORY include DESTINATION . FILES_MATCHING PATTERN "*.h")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,6 @@ else()
 endif()
 
 # Add library for static standalone
-# This is then used for CLI as a way for testing the library
 add_library(resources-static-standalone STATIC IMPORTED GLOBAL)
 add_dependencies(resources-static-standalone resources)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ if (WIN32)
                 $<TARGET_FILE:resources-tools-static-standalone>
                 /VERBOSE
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            BYPRODUCTS ${RESOURCES_STANDALONE_LIB_NAME}
         )
 
 elseif(APPLE)
@@ -114,6 +115,7 @@ elseif(APPLE)
                 $<TARGET_FILE:yaml-cpp::yaml-cpp>
                 $<TARGET_FILE:resources-tools-static-standalone>
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            BYPRODUCTS ${RESOURCES_STANDALONE_LIB_NAME}
         )
 
 else()

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -30,8 +30,7 @@ set(SRC_FILES
 
 ccp_add_executable(resources-cli ${SRC_FILES})
 
-# Links with resources-static-standalone to ensure that the combine lib is functional
-target_link_libraries(resources-cli PRIVATE resources-static-standalone argparse::argparse)
+target_link_libraries(resources-cli PRIVATE resources argparse::argparse)
 
 get_target_property(_SOURCES resources-cli SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -30,7 +30,8 @@ set(SRC_FILES
 
 ccp_add_executable(resources-cli ${SRC_FILES})
 
-target_link_libraries(resources-cli PRIVATE resources argparse::argparse yaml-cpp::yaml-cpp)
+# Links with resources-static-standalone to ensure that the combine lib is functional
+target_link_libraries(resources-cli PRIVATE resources-static-standalone argparse::argparse)
 
 get_target_property(_SOURCES resources-cli SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -30,7 +30,8 @@ set(SRC_FILES
 
 ccp_add_executable(resources-cli ${SRC_FILES})
 
-target_link_libraries(resources-cli PRIVATE resources argparse::argparse)
+# Links with resources-static-standalone to ensure that the combine lib is functional
+target_link_libraries(resources-cli PRIVATE resources-static-standalone argparse::argparse)
 
 get_target_property(_SOURCES resources-cli SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -54,3 +54,52 @@ endif ()
 target_link_libraries(resources-tools PRIVATE cryptopp::cryptopp CURL::libcurl ZLIB::ZLIB static_bsdiff)
 
 target_include_directories(resources-tools PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+
+
+# Combine resource tools into single library
+if (WIN32)
+
+        set(RESOURCES_TOOLS_STANDALONE_LIB_NAME _resources_tools_static_standalone.lib)
+
+        add_custom_command(TARGET resources-tools POST_BUILD
+        COMMAND lib.exe 
+                /OUT:${RESOURCES_TOOLS_STANDALONE_LIB_NAME}
+                $<TARGET_FILE:resources-tools>
+                $<TARGET_FILE:cryptopp::cryptopp>
+                $<TARGET_FILE:ZLIB::ZLIB>
+                $<TARGET_FILE:static_bsdiff>
+                $<TARGET_FILE:CURL::libcurl_static>
+                ws2_32.lib
+                crypt32.lib
+                /VERBOSE
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+
+elseif(APPLE)
+
+        set(RESOURCES_TOOLS_STANDALONE_LIB_NAME _resources_tools_static_standalone.a)
+
+        #libtool -static -o new.a old1.a old2.a
+        add_custom_command(TARGET resources-tools POST_BUILD
+                COMMAND libtool -static -o ${RESOURCES_TOOLS_STANDALONE_LIB_NAME}
+                        $<TARGET_FILE:resources-tools>
+                        $<TARGET_FILE:cryptopp::cryptopp>
+                        $<TARGET_FILE:CURL::libcurl_static>
+                        $<TARGET_FILE:ZLIB::ZLIB>
+                        $<TARGET_FILE:static_bsdiff>
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                )
+
+else()
+    message(FATAL_ERROR "Unsupported platform")
+
+endif()
+
+add_library(resources-tools-static-standalone STATIC IMPORTED GLOBAL)
+add_dependencies(resources-tools-static-standalone resources-tools)
+
+set_target_properties(resources-tools-static-standalone
+        PROPERTIES
+        IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${RESOURCES_TOOLS_STANDALONE_LIB_NAME}
+        INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_LIST_DIR}/include"
+        )


### PR DESCRIPTION
Produces a simplified artifact that can be easily linked to external projects. Change made in response to requirement of customer that ingests this library.