### PR TITLE
Add filter file support when creating Resource Groups.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.31.0)
-project(resources VERSION 4.0.0)
+project(resources VERSION 4.1.0)
 
 include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -16,6 +16,8 @@ set(SRC_FILES
         src/CreatePatchCliOperation.h
         src/CreateResourceGroupCliOperation.cpp
         src/CreateResourceGroupCliOperation.h
+        src/CreateResourceGroupFromFilterCliOperation.cpp
+        src/CreateResourceGroupFromFilterCliOperation.h
         src/Defines.h
         src/DiffResourceGroupCliOperation.cpp
         src/DiffResourceGroupCliOperation.h

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -32,7 +32,7 @@ set(SRC_FILES
 
 ccp_add_executable(resources-cli ${SRC_FILES})
 
-target_link_libraries(resources-cli PRIVATE resources argparse::argparse yaml-cpp::yaml-cpp)
+target_link_libraries(resources-cli PRIVATE resources resources-tools argparse::argparse yaml-cpp::yaml-cpp)
 
 get_target_property(_SOURCES resources-cli SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/cli/src/CliOperation.cpp
+++ b/cli/src/CliOperation.cpp
@@ -324,7 +324,7 @@ std::string CliOperation::SecondsToString( std::chrono::seconds seconds ) const
 	return ss.str();
 }
 
-std::string CliOperation::VersionToString( CarbonResources::Version& version ) const
+std::string CliOperation::VersionToString( const CarbonResources::Version& version ) const
 {
 	std::stringstream ss;
 

--- a/cli/src/CliOperation.h
+++ b/cli/src/CliOperation.h
@@ -70,7 +70,7 @@ protected:
 
 	std::string SecondsToString( std::chrono::seconds seconds ) const;
 
-	std::string VersionToString( CarbonResources::Version& version ) const;
+	std::string VersionToString( const CarbonResources::Version& version ) const;
 
 	std::string ResourceSourceTypeChoicesAsString() const;
 

--- a/cli/src/CreateResourceGroupFromFilterCliOperation.cpp
+++ b/cli/src/CreateResourceGroupFromFilterCliOperation.cpp
@@ -6,18 +6,20 @@
 #include <argparse/argparse.hpp>
 #include <ResourceGroup.h>
 #include <unordered_set>
+#include <FilterIndexMappingFile.h>
 
 CreateResourceGroupFromFilterCliOperation::CreateResourceGroupFromFilterCliOperation() :
-	CliOperation( "create-group-from-filter", "Create a Resource Group from a filter files." ),
-	m_outputFileArgumentId( "--output-file" ),
-	m_documentVersionArgumentId( "--document-version" ),
-	m_resourcePrefixArgumentId( "--resource-prefix" ),
+	CliOperation( "create-group-from-filter", "Create filtered Resource Group(s)." ),
+	m_filterIndexMappingFileId( "--filter-index-mapping-file" ),
+	m_filterFileBasePathId( "--filter-file-basepath" ),
+	m_resourceFileBasePathId( "--output-resource-file-basepath" ),
+	m_documentVersionId( "--document-version" ),
+	m_resourcePrefixId( "--resource-prefix" ),
 	m_skipCompressionId( "--skip-compression" ),
 	m_exportResourcesId( "--export-resources" ),
 	m_exportResourcesDestinationTypeId( "--export-resources-destination-type" ),
 	m_exportResourcesDestinationPathId( "--export-resources-destination-path" ),
-	m_filterFilesArgumentId( "--filter-file" ),
-	m_filterFilesBasePathArgumentId( "--filter-file-basepath" ),
+	m_prefixMapBasepathId( "--prefix-map-basepath" ),
 	m_skipNonExistentInputDirectoriesId( "--skip-non-existent-input-directories" ),
 	m_streamChunkSizeId( "--stream-chunk-size" ),
 	m_remoteUrlToGetCompressionId( "--remote-url-to-attempt-to-get-compression-info" ),
@@ -31,11 +33,15 @@ CreateResourceGroupFromFilterCliOperation::CreateResourceGroupFromFilterCliOpera
 
 	CarbonResources::ResourceGroupExportToFileParams defaultExportParams;
 
-	AddArgument( m_outputFileArgumentId, "Filename for created resource group.", false, false, defaultExportParams.filename.string() );
+	AddArgument( m_filterIndexMappingFileId, "Path to filter index mapping file for resource filtering. See carbon-resources documentation for file specification.", true, true, "" );
 
-	AddArgument( m_documentVersionArgumentId, "Document version for created resource group.", false, false, VersionToString( defaultImportParams.outputDocumentVersion ) );
+    AddArgument( m_filterFileBasePathId, "Base path to filter files.", true, true, "" );
 
-	AddArgument( m_resourcePrefixArgumentId, R"(Optional resource path prefix, such as "res" or "app")", false, false, "" );
+    AddArgument( m_resourceFileBasePathId, "Base path for output resource files.", false, true, "" );
+
+	AddArgument( m_documentVersionId, "Document version for created resource group.", false, false, VersionToString( defaultImportParams.outputDocumentVersion ) );
+
+	AddArgument( m_resourcePrefixId, R"(Optional resource path prefix, such as "res" or "app")", false, false, "" );
 
 	AddArgumentFlag( m_skipCompressionId, "Set skip compression calculations on resources." );
 
@@ -45,9 +51,7 @@ CreateResourceGroupFromFilterCliOperation::CreateResourceGroupFromFilterCliOpera
 
 	AddArgument( m_exportResourcesDestinationPathId, "Represents the base path where the exported resources will be saved. Requires --export-resources", false, false, defaultImportParams.exportSettings.destinationSettings.basePath.string() );
 
-	AddArgument( m_filterFilesArgumentId, "Path to filter file for resource filtering.", true, true, "" );
-
-	AddArgument( m_filterFilesBasePathArgumentId, "Base directory for prefix mappings defined in filter files.", false, false, "" );
+	AddArgument( m_prefixMapBasepathId, "Base directory for prefix mappings defined in filter files.", false, false, "" );
 
 	AddArgumentFlag( m_skipNonExistentInputDirectoriesId, "Skips input directories specified that don't exist rather than error." );
 
@@ -62,8 +66,6 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 {
 	CarbonResources::CreateResourceGroupFromFilterParams createResourceGroupParams;
 
-	CarbonResources::ResourceGroupExportToFileParams exportParams;
-
 	try
 	{
 		createResourceGroupParams.fileStreamChunkSize = std::stoull( m_argumentParser->get( m_streamChunkSizeId ) );
@@ -77,7 +79,7 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 		return false;
 	}
 
-	bool versionIsValid = ParseDocumentVersion( m_argumentParser->get( m_documentVersionArgumentId ), createResourceGroupParams.outputDocumentVersion );
+	bool versionIsValid = ParseDocumentVersion( m_argumentParser->get( m_documentVersionId ), createResourceGroupParams.outputDocumentVersion );
 
 	if( !versionIsValid )
 	{
@@ -86,7 +88,7 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 		return false;
 	}
 
-	createResourceGroupParams.resourcePrefix = m_argumentParser->get( m_resourcePrefixArgumentId );
+	createResourceGroupParams.resourcePrefix = m_argumentParser->get( m_resourcePrefixId );
 
 	createResourceGroupParams.compressionCalculationSettings.calculateCompressions = !m_argumentParser->get<bool>( m_skipCompressionId );
 
@@ -110,25 +112,49 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 		createResourceGroupParams.exportSettings.destinationSettings.basePath = m_argumentParser->get<std::string>( m_exportResourcesDestinationPathId );
 	}
 
-	exportParams.filename = m_argumentParser->get<std::string>( m_outputFileArgumentId );
+    // Load filter settings from file
+	std::filesystem::path basePathToFilterFiles = m_argumentParser->get<std::string>( m_filterFileBasePathId );
 
-	exportParams.outputDocumentVersion = createResourceGroupParams.outputDocumentVersion;
+    std::filesystem::path basePathRespourceFiles = m_argumentParser->get<std::string>( m_resourceFileBasePathId );
 
-	if( m_argumentParser->is_used( m_filterFilesArgumentId ) )
-	{
-		std::vector<std::filesystem::path> filterIniFilePaths;
-		auto iniFileStringVector = m_argumentParser->get<std::vector<std::string>>( m_filterFilesArgumentId );
+	std::filesystem::path filterIndexMappingPath = m_argumentParser->get<std::string>( m_filterIndexMappingFileId );
 
-		for( const auto& iniPathStr : iniFileStringVector )
-		{
-			if( !iniPathStr.empty() )
-			{
-				createResourceGroupParams.filterSettings.filterFilePaths.emplace_back( iniPathStr );
-			}
-		}
+    FilterIndexMappingFile filterIndexMappingFile;
 
-		createResourceGroupParams.filterSettings.prefixMapBasePath = m_argumentParser->get<std::string>( m_filterFilesBasePathArgumentId );
-	}
+    if (!filterIndexMappingFile.LoadFromFile(filterIndexMappingPath))
+    {
+		returnErrorMessage = "Failed to load filter index mappings from file provided: " + filterIndexMappingPath.string();
+
+		return false;
+    }
+
+    // Set the filters from file data
+	createResourceGroupParams.filterSettings.prefixMapBasePath = m_argumentParser->get<std::string>( m_prefixMapBasepathId );
+
+    const std::vector<std::unique_ptr<FilterMapping>>& mappings = filterIndexMappingFile.GetFilterMappings();
+
+    std::vector<std::unique_ptr<CarbonResources::ResourceGroupExportToFileParams>> exportParameters;
+
+    for (auto& mapping : mappings)
+    {
+		std::unique_ptr<CarbonResources::Filter> filter = std::make_unique<CarbonResources::Filter>();
+
+        for( auto filterPath : mapping->filterFilePaths )
+        {
+			filter->filterFilePaths.push_back( basePathToFilterFiles / filterPath );
+        }
+
+        createResourceGroupParams.filterSettings.filters.push_back( std::move( filter ) );
+
+        std::unique_ptr<CarbonResources::ResourceGroupExportToFileParams> exportParamter = std::make_unique<CarbonResources::ResourceGroupExportToFileParams>();
+
+        exportParamter->outputDocumentVersion = createResourceGroupParams.outputDocumentVersion;
+
+        exportParamter->filename = basePathRespourceFiles / mapping->outputPath;
+
+        exportParameters.push_back( std::move( exportParamter ) );
+
+    }
 
 	if( m_argumentParser->is_used( m_remoteUrlToGetCompressionId ) )
 	{
@@ -137,23 +163,24 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 
 	if( ShowCliStatusUpdates() )
 	{
-		PrintStartBanner( createResourceGroupParams, exportParams );
+		PrintStartBanner( createResourceGroupParams, createResourceGroupParams.outputDocumentVersion, filterIndexMappingPath, basePathToFilterFiles, basePathRespourceFiles );
 	}
 
-	return CreateResourceGroup( createResourceGroupParams, exportParams );
+	return CreateResourceGroups( createResourceGroupParams, exportParameters );
 }
 
 void CreateResourceGroupFromFilterCliOperation::PrintStartBanner(
-	CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
-	CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const
+	const CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
+	const CarbonResources::Version& outputVersion,
+	const std::filesystem::path& filterIndexMappingFilePath,
+    const std::filesystem::path& basePathToFilterFiles,
+	const std::filesystem::path& basePathRespourceFiles ) const
 {
 	std::cout << "---Creating Resource Group---" << std::endl;
 
 	PrintCommonOperationHeaderInformation();
 
-	std::cout << "Output File: " << ResourceGroupExportToFileParams.filename << std::endl;
-
-	std::cout << "Output Document Version: " << VersionToString( ResourceGroupExportToFileParams.outputDocumentVersion ) << std::endl;
+	std::cout << "Output Document Version: " << VersionToString( outputVersion ) << std::endl;
 
 	std::cout << "Resource Prefix: " << createResourceGroupFromFilterParams.resourcePrefix << std::endl;
 
@@ -179,21 +206,13 @@ void CreateResourceGroupFromFilterCliOperation::PrintStartBanner(
 		std::cout << "Export Resources: Off" << std::endl;
 	}
 
-	if( !createResourceGroupFromFilterParams.filterSettings.filterFilePaths.empty() )
-	{
-		std::cout << "Resource Filter INI File(s): " << std::endl;
+	std::cout << "Resource filter index mapping file: " << filterIndexMappingFilePath << std::endl;
 
-		for( const auto& iniPath : createResourceGroupFromFilterParams.filterSettings.filterFilePaths )
-		{
-			std::cout << " - " << iniPath.generic_string() << std::endl;
-		}
+    std::cout << "Basepath to filter files: " << basePathToFilterFiles << std::endl;
 
-		std::cout << "Filter prefix base path: " << createResourceGroupFromFilterParams.filterSettings.prefixMapBasePath << std::endl;
-	}
-	else
-	{
-		std::cout << "Resource Filter INI File(s): None" << std::endl;
-	}
+    std::cout << "Basepath to resource files: " << basePathRespourceFiles << std::endl;
+
+    std::cout << "Prefix basepath: " << createResourceGroupFromFilterParams.filterSettings.prefixMapBasePath << std::endl;
 
 	if( createResourceGroupFromFilterParams.skipNonExistentInputDirectories )
 	{
@@ -224,21 +243,30 @@ void CreateResourceGroupFromFilterCliOperation::PrintStartBanner(
 			  << std::endl;
 }
 
-bool CreateResourceGroupFromFilterCliOperation::CreateResourceGroup(
+bool CreateResourceGroupFromFilterCliOperation::CreateResourceGroups(
 	CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
-	CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const
+	std::vector<std::unique_ptr<CarbonResources::ResourceGroupExportToFileParams>>& exportParams ) const
 {
-	CarbonResources::ResourceGroup resourceGroup;
-
 	createResourceGroupFromFilterParams.callbackSettings.statusCallback = GetStatusCallback();
 	createResourceGroupFromFilterParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
 
-	if( ShowCliStatusUpdates() )
+    if( ShowCliStatusUpdates() )
 	{
-		CliStatusUpdate( "Creating resource group from directory." );
+		CliStatusUpdate( "Creating resource group(s) from filter mappings." );
 	}
 
-	CarbonResources::Result createFromDirectoryResult = resourceGroup.CreateFromFilter( createResourceGroupFromFilterParams );
+    std::vector < std::unique_ptr<CarbonResources::ResourceGroup>> resourceGroups;
+
+    for (auto& filter : createResourceGroupFromFilterParams.filterSettings.filters)
+    {
+		std::unique_ptr<CarbonResources::ResourceGroup> resourceGroup = std::make_unique<CarbonResources::ResourceGroup>();
+
+		filter->outputResourceGroup = resourceGroup.get();
+
+        resourceGroups.push_back( std::move( resourceGroup ) );
+    }
+
+	CarbonResources::Result createFromDirectoryResult = CarbonResources::ResourceGroup::CreateFromFilter( createResourceGroupFromFilterParams );
 
 	if( createFromDirectoryResult.type != CarbonResources::ResultType::SUCCESS )
 	{
@@ -247,22 +275,30 @@ bool CreateResourceGroupFromFilterCliOperation::CreateResourceGroup(
 		return false;
 	}
 
-	ResourceGroupExportToFileParams.callbackSettings.statusCallback = GetStatusCallback();
-	ResourceGroupExportToFileParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
 
+    // Export lists
 	if( ShowCliStatusUpdates() )
 	{
 		CliStatusUpdate( "Exporting resource group to file." );
 	}
 
-	CarbonResources::Result exportToFileResult = resourceGroup.ExportToFile( ResourceGroupExportToFileParams );
+	auto resourceIter = resourceGroups.begin();
+	for( auto exportIter = exportParams.begin(); exportIter != exportParams.end(); exportIter++, resourceIter++ )
+    {
+		CarbonResources::ResourceGroupExportToFileParams& exportParams = **exportIter;
 
-	if( exportToFileResult.type != CarbonResources::ResultType::SUCCESS )
-	{
-		PrintCarbonResourcesError( exportToFileResult );
+        exportParams.callbackSettings.statusCallback = GetStatusCallback();
+		exportParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
 
-		return false;
-	}
+		CarbonResources::Result exportToFileResult = ( *resourceIter )->ExportToFile( exportParams );
+
+        if( exportToFileResult.type != CarbonResources::ResultType::SUCCESS )
+		{
+			PrintCarbonResourcesError( exportToFileResult );
+
+			return false;
+		}
+    }
 
 	if( ShowCliStatusUpdates() )
 	{

--- a/cli/src/CreateResourceGroupFromFilterCliOperation.cpp
+++ b/cli/src/CreateResourceGroupFromFilterCliOperation.cpp
@@ -1,0 +1,273 @@
+// Copyright © 2025 CCP ehf.
+
+#include "CreateResourceGroupFromFilterCliOperation.h"
+
+#include <string>
+#include <argparse/argparse.hpp>
+#include <ResourceGroup.h>
+#include <unordered_set>
+
+CreateResourceGroupFromFilterCliOperation::CreateResourceGroupFromFilterCliOperation() :
+	CliOperation( "create-group-from-filter", "Create a Resource Group from a filter files." ),
+	m_outputFileArgumentId( "--output-file" ),
+	m_documentVersionArgumentId( "--document-version" ),
+	m_resourcePrefixArgumentId( "--resource-prefix" ),
+	m_skipCompressionId( "--skip-compression" ),
+	m_exportResourcesId( "--export-resources" ),
+	m_exportResourcesDestinationTypeId( "--export-resources-destination-type" ),
+	m_exportResourcesDestinationPathId( "--export-resources-destination-path" ),
+	m_filterFilesArgumentId( "--filter-file" ),
+	m_filterFilesBasePathArgumentId( "--filter-file-basepath" ),
+	m_skipNonExistentInputDirectoriesId( "--skip-non-existent-input-directories" ),
+	m_streamChunkSizeId( "--stream-chunk-size" ),
+	m_remoteUrlToGetCompressionId( "--remote-url-to-attempt-to-get-compression-info" ),
+	m_skipBinaryOperationCalculationId( "--skip-binary-operation-calculation" )
+{
+
+	// Struct is inspected to ascertain default values
+	// This keeps default value settings in one place
+	// Lib defaults matches CLI
+	CarbonResources::CreateResourceGroupFromFilterParams defaultImportParams;
+
+	CarbonResources::ResourceGroupExportToFileParams defaultExportParams;
+
+	AddArgument( m_outputFileArgumentId, "Filename for created resource group.", false, false, defaultExportParams.filename.string() );
+
+	AddArgument( m_documentVersionArgumentId, "Document version for created resource group.", false, false, VersionToString( defaultImportParams.outputDocumentVersion ) );
+
+	AddArgument( m_resourcePrefixArgumentId, R"(Optional resource path prefix, such as "res" or "app")", false, false, "" );
+
+	AddArgumentFlag( m_skipCompressionId, "Set skip compression calculations on resources." );
+
+	AddArgumentFlag( m_exportResourcesId, "Export resources after processing. see --export-resources-destination-type and --export-resources-destination-path" );
+
+	AddArgument( m_exportResourcesDestinationTypeId, "Represents the type of repository where exported resources will be saved. Requires --export-resources", false, false, DestinationTypeToString( defaultImportParams.exportSettings.destinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+
+	AddArgument( m_exportResourcesDestinationPathId, "Represents the base path where the exported resources will be saved. Requires --export-resources", false, false, defaultImportParams.exportSettings.destinationSettings.basePath.string() );
+
+	AddArgument( m_filterFilesArgumentId, "Path to filter file for resource filtering.", true, true, "" );
+
+	AddArgument( m_filterFilesBasePathArgumentId, "Base directory for prefix mappings defined in filter files.", false, false, "" );
+
+	AddArgumentFlag( m_skipNonExistentInputDirectoriesId, "Skips input directories specified that don't exist rather than error." );
+
+	AddArgument( m_streamChunkSizeId, "Represents the chunks streamed in bytes when streaming data.", false, false, SizeToString( defaultImportParams.fileStreamChunkSize ) );
+
+	AddArgument( m_remoteUrlToGetCompressionId, "If supplied, url is checked to get compression information.", false, false, defaultImportParams.compressionCalculationSettings.remoteUrlToAttemptToGetCompression.string() );
+
+	AddArgumentFlag( m_skipBinaryOperationCalculationId, "Set skip to skip binary operation for resources" );
+}
+
+bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErrorMessage ) const
+{
+	CarbonResources::CreateResourceGroupFromFilterParams createResourceGroupParams;
+
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
+
+	try
+	{
+		createResourceGroupParams.fileStreamChunkSize = std::stoull( m_argumentParser->get( m_streamChunkSizeId ) );
+	}
+	catch( std::invalid_argument& )
+	{
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		return false;
+	}
+
+	bool versionIsValid = ParseDocumentVersion( m_argumentParser->get( m_documentVersionArgumentId ), createResourceGroupParams.outputDocumentVersion );
+
+	if( !versionIsValid )
+	{
+		returnErrorMessage = "Invalid document version";
+
+		return false;
+	}
+
+	createResourceGroupParams.resourcePrefix = m_argumentParser->get( m_resourcePrefixArgumentId );
+
+	createResourceGroupParams.compressionCalculationSettings.calculateCompressions = !m_argumentParser->get<bool>( m_skipCompressionId );
+
+	createResourceGroupParams.skipNonExistentInputDirectories = m_argumentParser->get<bool>( m_skipNonExistentInputDirectoriesId );
+
+	createResourceGroupParams.calculateBinaryOperation = !m_argumentParser->get<bool>( m_skipBinaryOperationCalculationId );
+
+	createResourceGroupParams.exportSettings.enabled = m_argumentParser->get<bool>( m_exportResourcesId );
+
+	if( createResourceGroupParams.exportSettings.enabled )
+	{
+		std::string exportResourcesDesinationType = m_argumentParser->get<std::string>( m_exportResourcesDestinationTypeId );
+
+		if( !StringToResourceDestinationType( exportResourcesDesinationType, createResourceGroupParams.exportSettings.destinationSettings.destinationType ) )
+		{
+			returnErrorMessage = "Invalid chunk destination type";
+
+			return false;
+		}
+
+		createResourceGroupParams.exportSettings.destinationSettings.basePath = m_argumentParser->get<std::string>( m_exportResourcesDestinationPathId );
+	}
+
+	exportParams.filename = m_argumentParser->get<std::string>( m_outputFileArgumentId );
+
+	exportParams.outputDocumentVersion = createResourceGroupParams.outputDocumentVersion;
+
+	if( m_argumentParser->is_used( m_filterFilesArgumentId ) )
+	{
+		std::vector<std::filesystem::path> filterIniFilePaths;
+		auto iniFileStringVector = m_argumentParser->get<std::vector<std::string>>( m_filterFilesArgumentId );
+
+		for( const auto& iniPathStr : iniFileStringVector )
+		{
+			if( !iniPathStr.empty() )
+			{
+				createResourceGroupParams.filterSettings.filterFilePaths.emplace_back( iniPathStr );
+			}
+		}
+
+		createResourceGroupParams.filterSettings.prefixMapBasePath = m_argumentParser->get<std::string>( m_filterFilesBasePathArgumentId );
+	}
+
+	if( m_argumentParser->is_used( m_remoteUrlToGetCompressionId ) )
+	{
+		createResourceGroupParams.compressionCalculationSettings.remoteUrlToAttemptToGetCompression = m_argumentParser->get<std::string>( m_remoteUrlToGetCompressionId );
+	}
+
+	if( ShowCliStatusUpdates() )
+	{
+		PrintStartBanner( createResourceGroupParams, exportParams );
+	}
+
+	return CreateResourceGroup( createResourceGroupParams, exportParams );
+}
+
+void CreateResourceGroupFromFilterCliOperation::PrintStartBanner(
+	CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
+	CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const
+{
+	std::cout << "---Creating Resource Group---" << std::endl;
+
+	PrintCommonOperationHeaderInformation();
+
+	std::cout << "Output File: " << ResourceGroupExportToFileParams.filename << std::endl;
+
+	std::cout << "Output Document Version: " << VersionToString( ResourceGroupExportToFileParams.outputDocumentVersion ) << std::endl;
+
+	std::cout << "Resource Prefix: " << createResourceGroupFromFilterParams.resourcePrefix << std::endl;
+
+	if( createResourceGroupFromFilterParams.compressionCalculationSettings.calculateCompressions )
+	{
+		std::cout << "Calculate Compression: On" << std::endl;
+	}
+	else
+	{
+		std::cout << "Calculate Compression: Off" << std::endl;
+	}
+
+	if( createResourceGroupFromFilterParams.exportSettings.enabled )
+	{
+		std::cout << "Export Resources: On" << std::endl;
+
+		std::cout << "Export Resources Type: " << DestinationTypeToString( createResourceGroupFromFilterParams.exportSettings.destinationSettings.destinationType ) << std::endl;
+
+		std::cout << "Export Resources Base Path: " << createResourceGroupFromFilterParams.exportSettings.destinationSettings.basePath << std::endl;
+	}
+	else
+	{
+		std::cout << "Export Resources: Off" << std::endl;
+	}
+
+	if( !createResourceGroupFromFilterParams.filterSettings.filterFilePaths.empty() )
+	{
+		std::cout << "Resource Filter INI File(s): " << std::endl;
+
+		for( const auto& iniPath : createResourceGroupFromFilterParams.filterSettings.filterFilePaths )
+		{
+			std::cout << " - " << iniPath.generic_string() << std::endl;
+		}
+
+		std::cout << "Filter prefix base path: " << createResourceGroupFromFilterParams.filterSettings.prefixMapBasePath << std::endl;
+	}
+	else
+	{
+		std::cout << "Resource Filter INI File(s): None" << std::endl;
+	}
+
+	if( createResourceGroupFromFilterParams.skipNonExistentInputDirectories )
+	{
+		std::cout << "Skip non existant input directories: On" << std::endl;
+	}
+	else
+	{
+		std::cout << "Skip non existant input directories: Off" << std::endl;
+	}
+
+	if( createResourceGroupFromFilterParams.calculateBinaryOperation )
+	{
+		std::cout << "Binary operation calculation: On" << std::endl;
+	}
+	else
+	{
+		std::cout << "Binary operation calculation: Off" << std::endl;
+	}
+
+	if( createResourceGroupFromFilterParams.compressionCalculationSettings.remoteUrlToAttemptToGetCompression != "" )
+	{
+		std::cout << "Compression info check url: " << createResourceGroupFromFilterParams.compressionCalculationSettings.remoteUrlToAttemptToGetCompression << std::endl;
+	}
+
+	std::cout << "File stream chunk Size: " << createResourceGroupFromFilterParams.fileStreamChunkSize << " Bytes" << std::endl;
+
+	std::cout << "----------------------------\n"
+			  << std::endl;
+}
+
+bool CreateResourceGroupFromFilterCliOperation::CreateResourceGroup(
+	CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
+	CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const
+{
+	CarbonResources::ResourceGroup resourceGroup;
+
+	createResourceGroupFromFilterParams.callbackSettings.statusCallback = GetStatusCallback();
+	createResourceGroupFromFilterParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
+
+	if( ShowCliStatusUpdates() )
+	{
+		CliStatusUpdate( "Creating resource group from directory." );
+	}
+
+	CarbonResources::Result createFromDirectoryResult = resourceGroup.CreateFromFilter( createResourceGroupFromFilterParams );
+
+	if( createFromDirectoryResult.type != CarbonResources::ResultType::SUCCESS )
+	{
+		PrintCarbonResourcesError( createFromDirectoryResult );
+
+		return false;
+	}
+
+	ResourceGroupExportToFileParams.callbackSettings.statusCallback = GetStatusCallback();
+	ResourceGroupExportToFileParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
+
+	if( ShowCliStatusUpdates() )
+	{
+		CliStatusUpdate( "Exporting resource group to file." );
+	}
+
+	CarbonResources::Result exportToFileResult = resourceGroup.ExportToFile( ResourceGroupExportToFileParams );
+
+	if( exportToFileResult.type != CarbonResources::ResultType::SUCCESS )
+	{
+		PrintCarbonResourcesError( exportToFileResult );
+
+		return false;
+	}
+
+	if( ShowCliStatusUpdates() )
+	{
+		CliStatusUpdate( "Operation complete." );
+	}
+
+	return true;
+}

--- a/cli/src/CreateResourceGroupFromFilterCliOperation.cpp
+++ b/cli/src/CreateResourceGroupFromFilterCliOperation.cpp
@@ -12,7 +12,7 @@ CreateResourceGroupFromFilterCliOperation::CreateResourceGroupFromFilterCliOpera
 	CliOperation( "create-group-from-filter", "Create filtered Resource Group(s)." ),
 	m_filterIndexMappingFileId( "--filter-index-mapping-file" ),
 	m_filterFileBasePathId( "--filter-file-basepath" ),
-	m_resourceFileBasePathId( "--output-resource-file-basepath" ),
+	m_outputResourceFileBasePathId( "--output-resource-file-basepath" ),
 	m_documentVersionId( "--document-version" ),
 	m_resourcePrefixId( "--resource-prefix" ),
 	m_skipCompressionId( "--skip-compression" ),
@@ -37,7 +37,7 @@ CreateResourceGroupFromFilterCliOperation::CreateResourceGroupFromFilterCliOpera
 
     AddArgument( m_filterFileBasePathId, "Base path to filter files.", true, true, "" );
 
-    AddArgument( m_resourceFileBasePathId, "Base path for output resource files.", false, true, "" );
+    AddArgument( m_outputResourceFileBasePathId, "Base path for output resource files.", false, true, "" );
 
 	AddArgument( m_documentVersionId, "Document version for created resource group.", false, false, VersionToString( defaultImportParams.outputDocumentVersion ) );
 
@@ -115,7 +115,7 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
     // Load filter settings from file
 	std::filesystem::path basePathToFilterFiles = m_argumentParser->get<std::string>( m_filterFileBasePathId );
 
-    std::filesystem::path basePathRespourceFiles = m_argumentParser->get<std::string>( m_resourceFileBasePathId );
+    std::filesystem::path basePathResourceFiles = m_argumentParser->get<std::string>( m_outputResourceFileBasePathId );
 
 	std::filesystem::path filterIndexMappingPath = m_argumentParser->get<std::string>( m_filterIndexMappingFileId );
 
@@ -150,7 +150,7 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 
         exportParamter->outputDocumentVersion = createResourceGroupParams.outputDocumentVersion;
 
-        exportParamter->filename = basePathRespourceFiles / mapping->outputPath;
+        exportParamter->filename = basePathResourceFiles / mapping->outputPath;
 
         exportParameters.push_back( std::move( exportParamter ) );
 
@@ -163,7 +163,7 @@ bool CreateResourceGroupFromFilterCliOperation::Execute( std::string& returnErro
 
 	if( ShowCliStatusUpdates() )
 	{
-		PrintStartBanner( createResourceGroupParams, createResourceGroupParams.outputDocumentVersion, filterIndexMappingPath, basePathToFilterFiles, basePathRespourceFiles );
+		PrintStartBanner( createResourceGroupParams, createResourceGroupParams.outputDocumentVersion, filterIndexMappingPath, basePathToFilterFiles, basePathResourceFiles );
 	}
 
 	return CreateResourceGroups( createResourceGroupParams, exportParameters );
@@ -276,7 +276,7 @@ bool CreateResourceGroupFromFilterCliOperation::CreateResourceGroups(
 	}
 
 
-    // Export lists
+    // Export Resource Groups
 	if( ShowCliStatusUpdates() )
 	{
 		CliStatusUpdate( "Exporting resource group to file." );

--- a/cli/src/CreateResourceGroupFromFilterCliOperation.h
+++ b/cli/src/CreateResourceGroupFromFilterCliOperation.h
@@ -19,19 +19,27 @@ public:
 
 private:
 	void PrintStartBanner(
-		CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
-		CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const;
+		const CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
+		const CarbonResources::Version& outputVersion,
+		const std::filesystem::path& filterIndexMappingFilePath,
+		const std::filesystem::path& basePathToFilterFiles,
+		const std::filesystem::path& basePathRespourceFiles ) const;
 
-	bool CreateResourceGroup(
+	bool CreateResourceGroups(
 		CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
-		CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const;
+		std::vector<std::unique_ptr<CarbonResources::ResourceGroupExportToFileParams>>& exportParams ) const;
 
 private:
-	std::string m_outputFileArgumentId;
 
-	std::string m_documentVersionArgumentId;
+    std::string m_filterIndexMappingFileId;
 
-	std::string m_resourcePrefixArgumentId;
+    std::string m_filterFileBasePathId;
+
+    std::string m_resourceFileBasePathId;
+
+	std::string m_documentVersionId;
+
+	std::string m_resourcePrefixId;
 
 	std::string m_skipCompressionId;
 
@@ -41,9 +49,7 @@ private:
 
 	std::string m_exportResourcesDestinationPathId;
 
-	std::string m_filterFilesArgumentId;
-
-	std::string m_filterFilesBasePathArgumentId;
+	std::string m_prefixMapBasepathId;
 
 	std::string m_skipNonExistentInputDirectoriesId;
 

--- a/cli/src/CreateResourceGroupFromFilterCliOperation.h
+++ b/cli/src/CreateResourceGroupFromFilterCliOperation.h
@@ -1,0 +1,57 @@
+// Copyright © 2025 CCP ehf.
+
+#pragma once
+#ifndef CreateResourceGroupFromFilterCliOperation_H
+#define CreateResourceGroupFromFilterCliOperation_H
+
+#include <filesystem>
+
+#include "CliOperation.h"
+
+#include <ResourceGroup.h>
+
+class CreateResourceGroupFromFilterCliOperation : public CliOperation
+{
+public:
+	CreateResourceGroupFromFilterCliOperation();
+
+	virtual bool Execute( std::string& returnErrorMessage ) const final;
+
+private:
+	void PrintStartBanner(
+		CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
+		CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const;
+
+	bool CreateResourceGroup(
+		CarbonResources::CreateResourceGroupFromFilterParams& createResourceGroupFromFilterParams,
+		CarbonResources::ResourceGroupExportToFileParams& ResourceGroupExportToFileParams ) const;
+
+private:
+	std::string m_outputFileArgumentId;
+
+	std::string m_documentVersionArgumentId;
+
+	std::string m_resourcePrefixArgumentId;
+
+	std::string m_skipCompressionId;
+
+	std::string m_exportResourcesId;
+
+	std::string m_exportResourcesDestinationTypeId;
+
+	std::string m_exportResourcesDestinationPathId;
+
+	std::string m_filterFilesArgumentId;
+
+	std::string m_filterFilesBasePathArgumentId;
+
+	std::string m_skipNonExistentInputDirectoriesId;
+
+	std::string m_streamChunkSizeId;
+
+	std::string m_remoteUrlToGetCompressionId;
+
+	std::string m_skipBinaryOperationCalculationId;
+};
+
+#endif // CreateResourceGroupFromFilterCliOperation_H

--- a/cli/src/CreateResourceGroupFromFilterCliOperation.h
+++ b/cli/src/CreateResourceGroupFromFilterCliOperation.h
@@ -35,7 +35,7 @@ private:
 
     std::string m_filterFileBasePathId;
 
-    std::string m_resourceFileBasePathId;
+    std::string m_outputResourceFileBasePathId;
 
 	std::string m_documentVersionId;
 

--- a/cli/src/main.cpp
+++ b/cli/src/main.cpp
@@ -10,6 +10,7 @@
 #include "Cli.h"
 #include "ApplyPatchCliOperation.h"
 #include "CreateResourceGroupCliOperation.h"
+#include "CreateResourceGroupFromFilterCliOperation.h"
 #include "CreatePatchCliOperation.h"
 #include "CreateBundleCliOperation.h"
 #include "UnpackBundleCliOperation.h"
@@ -38,6 +39,10 @@ int main( int argc, char** argv )
 	CreateResourceGroupCliOperation createResourceGroupOperation;
 
 	cli.AddOperation( &createResourceGroupOperation );
+
+    CreateResourceGroupFromFilterCliOperation createResourceGroupFromFilterOperation;
+
+	cli.AddOperation( &createResourceGroupFromFilterOperation );
 
 	CreatePatchCliOperation createPatchOperation;
 

--- a/doc/source/DesignDocuments/fileFiltering.rst
+++ b/doc/source/DesignDocuments/fileFiltering.rst
@@ -14,8 +14,8 @@ or through the CLI via the ``--create-group-from-filter`` operation.
 
 .. _file-format:
 
-File Format
-***********
+Filter File Format
+******************
 
 Filtering is achieved by providing a filter file that follows the following structure:
 
@@ -103,8 +103,8 @@ There are 3 pattern variations that are supported which can be seen in the follo
 
     [section1]                              # Filter section
         respaths = prefix1:/Path/*          # 1. Path with asterisk path wildcard
-        respaths = prefix2:/Path/...        # 2. Path with elipsis recursive path wildcard
-        respaths = prefix3:/Path/File.txt   # 3. Exact path specification
+                   prefix2:/Path/...        # 2. Path with elipsis recursive path wildcard
+                   prefix3:/Path/File.txt   # 3. Exact path specification
 
 Respaths can also include inlined include and exclude patterns:
 
@@ -175,7 +175,7 @@ Patterns can be provided at three different levels.
 
 1. Globally in the ``[DEFAULT]`` section using ``filter =`` .
 2. Section locally in sections using ``filter =`` .
-3. Semi locally to respath adding include/exclude rules to each path ``respaths = prefix1:/* [ include ] ![ exclude ]``
+3. Locally to respath adding rules to each path ``respaths = prefix1:/* [ include ] ![ exclude ]``
 
 If no include pattern matches are specified then all files will be included. Only if an include is provided will files be excluded if they don't match the include patterns.
 
@@ -220,7 +220,7 @@ There are 3 filter patterns and understanding how these combine to include or ex
 
 2. Section local filters are combined with any filters specified in global filters.
 
-3. respaths filters combine with both global and section filters and importantly these add for all subsequent paths. This is explained more in the following examples.
+3. respaths filters combine with both global and section filters and importantly these add for all subsequent paths in the section. This is explained more in the following examples.
 
 This is easier to see by example:
 
@@ -242,21 +242,24 @@ Creating a Resource Group with the following filter file:
     [exampleSection]
         filter = [ include2 ]                   # 2. Section local include
         respaths = prefix1:/*                   # 3. respath1
-        respaths = prefix1:/* [ include3 ]      # 4. respath2 with respath include
-        respaths = prefix2:/*                   # 5. respath3 referencing another prefix
+                   prefix1:/* [ include3 ]      # 4. respath2 with respath include
+                   prefix2:/*                   # 5. respath3 referencing another prefix
 
 Two paths will be tested for inclusion: 
 
 ``#3`` will use ``respaths = prefix1:/*`` and combine global and section local patterns ``include1`` and ``include2``. This will match the following from the source files:
+
 1. ``include1.txt``
 2. ``include2.txt``
 
 ``#4`` will use ``respaths = prefix1:/* [ include3 ]`` which will extend the section local patterns to include ``include3``. This will match the following source files:
+
 1. ``include1.txt``
 2. ``include2.txt``
 3. ``include3.txt``
 
 ``#5`` will use ``respaths = prefix2:/*`` and doesn't sepecify any include rules. It will apply the include rules that have been constructed for the section at this point ``include1``, ``include2`` and ``include3``. This may be suprising. So this will match the following source files:
+
 1. ``Path/include3.txt``
 
 So in this example all files were matched.
@@ -266,3 +269,38 @@ Order is important. Swapping the last two paths will give result in ``Path/inclu
 .. warning::
 
     When include and exclude patterns are specified as part of a ``respath`` they are added to the whole set of include and exclude patterns for the section and apply to subsequent entries. Order is important.
+
+.. warning::
+
+    If a resource is specified directly it will not match filters if include and exclude rules are supplied at the end of the line. This peculiarty has been brought across from a predecessor.
+
+
+Filter index mapping File Format
+********************************
+
+When running filtering using the CLI the filter options are supplied via a filter index mapping file.
+
+The file is standard yaml:
+
+.. code-block:: yaml
+
+    # Filter index mappings used by resources job in CI
+    Version: 1.0.0
+    FilterIndexMappings:
+
+    - FilterMapping:
+        - FilterFile: filter1.ini
+        OutputIndexFilename: ResourceGroup1.yaml
+
+    - FilterMapping:
+        - FilterFile: filter2.ini
+        - FilterFile: filter3.ini
+        OutputIndexFilename: ResourceGroup2.yaml
+
+The example file above will create two Resource Groups ``ResourceGroup1.yaml`` and ``ResourceGroup2.yaml``.
+
+1. ``ResourceGroup1.yaml`` will apply filters from ``filter1.ini``
+2. ``ResourceGroup2.yaml`` will apply filters from ``filter2.ini`` and ``filter3.ini``
+
+For extra information regarding further arguments required to create filtered resource groups through CLI can be found via the CLI.
+    

--- a/doc/source/DesignDocuments/fileFiltering.rst
+++ b/doc/source/DesignDocuments/fileFiltering.rst
@@ -28,7 +28,7 @@ Filtering is achieved by providing a filter file that follows the following stru
     [exampleSection]                                    # [OPTIONAL] Filter section
         filter = [ include ] ![ exclude ]               # [OPTIONAL] Section local include and exclude patterns
         respaths = prefix1:/*                           # [OPTIONAL] Path pattern
-        respaths = prefix1:/* [ include ] ![ exclude ]  # [OPTIONAL] Path pattern with extra include and exclude patterns
+                   prefix1:/* [ include ] ![ exclude ]  # [OPTIONAL] Path pattern with extra include and exclude patterns
 
 Prefixmap
 =========

--- a/doc/source/DesignDocuments/fileFiltering.rst
+++ b/doc/source/DesignDocuments/fileFiltering.rst
@@ -1,0 +1,268 @@
+File Filtering
+##############
+
+Resource file filter rules can be passed while creating resources groups. 
+
+Filter files can be passed during Resource Group creation via
+
+:doc:`CarbonResources::ResourceGroup::CreateFromFilter <../../Tools/Api/ResourceGroup>`
+
+or through the CLI via the ``--create-group-from-filter`` operation.
+
+.. contents:: Table of Contents
+    :depth: 3
+
+.. _file-format:
+
+File Format
+***********
+
+Filtering is achieved by providing a filter file that follows the following structure:
+
+.. code-block:: ini
+
+    [DEFAULT]                                           # [REQUIRED] Default section for settings
+        prefixmap = prefix1:Path1                       # [REQUIRED] Base search paths
+        filter = [ include ] ![ exclude ]               # [OPTIONAL] Global include and exclude patterns
+
+    [exampleSection]                                    # [OPTIONAL] Filter section
+        filter = [ include ] ![ exclude ]               # [OPTIONAL] Section local include and exclude patterns
+        respaths = prefix1:/*                           # [OPTIONAL] Path pattern
+        respaths = prefix1:/* [ include ] ![ exclude ]  # [OPTIONAL] Path pattern with extra include and exclude patterns
+
+Prefixmap
+=========
+
+The prefix map must be defined as part of the ``[DEFAULT]`` section.
+
+It contains a list of search paths linked to named tags.
+
+A prefix can be given any name and can contain many search paths.
+
+.. code-block:: ini
+
+    prefixmap = prefix1:Path1,Path2 prefix2:.
+
+- Here two prefixes are created, ``prefix1`` and ``prefix2``.
+- ``prefix1`` has 2 search paths ``Path1`` and ``Path2``.
+- ``prefix2`` has 1 search path ``.``
+
+.. _include-exclude-pattern:
+
+Global include and exclude patterns
+===================================
+
+Optionally global include and exclude patterns can be specified in the ``[DEFAULT]`` section.
+
+Both include and exclude rules are not always required, just specifying include rules or exclude rules alone is valid.
+
+Many rules can be used, separated by commas.
+
+- Include rules are encased by square brackets.
+- Exclude rules are encased by square brakets with a preceeding ``!``
+
+.. code-block:: ini
+    
+    filter = [ include1, include2 ] ![ exclude ]
+
+- Here both include and exclude filters are specified.
+- Include patterns are ``include1`` and ``include2``.
+- A single exclude pattern ``exclude`` is set.
+
+Filter Sections
+===============
+
+Many filter sections can be specified. At least one is required for any filtering to take effect.
+
+.. code-block:: ini
+
+    [section1]                              # [OPTIONAL] Filter section
+        filter = [ include ] ![ exclude ]   # [OPTIONAL] Section local include and exclude patterns
+        respaths = prefix1:/*               # [OPTIONAL] Path pattern
+
+    [section2]                              # [OPTIONAL] Filter section
+        respaths = prefix2:/*               # [OPTIONAL] Path pattern
+
+- Two sections are specified ``section1`` and ``section2``
+
+Section include and exclude patterns
+====================================
+
+Each section can specify local include and exclude patterns.
+
+These follow the same syntax as the global patterns. See :ref:`include-exclude-pattern`
+
+Section respaths
+================
+
+Respaths are the part that actually specifies the paths to perform filtering on.
+
+There are 3 pattern variations that are supported which can be seen in the following:
+
+.. code-block:: ini
+
+    [section1]                              # Filter section
+        respaths = prefix1:/Path/*          # 1. Path with asterisk path wildcard
+        respaths = prefix2:/Path/...        # 2. Path with elipsis recursive path wildcard
+        respaths = prefix3:/Path/File.txt   # 3. Exact path specification
+
+Respaths can also include inlined include and exclude patterns:
+
+.. code-block:: ini
+
+    [section1]                           
+        respaths = prefix1:/Path/* [ include ] ![ exclude ]    
+
+See filtering logic to understand expected behaviour from this.
+
+See :ref:`include-exclude-pattern` for details on include and exclude patterns
+
+.. _filtering-logic:
+
+Filtering Logic
+***************
+
+It is important to understand the logic behind resource filtering to be sure your resources are included as you expect.
+
+
+The logic behind the filtering was inherited from a legacy system, therefore some of the logic may be suprising.
+
+Path construction
+=================
+
+The filtering system operates on a single based directory, the prefix base map.
+
+This directory acts as the base for all the search directories that are specified inside the filter files.
+
+.. code-block:: ini
+
+    prefixmap = prefix1:A/Path,B/Path prefix2:../Another/Path
+
+With this above example specifies 2 prefixes ``prefix1`` and ``prefix2`` and between them 3 search paths are specified
+
+1. ``A/Path``
+2. ``B/Path``
+3. ``../Another/Path``
+
+The full path is resolved by adding these paths to the base prefix map passed in as part of the operation.
+
+.. code-block:: ini
+
+    [section1]
+        respaths = prefix1:/*
+
+Each sections' respaths use the prefixes and adds the remaining path.
+
+The prefix name, ``prefix1`` in this case needs to be present in the prefix map.
+
+Each prefix can have multiple paths, therefore following the example the following path patterns will be checked
+
+1. ``[Prefix base path]/A/Path/*``
+2. ``[Prefix base path]/B/Path/*``
+
+When a resource is found that matches one of the patterns it will be added to the Resource Group.
+
+The resources' relative path will be based on the prefix base path. e.g:
+
+``[Prefix base path]/A/Path/Found.txt`` produces a resource with relative path ``Found.txt``
+
+Order matters! If duplicate relative paths are encountered, the first resource will be included in the Resource Group.
+
+Include & Exclude patterns
+==========================
+
+Patterns can be provided at three different levels.
+
+1. Globally in the ``[DEFAULT]`` section using ``filter =`` .
+2. Section locally in sections using ``filter =`` .
+3. Semi locally to respath adding include/exclude rules to each path ``respaths = prefix1:/* [ include ] ![ exclude ]``
+
+If no include pattern matches are specified then all files will be included. Only if an include is provided will files be excluded if they don't match the include patterns.
+
+The pattern matching is performed against the whole path of a file that is being tested from the patterns.
+
+.. code-block:: ini
+    
+    filter = [ include ]
+
+This example ensures each path contains the pattern ``include``. Paths that don't will not be included in the Resource Group.
+
+.. warning::
+
+    The include exclude patterns apply across the entire absolute path to the resource that is being checked.
+
+    This could lead to some unexpected behaviour for example if a pattern of ``c`` was provided it would match every single file tested if source files lived on the ``c:/`` drive. It is understandable that the user may have wanted to include only files that contained the letter ``c`` but this is not going to be the result.
+
+    This behaviour was inherited from a previous system, it may change in the future.
+
+Excludes work oposite to includes. Any path that matches the pattern will be excluded from Resource Groups.
+
+.. code-block:: ini
+    
+    filter = ![ exclude ]
+
+Here any path which contains ``exclude`` will not be added to the Resource Group.
+
+Excludes take precedence over includes, if a path matches an exclude pattern and an include pattern, it will be excluded.
+
+.. code-block:: ini
+    
+    filter = [ match ] ![ match ]
+
+Paths which match the pattern ``match`` would hit include and exclude rules, exclude takes preceedence so it will be excluded.
+
+How include/exclude pattern are combined
+----------------------------------------
+
+There are 3 filter patterns and understanding how these combine to include or exclude a path is important.
+
+1. Global filters affect all path matching. Anything added there will be applied to all paths that are tested for inclusion.
+
+2. Section local filters are combined with any filters specified in global filters.
+
+3. respaths filters combine with both global and section filters and importantly these add for all subsequent paths. This is explained more in the following examples.
+
+This is easier to see by example:
+
+Assuming there are 3 files in the prefix base path
+
+1. ``include1.txt``
+2. ``include2.txt``
+3. ``include3.txt``
+4. ``Path/include3.txt``
+
+Creating a Resource Group with the following filter file:
+
+.. code-block:: ini
+
+    [DEFAULT]
+        prefixmap = prefix1:. prefix2:Path/
+        filter = [ include1 ]                   # 1. Global include
+
+    [exampleSection]
+        filter = [ include2 ]                   # 2. Section local include
+        respaths = prefix1:/*                   # 3. respath1
+        respaths = prefix1:/* [ include3 ]      # 4. respath2 with respath include
+        respaths = prefix2:/*                   # 5. respath3 referencing another prefix
+
+Two paths will be tested for inclusion: 
+
+``#3`` will use ``respaths = prefix1:/*`` and combine global and section local patterns ``include1`` and ``include2``. This will match the following from the source files:
+1. ``include1.txt``
+2. ``include2.txt``
+
+``#4`` will use ``respaths = prefix1:/* [ include3 ]`` which will extend the section local patterns to include ``include3``. This will match the following source files:
+1. ``include1.txt``
+2. ``include2.txt``
+3. ``include3.txt``
+
+``#5`` will use ``respaths = prefix2:/*`` and doesn't sepecify any include rules. It will apply the include rules that have been constructed for the section at this point ``include1``, ``include2`` and ``include3``. This may be suprising. So this will match the following source files:
+1. ``Path/include3.txt``
+
+So in this example all files were matched.
+
+Order is important. Swapping the last two paths will give result in ``Path/include3.txt`` not being included.
+
+.. warning::
+
+    When include and exclude patterns are specified as part of a ``respath`` they are added to the whole set of include and exclude patterns for the section and apply to subsequent entries. Order is important.

--- a/doc/source/Tools/Api/ResourceGroup.rst
+++ b/doc/source/Tools/Api/ResourceGroup.rst
@@ -21,6 +21,10 @@ They can be saved/loaded from a filetype which supersedes resfileindex files.
 Input Parameters
 ----------------
 
+.. doxygenvariable:: DEFAULT_FILE_STREAM_SIZE
+
+.. doxygenvariable:: DEFAULT_STREAM_THRESHOLD_SIZE
+
 .. doxygenstruct:: CarbonResources::ResourceGroupImportFromFileParams
     :members:
 

--- a/doc/source/Tools/Api/ResourceGroup.rst
+++ b/doc/source/Tools/Api/ResourceGroup.rst
@@ -7,7 +7,12 @@ ResourceGroups represent a collection of Resources.
 
 They can be saved/loaded from a filetype which supersedes resfileindex files.
 
-See :doc:`../../DesignDocuments/resourceGroupFileFormat` file specification for more details.
+
+.. note::
+
+    See :doc:`../../DesignDocuments/resourceGroupFileFormat` file specification for details on Resource Groups.
+
+    See :doc:`../../DesignDocuments/fileFiltering` for further information on filtering.
 
 .. doxygenclass:: CarbonResources::ResourceGroup
     :members:
@@ -25,6 +30,9 @@ Input Parameters
 .. doxygenstruct:: CarbonResources::CreateResourceGroupFromDirectoryParams
     :members:
 
+.. doxygenstruct:: CarbonResources::CreateResourceGroupFromFilterParams
+    :members:
+
 .. doxygenstruct:: CarbonResources::PatchCreateParams
     :members:
 
@@ -40,3 +48,11 @@ Input Parameters
 .. doxygenstruct:: CarbonResources::ResourceGroupRemoveResourcesParams
     :members:
 
+.. doxygenstruct:: CarbonResources::CompressionCalculationSettings
+    :members:
+
+.. doxygenstruct:: CarbonResources::ExportResourceSettings
+    :members:
+
+.. doxygenstruct:: CarbonResources::FilterSettings
+    :members:

--- a/doc/source/designDocuments.rst
+++ b/doc/source/designDocuments.rst
@@ -8,3 +8,4 @@ Documents contained in this section detail design approaches in resources.
    
    DesignDocuments/filesystemDesign
    DesignDocuments/resourceGroupFileFormat
+   DesignDocuments/fileFiltering

--- a/include/BundleResourceGroup.h
+++ b/include/BundleResourceGroup.h
@@ -19,7 +19,7 @@ namespace CarbonResources
     *  Location where chunks can be sourced.
     *  @var BundleUnpackParams::resourceDestinationSettings
     *  Location where the unpacked resources should be saved.
-    *  @var BundleUnpackParams::CallbackSettings
+    *  @var BundleUnpackParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct BundleUnpackParams final

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -244,6 +244,8 @@ static const Version S_LIBRARY_VERSION = { VERSION_MAJOR, VERSION_MINOR, VERSION
 
 static const Version S_DOCUMENT_VERSION = { 0, 1, 0 }; /*!< Maximum document version supported by resources */
 
+static const Version S_CSV_DOCUMENT_VERSION = { 0, 0, 0 }; /*!< Document version for old style CSV */
+
 static const std::vector S_VALID_DOCUMENT_VERSIONS = {
 	Version{ 0, 0, 0 },
 	Version{ 0, 1, 0 }

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -124,6 +124,8 @@ using StatusCallback = std::function<void( StatusProgressType statusProgressType
     * Required resource not found
     * @var REQUIRED_INPUT_PARAMETER_NOT_SET
     * A required input parameter was not set
+    * @var FAILED_TO_INITIALIZE_RESOURCE_FILTER
+    * Failed to initialize ResourceFilter
     */
 enum class ResultType
 {
@@ -164,6 +166,7 @@ enum class ResultType
 	RESOURCE_LIST_NOT_SET,
 	RESOURCE_NOT_FOUND,
 	REQUIRED_INPUT_PARAMETER_NOT_SET,
+	FAILED_TO_INITIALIZE_RESOURCE_FILTER,
 	//NOTE: if adding to this enum, a complimentary entry must be added to resultToString.
 };
 

--- a/include/PatchResourceGroup.h
+++ b/include/PatchResourceGroup.h
@@ -16,7 +16,7 @@ namespace CarbonResources
 
 /** @struct PatchApplyParams
     *  @brief Function Parameters required for CarbonResources::PatchResourceGroup::Apply
-    *  @var PatchApplyParams::newBuildResourcesSourceSettings
+    *  @var PatchApplyParams::nextBuildResourcesSourceSettings
     *  Location where new resources can be sourced. Resources will be sourced from here if there are no patches related to them, indicating they are completely new files.
     *  @var PatchApplyParams::patchBinarySourceSettings
     *  Location where patch binaries can be sourced.
@@ -26,7 +26,7 @@ namespace CarbonResources
     *  Location where to place patched resources. This can match PatchApplyParams::resourcesToPatchSourceSettings to overwrite. Allows creation of staging area in case of failure.
     *  @var PatchApplyParams::temporaryFilePath
     *  Name of a temporary filename to use when patching large files. This file will be cleaned up on process completion. 
-    *  @var PatchApplyParams::CallbackSettings
+    *  @var PatchApplyParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct PatchApplyParams final

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -20,6 +20,20 @@ class PatchResourceGroup;
 class BundleResourceGroup;
 struct Result;
 
+/** 
+ * @brief Default file stream size.
+ * 
+ * 20mb index aligned.
+ */
+const uintmax_t DEFAULT_FILE_STREAM_SIZE = 20971520;
+
+/** 
+ * @brief Default resource stream threshold size.
+ * 
+ * 500mb index aligned.
+ */
+const uintmax_t DEFAULT_STREAM_THRESHOLD_SIZE = 524288000;
+
 /** @struct CallbackSettings
     *  @brief Parameters relating to status callback.
     *  @var CallbackSettings::statusCallback
@@ -239,7 +253,7 @@ struct CreateResourceGroupFromDirectoryParams
 {
 	std::filesystem::path directory = "";
 
-	uintmax_t resourceStreamThreshold = 524288000;
+	uintmax_t resourceStreamThreshold = DEFAULT_STREAM_THRESHOLD_SIZE;
 
 	Version outputDocumentVersion = S_DOCUMENT_VERSION;
 
@@ -253,7 +267,7 @@ struct CreateResourceGroupFromDirectoryParams
 
     ResourceDestinationSettings exportResourcesDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "ExportedResources" };
 
-    uintmax_t fileStreamChunkSize = 20971520;
+    uintmax_t fileStreamChunkSize = DEFAULT_FILE_STREAM_SIZE;
 };
 
 /** @struct Filter
@@ -342,7 +356,7 @@ struct CompressionCalculationSettings
     */
 struct CreateResourceGroupFromFilterParams
 {
-	uintmax_t fileStreamChunkSize = 20971520;
+	uintmax_t fileStreamChunkSize = DEFAULT_FILE_STREAM_SIZE;
 
 	Version outputDocumentVersion = S_DOCUMENT_VERSION;
 

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -33,6 +33,20 @@ struct CallbackSettings
 	int verbosityLevel = -1;
 };
 
+/** @struct DownloadSettings
+    *  @brief Parameters relating downloading
+    *  @var DownloadSettings::retrySeconds
+    *  Delay before a failed download is retried (seconds)
+    *  @var DownloadSettings::retryCount
+    *  Number of times times a download is retried before failure. Note: a backoff is also applied before retry.
+    */
+struct DownloadSettings
+{
+	std::chrono::seconds retrySeconds{ 1 };
+
+	uintmax_t retryCount = 3;
+};
+
 /** @struct ResourceSourceSettings
     *  @brief Parameters to represent where and how a resource is sourced.
     *  @var ResourceSourceSettings::sourceType
@@ -77,7 +91,7 @@ struct ResourceDestinationSettings
     *  Size of chunks to read files in. Default is 10000000.
     *  @var BundleCreateParams::resourceBundleResourceGroupDestinationSettings
     *  Where to save the resulting BundleResourceGroup
-    *  @var BundleCreateParams::CallbackSettings
+    *  @var BundleCreateParams::callbackSettings
     *  Settings relating to status callback messaging
     *  @var BundleCreateParams::downloadRetrySeconds
     *  Delay before a failed download is retried (seconds)
@@ -119,15 +133,15 @@ struct BundleCreateParams
     *  Relative path for output PatchResourceGroup which will contain all the patches produced.
     *  @var PatchCreateParams::patchFileRelativePathPrefix
     *  Relative path prefix for produced patch binaries. Default is "Patches/Patch" which will produce patches such as Patches/Patch.1 ...
-    *  @var PatchCreateParams::resourceSourceSettingsFrom
+    *  @var PatchCreateParams::resourceSourceSettingsPrevious
     *  Where resources for the previous build will be sourced.
-    *  @var PatchCreateParams::resourceSourceSettingsTo
+    *  @var PatchCreateParams::resourceSourceSettingsNext
     *  Where resources for the current ResourceGroup build will be sourced.
     *  @var PatchCreateParams::resourcePatchBinaryDestinationSettings
     *  Where the produced binary patches will be saved.
     *  @var PatchCreateParams::resourcePatchResourceGroupDestinationSettings
     *  Where the produced PatchResourceGroup will be saved.
-    *  @var PatchCreateParams::CallbackSettings
+    *  @var PatchCreateParams::callbackSettings
     *  Settings relating to status callback messaging
     *  @var PatchCreateParams::downloadRetrySeconds
     *  Delay before a failed download is retried (seconds)
@@ -169,7 +183,7 @@ struct PatchCreateParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::ImportFromFile
     *  @var ResourceGroupImportFromFileParams::filename
     *  Full filename of input file.
-    *  @var ResourceGroupImportFromFileParams::CallbackSettings
+    *  @var ResourceGroupImportFromFileParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct ResourceGroupImportFromFileParams
@@ -185,7 +199,7 @@ struct ResourceGroupImportFromFileParams
     *  Full filename of output file. If directory doesn't exist it will be created.
     *  @var ResourceGroupExportToFileParams::outputDocumentVersion
     *  Document version to output. By default this will be latest supported by the library.
-    *  @var ResourceGroupExportToFileParams::CallbackSettings
+    *  @var ResourceGroupExportToFileParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct ResourceGroupExportToFileParams
@@ -205,7 +219,7 @@ struct ResourceGroupExportToFileParams
     *  Files encountered that are above this the threshold value will be streamed in. Value is in bytes, default: 10000000
     *  @var CreateResourceGroupFromDirectoryParams::outputDocumentVersion
     *  Document version to output. By default this will be latest supported by the library.
-    *  @var CreateResourceGroupFromDirectoryParams::CallbackSettings
+    *  @var CreateResourceGroupFromDirectoryParams::callbackSettings
     *  Settings relating to status callback messaging
     *  @var CreateResourceGroupFromDirectoryParams::resourcePrefix
     *  Resource prefix setting, e.g. res.
@@ -217,6 +231,9 @@ struct ResourceGroupExportToFileParams
     *  @var CreateResourceGroupFromDirectoryParams::exportResourcesDestinationSettings
     *  If export resources is set, specifies where the produced PatchResourceGroup will be saved.
     *  @see CreateResourceGroupFromDirectoryParams::exportResources
+    *  @var CreateResourceGroupFromDirectoryParams::fileStreamChunkSize
+    *  Chunk size to stream in data
+    *  @see CreateResourceGroupFromDirectoryParams::resourceStreamThreshold
     */
 struct CreateResourceGroupFromDirectoryParams
 {
@@ -235,6 +252,99 @@ struct CreateResourceGroupFromDirectoryParams
     bool exportResources = false;
 
     ResourceDestinationSettings exportResourcesDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_CDN, "ExportedResources" };
+
+    uintmax_t fileStreamChunkSize = 20971520;
+};
+
+/** @struct FilterSettings
+    *  @brief Function Parameters related to filtering
+    *  @var FilterSettings::filterFilePaths
+    *  Paths to filter files to apply
+    *  @var FilterSettings::prefixMapBasePath
+    *  Base directory used for prefixmap in filter files, refer to filter file spec.
+    */
+struct FilterSettings
+{
+	std::vector<std::filesystem::path> filterFilePaths = {};
+
+	std::filesystem::path prefixMapBasePath = "";
+};
+
+/** @struct ExportResourceSettings
+    *  @brief Function Parameters related to resource exporting
+    *  @var ExportResourceSettings::enabled
+    *  Specifies if export is turned on
+    *  @var ExportResourceSettings::destinationSettings
+    *  Destination settings related to exported resource
+    */
+struct ExportResourceSettings
+{
+	bool enabled = false;
+
+	ResourceDestinationSettings destinationSettings = {
+		CarbonResources::ResourceDestinationType::LOCAL_CDN,
+		"ExportedResources"
+	};
+};
+
+/** @struct CompressionCalculationSettings
+    *  @brief Function Parameters related to resource compression calculation
+    *  @var CompressionCalculationSettings::calculateCompressions
+    *  Specifies if compression will be calculated for resoures
+    *  @var CompressionCalculationSettings::remoteUrlToAttemptToGetCompression
+    *  Path to remote location to attempt to get compression information
+    *  @var CompressionCalculationSettings::downloadSettings
+    *  Download settings used, related to CompresionCalculationSettings::remoteUrlToAttemptToGetCompression
+    */
+struct CompressionCalculationSettings
+{
+	bool calculateCompressions = true;
+
+	std::filesystem::path remoteUrlToAttemptToGetCompression = "";
+
+	DownloadSettings downloadSettings;
+};
+
+/** @struct CreateResourceGroupFromFilterParams
+    *  @brief Function Parameters required for CarbonResources::ResourceGroup::CreateFromFilters
+    *  @var CreateResourceGroupFromFilterParams::fileStreamChunkSize
+    *  Chunk size to stream in data
+    *  @var CreateResourceGroupFromFilterParams::outputDocumentVersion
+    *  Document version to output. By default this will be latest supported by the library.
+    *  @var CreateResourceGroupFromFilterParams::callbackSettings
+    *  Settings relating to status callback messaging
+    *  @var CreateResourceGroupFromFilterParams::resourcePrefix
+    *  Resource prefix setting, e.g. res.
+    *  @var CreateResourceGroupFromFilterParams::skipNonExistentInputDirectories
+    *  If true will skip filter source directories that don't exist rather than error.
+    *  @var CreateResourceGroupFromFilterParams::compressionCalculationSettings
+    *  Settings related to compression calculations
+    *  @var CreateResourceGroupFromFilterParams::exportSettings
+    *  Settings related to exporting
+    *  @var CreateResourceGroupFromFilterParams::filterSettings
+    *  Settings related to filtering
+    *  @var CreateResourceGroupFromFilterParams::calculateBinaryOperation
+    *  Set true to include calculation of binary operation
+    */
+struct CreateResourceGroupFromFilterParams
+{
+	uintmax_t fileStreamChunkSize = 20971520;
+
+	Version outputDocumentVersion = S_DOCUMENT_VERSION;
+
+	CallbackSettings callbackSettings;
+
+	std::string resourcePrefix = "";
+
+	bool skipNonExistentInputDirectories = false;
+
+	CompressionCalculationSettings compressionCalculationSettings;
+
+	ExportResourceSettings exportSettings;
+
+	FilterSettings filterSettings;
+
+    bool calculateBinaryOperation = true;
 };
 
 /** @struct ResourceGroupMergeParams
@@ -243,7 +353,7 @@ struct CreateResourceGroupFromDirectoryParams
     *  ResourceGroup to merge
     *  @var ResourceGroupMergeParams::mergedResourceGroup
     *  Resulting ResourceGroup after merge
-    *  @var ResourceGroupMergeParams::CallbackSettings
+    *  @var ResourceGroupMergeParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct ResourceGroupMergeParams
@@ -261,7 +371,7 @@ struct ResourceGroupMergeParams
     *  List of Resources to remove identified by RelativePath.
     *  @var ResourceGroupRemoveResourcesParams::errorIfResourceNotFound
     *  If true the function will return an error state if supplied Resource is not present in ResourceGroup
-    *  @var ResourceGroupRemoveResourcesParams::CallbackSettings
+    *  @var ResourceGroupRemoveResourcesParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct ResourceGroupRemoveResourcesParams
@@ -281,7 +391,7 @@ struct ResourceGroupRemoveResourcesParams
     *  Output list of relative paths that have been added or modified on second group.
     *  @var ResourceGroupDiffAgainstGroupParams::subtractions
     *  Output list of relative paths that have been removed on second group.
-    *  @var ResourceGroupDiffAgainstGroupParams::CallbackSettings
+    *  @var ResourceGroupDiffAgainstGroupParams::callbackSettings
     *  Settings relating to status callback messaging
     */
 struct ResourceGroupDiffAgainstGroupParams
@@ -343,6 +453,11 @@ public:
 	/// @return Result see CarbonResources::Result for more details.
 	/// @note No file filtering supported
 	Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params );
+
+    /// @brief Creates a ResourceGroup from a supplied filter files.
+	/// @param params input parameters, See CreateResourceGroupFromFilterParams for more details.
+	/// @return Result see CarbonResources::Result for more details.
+	Result CreateFromFilter( const CreateResourceGroupFromFilterParams& params );
 
 	/// @brief Merges a supplied ResourceGroup with this one. Merge performed on RelativePath, merge ResourceGroup takes precedent.
 	/// @param params input parameters, See ResourceGroupMergeParams for more details.

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -256,16 +256,30 @@ struct CreateResourceGroupFromDirectoryParams
     uintmax_t fileStreamChunkSize = 20971520;
 };
 
-/** @struct FilterSettings
-    *  @brief Function Parameters related to filtering
+/** @struct Filter
+    *  @brief Function Parameters related to filters
     *  @var FilterSettings::filterFilePaths
     *  Paths to filter files to apply
+    *  @var FilterSettings::outputResourceGroup
+    *  Output resource group to populate with filtered resources
+    */
+struct Filter
+{
+	std::vector<std::filesystem::path> filterFilePaths = {};
+
+	ResourceGroup* outputResourceGroup = nullptr;
+};
+
+/** @struct FilterSettings
+    *  @brief Function Parameters related to filtering
+    *  @var FilterSettings::filters
+    *  Filters to apply
     *  @var FilterSettings::prefixMapBasePath
     *  Base directory used for prefixmap in filter files, refer to filter file spec.
     */
 struct FilterSettings
 {
-	std::vector<std::filesystem::path> filterFilePaths = {};
+	std::vector<std::unique_ptr<Filter>> filters = {};
 
 	std::filesystem::path prefixMapBasePath = "";
 };
@@ -454,10 +468,10 @@ public:
 	/// @note No file filtering supported
 	Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params );
 
-    /// @brief Creates a ResourceGroup from a supplied filter files.
+    /// @brief Creates a filtered ResourceGroup.
 	/// @param params input parameters, See CreateResourceGroupFromFilterParams for more details.
 	/// @return Result see CarbonResources::Result for more details.
-	Result CreateFromFilter( const CreateResourceGroupFromFilterParams& params );
+	static Result CreateFromFilter( const CreateResourceGroupFromFilterParams& params );
 
 	/// @brief Merges a supplied ResourceGroup with this one. Merge performed on RelativePath, merge ResourceGroup takes precedent.
 	/// @param params input parameters, See ResourceGroupMergeParams for more details.

--- a/src/Enums.cpp
+++ b/src/Enums.cpp
@@ -156,6 +156,10 @@ bool ResultTypeToString( ResultType resultType, std::string& output )
 	case ResultType::REQUIRED_INPUT_PARAMETER_NOT_SET:
 		output = "A required parameter was not set";
 		return true;
+
+    case ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER:
+		output = "Failed to initialize ResourceFilter";
+		return true;
 	}
 
 	output = "Error code unrecognised. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";

--- a/src/ResourceGroup.cpp
+++ b/src/ResourceGroup.cpp
@@ -68,6 +68,15 @@ Result ResourceGroup::CreateFromDirectory( const CreateResourceGroupFromDirector
 	return m_impl->CreateFromDirectory( params, statusSettings );
 }
 
+Result ResourceGroup::CreateFromFilter( const CreateResourceGroupFromFilterParams& params )
+{
+	StatusSettings statusSettings;
+	statusSettings.SetCallbackSettings( params.callbackSettings );
+	statusSettings.Update( CarbonResources::StatusProgressType::START, 0, 0, "Starting Process" );
+
+	return m_impl->CreateFromFilter( params, statusSettings );
+}
+
 Result ResourceGroup::Merge( const ResourceGroupMergeParams& params ) const
 {
 	StatusSettings statusSettings;

--- a/src/ResourceGroup.cpp
+++ b/src/ResourceGroup.cpp
@@ -74,7 +74,7 @@ Result ResourceGroup::CreateFromFilter( const CreateResourceGroupFromFilterParam
 	statusSettings.SetCallbackSettings( params.callbackSettings );
 	statusSettings.Update( CarbonResources::StatusProgressType::START, 0, 0, "Starting Process" );
 
-	return m_impl->CreateFromFilter( params, statusSettings );
+	return ResourceGroupImpl::CreateFromFilter( params, statusSettings );
 }
 
 Result ResourceGroup::Merge( const ResourceGroupMergeParams& params ) const

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -343,7 +343,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 
     bool ignoreCase = false;
 
-    if (documentVersion == VersionInternal(0, 0, 0))
+    if( documentVersion == VersionInternal( S_CSV_DOCUMENT_VERSION ) )
     {
 		ignoreCase = true;
     }
@@ -919,11 +919,6 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 	}
 
 	return Result{ ResultType::SUCCESS };
-}
-
-bool ResourceGroup::ResourceGroupImpl::ResourceExists( ResourceInfo& resource )
-{
-	return m_resourcesParameter.Contains( &resource );
 }
 
 Result ResourceGroup::ResourceGroupImpl::ImportFromData( const std::string& data, StatusSettings& statusSettings, DocumentType documentType /* = DocumentType::YAML */ )

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -548,10 +548,9 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 								filterMatchInformation += matchSection;
 								filterMatchInformation += ",matched path - ";
 								filterMatchInformation += matchPath;
-								goto nextFilterGroup;
+								break;
 							}
 						}
-					    nextFilterGroup:;
 
 					}
 

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -11,6 +11,8 @@
 #include <Md5ChecksumStream.h>
 #include <GzipCompressionStream.h>
 #include <cctype>
+#include <algorithm>
+
 #include "ResourceInfo/PatchResourceGroupInfo.h"
 #include "ResourceInfo/BundleResourceGroupInfo.h"
 #include "ResourceInfo/ResourceGroupInfo.h"
@@ -339,74 +341,102 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 	// Ensure document version is valid
 	VersionInternal documentVersion( params.outputDocumentVersion );
 
+    bool ignoreCase = false;
+
+    if (documentVersion == VersionInternal(0, 0, 0))
+    {
+		ignoreCase = true;
+    }
+
 	if( !documentVersion.isVersionValid() )
 	{
 		return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
 	}
 
-	// Initialize ResourceFilter
-	if( params.filterSettings.filterFilePaths.empty() )
+	statusSettings.Update( StatusProgressType::PERCENTAGE, 5, 10, "Loading filter files" );
+
+	// Initialise Resource Filters
+	std::vector<std::shared_ptr<FilterGroup>> filterGroups;
+
+	for( auto& filter : params.filterSettings.filters )
 	{
-		std::string errorMsg = "No filter files provided.";
-		return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER, errorMsg };
-	}
-
-	statusSettings.Update( StatusProgressType::PERCENTAGE, 0, 5, "Loading filter files" );
-
-	std::vector<std::unique_ptr<ResourceTools::ResourceFilter>> filters;
-
-	for( auto filterPath : params.filterSettings.filterFilePaths )
-	{
-		// Get filter file data
-		std::string filterData;
-
-		if( !ResourceTools::GetLocalFileData( filterPath, filterData ) )
+		if( filter->filterFilePaths.empty() )
 		{
-			std::string errorMsg = "Failed to open filter file: " + filterPath.string();
-			return Result{ ResultType::FAILED_TO_OPEN_FILE, errorMsg };
-		}
-
-		ResourceTools::FilterFile fileData;
-
-		try
-		{
-			ResourceTools::FilterFileReader::LoadFromIniFileData( filterData.data(), filterData.size(), fileData );
-		}
-		catch( const std::exception& e )
-		{
-			std::string errorMsg = "Failed to read filter file: " + std::string( e.what() );
-
+			std::string errorMsg = "No filter files provided.";
 			return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER, errorMsg };
 		}
 
-		std::unique_ptr<ResourceTools::ResourceFilter> filter = std::make_unique<ResourceTools::ResourceFilter>();
+		std::shared_ptr<FilterGroup> filterGroup = std::make_shared<FilterGroup>();
 
-		if( !filter->SetFromFilterFileData( fileData ) )
+		filterGroup->resourceGroup = filter->outputResourceGroup->m_impl;
+
+		for( auto filterPath : filter->filterFilePaths )
 		{
-			return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER };
+			// Get filter file data
+			std::string filterData;
+
+			if( !ResourceTools::GetLocalFileData( filterPath, filterData ) )
+			{
+				std::string errorMsg = "Failed to open filter file: " + filterPath.string();
+				return Result{ ResultType::FAILED_TO_OPEN_FILE, errorMsg };
+			}
+
+			ResourceTools::FilterFile fileData;
+
+			try
+			{
+				ResourceTools::FilterFileReader::LoadFromIniFileData( filterData.data(), filterData.size(), fileData, ignoreCase );
+			}
+			catch( const std::exception& e )
+			{
+				std::string errorMsg = "Failed to read filter file: " + std::string( e.what() );
+
+				return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER, errorMsg };
+			}
+
+			std::unique_ptr<ResourceTools::ResourceFilter> filter = std::make_unique<ResourceTools::ResourceFilter>();
+
+			if( !filter->SetFromFilterFileData( fileData ) )
+			{
+				return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER };
+			}
+
+			filterGroup->filters.push_back( std::move( filter ) );
 		}
 
-		filters.emplace_back( std::move( filter ) );
+		filterGroups.push_back( std::move( filterGroup ) );
 	}
 
-	// Populate the directories from the filter files
+	// Populate all search paths
 	std::vector<std::filesystem::path> searchPaths;
 
-	for( auto& filter : filters )
+	for( auto& filterGroup : filterGroups )
 	{
-		const std::vector<std::filesystem::path>& filterPaths = filter->GetPrefixPaths();
-
-		for( auto& filterPath : filterPaths )
+		for( auto& filter : filterGroup->filters )
 		{
-			searchPaths.push_back( filterPath );
+			const std::vector<std::filesystem::path>& filterPaths = filter->GetPrefixPaths();
+
+			for( auto& filterPath : filterPaths )
+			{
+				if( std::find( searchPaths.begin(), searchPaths.end(), filterPath ) == searchPaths.end() )
+				{
+					searchPaths.push_back( filterPath );
+				}
+			}
 		}
 	}
 
-	// Process all directories
-	// Apply filters if supplied
+	// Process files in search paths
 	{
 		StatusSettings inputDirectoryStatus;
 		statusSettings.Update( StatusProgressType::PERCENTAGE, 10, 90, "Creating resource group from directories", &inputDirectoryStatus );
+
+		std::map<std::string, int> checkedRelativePaths;
+		std::string matchSection = "";
+		std::string matchPath = "";
+		std::string filterMatchInformation = "";
+		ResourceTools::Downloader downloader;
+		ResourceTools::FileDataStreamIn fileStreamIn( params.fileStreamChunkSize );
 
 		int i = 0;
 		for( auto searchPath : searchPaths )
@@ -423,6 +453,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 				inputDirectoryStatus.Update( StatusProgressType::PERCENTAGE, progress, step, "Processing Directory: " + inputDirectory.string(), &fileProcessingInnerStatusSettings );
 			}
 
+			// Check validity of search path
 			if( !std::filesystem::exists( inputDirectory ) )
 			{
 				if( params.skipNonExistentInputDirectories )
@@ -437,22 +468,59 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 				}
 			}
 
-			// Walk directory and create a resource from each file using data
+			// Walk directory
 			auto recursiveDirectoryIter = std::filesystem::recursive_directory_iterator( inputDirectory );
 			{
 
+				// Walk entries
 				for( const std::filesystem::directory_entry& entry : recursiveDirectoryIter )
 				{
-					if( entry.is_regular_file() )
+					if( !entry.is_regular_file() )
 					{
-						std::filesystem::path filePathRelativeToInputDirectory = std::filesystem::relative( entry.path(), params.filterSettings.prefixMapBasePath );
+						// Not a file
+						continue;
+					}
 
-						bool filterMatchDetected = false;
-						std::string matchSection = "";
-						std::string matchPath = "";
-						for( auto& filter : filters )
+					std::filesystem::path entryPath = entry.path();
+
+					std::string entryPathString;
+
+                    if (inputDirectoryStatus.RequiresStatusUpdates())
+                    {
+						entryPathString = entryPath.string();
+                    }
+
+					// Process file
+					// Check each filter group
+					std::vector<std::shared_ptr<FilterGroup>> matchedFilters;
+
+					std::filesystem::path filePathRelativeToInputDirectory = std::filesystem::relative( entryPath, params.filterSettings.prefixMapBasePath );
+
+                    std::string normalisedRelativePath = filePathRelativeToInputDirectory.generic_string();
+
+                    // Filtering is not case sensitive
+                    if (ignoreCase)
+                    {
+						std::transform( normalisedRelativePath.begin(), normalisedRelativePath.end(), normalisedRelativePath.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+                    }
+
+					if( fileProcessingInnerStatusSettings.RequiresStatusUpdates() )
+					{
+						filterMatchInformation = "";
+					}
+
+					for( auto& filterGroup : filterGroups )
+					{
+						if( fileProcessingInnerStatusSettings.RequiresStatusUpdates() )
 						{
-							// Ensure that the search path is relevant to the filter
+							filterMatchInformation = filterMatchInformation + "Filter:";
+						}
+
+						// Check each filter in filter group
+						for( auto& filter : filterGroup->filters )
+						{
+
+							// Check that the current search path is relevant to the current filter
 							const std::vector<std::filesystem::path>& filterSearchPaths = filter->GetPrefixPaths();
 
 							bool searchPathInFilter = false;
@@ -472,389 +540,380 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceG
 								continue;
 							}
 
-							if( filter->CheckPath( filePathRelativeToInputDirectory, matchSection, matchPath ) )
+							if( filter->CheckPath( normalisedRelativePath, matchSection, matchPath ) )
 							{
-								filterMatchDetected = true;
-								break;
+								matchedFilters.push_back( filterGroup );
+
+								filterMatchInformation += " matched section filter - ";
+								filterMatchInformation += matchSection;
+								filterMatchInformation += ",matched path - ";
+								filterMatchInformation += matchPath;
+								goto nextFilterGroup;
 							}
 						}
+					    nextFilterGroup:;
 
-						if( !filterMatchDetected )
-						{
-							//File doesn't meet any of the filters
-							fileProcessingInnerStatusSettings.Update( CarbonResources::StatusProgressType::UNBOUNDED, 0, 0, "Skipping File that didn't match filters: " + entry.path().string() );
-							continue;
-						}
+					}
 
-						// Create resource
-						std::stringstream ss;
+					// Check if any filters were matched
+					if( matchedFilters.empty() )
+					{
+						//File doesn't meet any of the filters
+						fileProcessingInnerStatusSettings.Update( CarbonResources::StatusProgressType::UNBOUNDED, 0, 0, "Skipping File that didn't match filters: " + entryPathString );
+						continue;
+					}
 
+					// Create resource
+					std::stringstream ss;
+
+					if( fileProcessingInnerStatusSettings.RequiresStatusUpdates() )
+					{
 						ss << "Processing file: "
 						   << filePathRelativeToInputDirectory.string()
-						   << ", Match filter: "
-						   << matchSection
-						   << ", Match path: "
-						   << matchPath;
+						   << " # "
+						   << filterMatchInformation;
+					}
 
-						StatusSettings resourceProcessGranular;
-						fileProcessingInnerStatusSettings.Update( CarbonResources::StatusProgressType::UNBOUNDED, 0, 0, ss.str(), &resourceProcessGranular );
+					StatusSettings resourceProcessGranular;
+					fileProcessingInnerStatusSettings.Update( CarbonResources::StatusProgressType::UNBOUNDED, 0, 0, ss.str(), &resourceProcessGranular );
 
-						// Process data via streaming
-						ResourceTools::FileDataStreamIn fileStreamIn( params.fileStreamChunkSize );
+					// Process the file data via streaming
+					ResourceTools::Md5ChecksumStream checksumStream;
 
-						ResourceTools::Md5ChecksumStream checksumStream;
+					std::filesystem::path resourceRelativePath = std::filesystem::relative( entryPath, inputDirectory );
 
-						std::filesystem::path resourceRelativePath = std::filesystem::relative( entry.path(), inputDirectory );
+                    std::string resourceRelativePathString = resourceRelativePath.generic_string();
 
-						if( !fileStreamIn.StartRead( entry.path() ) )
+                    if( ignoreCase )
+					{
+						std::transform( resourceRelativePathString.begin(), resourceRelativePathString.end(), resourceRelativePathString.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+					}
+
+					if( !fileStreamIn.StartRead( entryPath ) )
+					{
+						return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
+					}
+
+					// Calculate without compression to get checksum
+					while( !fileStreamIn.IsFinished() )
+					{
+						// Update status
+						if( resourceProcessGranular.RequiresStatusUpdates() )
+						{
+							float step = static_cast<float>( 100.0 / fileStreamIn.Size() );
+							float percentage = static_cast<float>( fileStreamIn.GetCurrentPosition() * step );
+							resourceProcessGranular.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentage, step, "Stream processing file attributes: " + entryPathString );
+						}
+
+						std::string fileData;
+
+						if( !( fileStreamIn >> fileData ) )
+						{
+							return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+						}
+
+						if( !( checksumStream << fileData ) )
+						{
+							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+						}
+					}
+
+					// Get Checksum
+					std::string checksum;
+
+					if( !checksumStream.FinishAndRetrieve( checksum ) )
+					{
+						return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+					}
+
+					// Create resource from parameters
+					ResourceInfoParams resourceParams;
+
+					resourceParams.relativePath = resourceRelativePathString;
+
+					resourceParams.prefix = params.resourcePrefix;
+
+					resourceParams.uncompressedSize = entry.file_size();
+
+					resourceParams.compressedSize = 0; // If required this will be calculated later
+
+					resourceParams.checksum = checksum;
+
+					if( params.calculateBinaryOperation )
+					{
+						resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entryPath );
+					}
+
+					Location location;
+
+					Result calculateLocationResult = location.SetFromRelativePathAndDataChecksum( resourceParams.relativePath, resourceParams.checksum, resourceParams.prefix );
+
+					if( calculateLocationResult.type != ResultType::SUCCESS )
+					{
+						return calculateLocationResult;
+					}
+
+					resourceParams.location = location.ToString();
+
+					ResourceInfo resource( resourceParams );
+
+					// If resource already exists in other include path then skip this resource
+					if( checkedRelativePaths.find( resourceRelativePathString ) != checkedRelativePaths.end() )
+					{
+						resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Skipping file as it was found in multiple paths: " + entryPathString );
+						continue;
+					}
+					else
+					{
+						checkedRelativePaths[resourceRelativePathString] = 1;
+					}
+
+					// Setup export
+					std::filesystem::path resourceDestinationPath;
+
+					Result constructDestinationPathResult = resource.GetDestinationPath( params.exportSettings.destinationSettings, resourceDestinationPath );
+
+					if( constructDestinationPathResult.type != ResultType::SUCCESS )
+					{
+						return constructDestinationPathResult;
+					}
+
+					// If further calculation is required on the data then calculate here
+					if( params.compressionCalculationSettings.calculateCompressions || params.exportSettings.enabled )
+					{
+						if( !fileStreamIn.StartRead( entryPath ) )
 						{
 							return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
 						}
 
-						// Calculate without compression to get checksum
-						while( !fileStreamIn.IsFinished() )
-						{
-							// Update status
-							if( resourceProcessGranular.RequiresStatusUpdates() )
-							{
-								float step = static_cast<float>( 100.0 / fileStreamIn.Size() );
-								float percentage = static_cast<float>( fileStreamIn.GetCurrentPosition() * step );
-								resourceProcessGranular.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentage, step, "Stream processing file attributes: " + entry.path().string() );
-							}
+						ResourceTools::FileDataStreamOut exportResourceDataStreamOut;
 
-							std::string fileData;
-
-							if( !( fileStreamIn >> fileData ) )
-							{
-								return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-							}
-
-							if( !( checksumStream << fileData ) )
-							{
-								return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-							}
-						}
-
-						// Get Checksum
-						std::string checksum;
-
-						if( !checksumStream.FinishAndRetrieve( checksum ) )
-						{
-							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-						}
-
-						// Create resource from parameters
-						ResourceInfoParams resourceParams;
-
-						resourceParams.relativePath = resourceRelativePath;
-
-						resourceParams.prefix = params.resourcePrefix;
-
-						resourceParams.uncompressedSize = entry.file_size();
-
-						resourceParams.compressedSize = 0; // If required this will be calculated later
-
-						resourceParams.checksum = checksum;
-
-						if( params.calculateBinaryOperation )
-						{
-							resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entry.path() );
-						}
-
-						Location l;
-
-						// Document version 0 requires lowercase relative paths
-						std::string relativePathNormalised = resourceParams.relativePath.string();
-						if( ( params.outputDocumentVersion.major == 0 ) && ( params.outputDocumentVersion.minor == 0 ) && ( params.outputDocumentVersion.patch == 0 ) )
-						{
-							std::transform( relativePathNormalised.begin(), relativePathNormalised.end(), relativePathNormalised.begin(), []( unsigned char c ) { return std::tolower( c ); } );
-						}
-
-
-						Result calculateLocationResult = l.SetFromRelativePathAndDataChecksum( relativePathNormalised, resourceParams.checksum, resourceParams.prefix );
-
-						if( calculateLocationResult.type != ResultType::SUCCESS )
-						{
-							return calculateLocationResult;
-						}
-
-						resourceParams.location = l.ToString();
-
-						std::unique_ptr<ResourceInfo> resource;
-						resource = std::make_unique<ResourceInfo>( resourceParams );
-
-						// If resource already exists in other include path then skip this resource
-						if( ResourceExists( *resource ) )
-						{
-							resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Skipping file as it was found in multiple paths: " + entry.path().string() );
-							continue;
-						}
-
-						// Setup export
 						std::filesystem::path resourceDestinationPath;
 
-						Result constructDestinationPathResult = resource->GetDestinationPath( params.exportSettings.destinationSettings, resourceDestinationPath );
+						Result getDestionationResult = resource.GetDestinationPath( params.exportSettings.destinationSettings, resourceDestinationPath );
 
-						if( constructDestinationPathResult.type != ResultType::SUCCESS )
+						if( getDestionationResult.type != ResultType::SUCCESS )
 						{
-							return constructDestinationPathResult;
+							return getDestionationResult;
 						}
 
-						// If further calculation is required on the data then calculate here
-						if( params.compressionCalculationSettings.calculateCompressions || params.exportSettings.enabled )
+						std::string compressedData;
+
+						uintmax_t compressedDataSize = 0;
+
+						ResourceTools::GzipCompressionStream compressionStream( &compressedData );
+
+						// Compression will need to be calculated if specified or an exported resource requires it
+						bool calculateCompressions = params.compressionCalculationSettings.calculateCompressions;
+						bool exportResource = params.exportSettings.enabled;
+
+						// Check url for compression information if supplied
+						// If argument set to skip if file already exists in destination then
+						// Check for file and if to skip
+						if( params.compressionCalculationSettings.remoteUrlToAttemptToGetCompression != "" )
 						{
-							if( !fileStreamIn.StartRead( entry.path() ) )
+
+							std::string resourceUrl = params.compressionCalculationSettings.remoteUrlToAttemptToGetCompression.string() + "/" + resourceParams.location;
+
+							// Check if file exists in remote location
+							std::string response;
+
+							ResourceTools::Response downloadResponse;
+
+							downloadResponse = downloader.GetHeader( resourceUrl, params.compressionCalculationSettings.downloadSettings.retryCount, params.compressionCalculationSettings.downloadSettings.retrySeconds, response );
+
+							if( downloadResponse == ResourceTools::Response::SUCCESS )
+							{
+								resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Attempting to get compression data from remote: " + resourceUrl );
+
+								// Parse the header for the content size
+								std::string contentLengthStr;
+
+								if( ResourceTools::Downloader::GetAttributeValueFromHeader( response, "Content-Length", contentLengthStr ) )
+								{
+									// Parse content length
+									try
+									{
+										unsigned long in = std::stoul( contentLengthStr );
+										if( in > std::numeric_limits<uint32_t>::max() )
+										{
+											resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
+										}
+										else
+										{
+											// Compression is from the existing file rather than new one.
+											compressedDataSize = static_cast<uint32_t>( in );
+											calculateCompressions = false;
+											exportResource = false;
+										}
+									}
+									catch( std::invalid_argument& )
+									{
+										resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
+									}
+									catch( std::out_of_range& )
+									{
+										resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
+									}
+								}
+							}
+							else if( downloadResponse == ResourceTools::Response::DOWNLOAD_ERROR )
+							{
+								std::stringstream ss;
+
+								ss << "Error while downloading header from: "
+								   << resourceUrl
+								   << " Response:\n"
+								   << response;
+
+								return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
+							}
+
+							if( calculateCompressions )
+							{
+								resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Resource not found at remote location, compression calculation will continue: " + resourceUrl );
+							}
+						}
+
+						if( exportResource )
+						{
+							if( !exportResourceDataStreamOut.StartWrite( resourceDestinationPath ) )
 							{
 								return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
 							}
+						}
 
-							ResourceTools::FileDataStreamOut exportResourceDataStreamOut;
+						if( ( exportResource && params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN ) )
+						{
+							calculateCompressions = true;
+						}
 
-							std::filesystem::path resourceDestinationPath;
-
-							Result getDestionationResult = resource->GetDestinationPath( params.exportSettings.destinationSettings, resourceDestinationPath );
-
-							if( getDestionationResult.type != ResultType::SUCCESS )
+						if( calculateCompressions )
+						{
+							if( !compressionStream.Start() )
 							{
-								return getDestionationResult;
+								return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
 							}
+						}
 
-							std::string compressedData;
-
-							uintmax_t compressedDataSize = 0;
-
-							ResourceTools::GzipCompressionStream compressionStream( &compressedData );
-
-							// Compression will need to be calculated if specified or an exported resource requires it
-							bool calculateCompressions = params.compressionCalculationSettings.calculateCompressions;
-							bool exportResource = params.exportSettings.enabled;
-
-							// Check url for compression information if supplied
-							// If argument set to skip if file already exists in destination then
-							// Check for file and if to skip
-							if( params.compressionCalculationSettings.remoteUrlToAttemptToGetCompression != "" )
+						if( calculateCompressions || exportResource )
+						{
+							while( !fileStreamIn.IsFinished() )
 							{
-
-								std::string location;
-
-								Result getLocationResult = resource->GetLocation( location );
-
-								if( getLocationResult.type != ResultType::SUCCESS )
+								// Update status
+								if( resourceProcessGranular.RequiresStatusUpdates() )
 								{
-									return getLocationResult;
-								}
+									float step = static_cast<float>( 100.0 / fileStreamIn.Size() );
+									float percentage = static_cast<float>( fileStreamIn.GetCurrentPosition() * step );
 
-								std::string resourceUrl = params.compressionCalculationSettings.remoteUrlToAttemptToGetCompression.string() + "/" + location;
-								std::replace( resourceUrl.begin(), resourceUrl.end(), '\\', '/' );
-
-								// Check if file exists in remote location
-								ResourceTools::Downloader downloader;
-
-								std::string response;
-
-								ResourceTools::Response downloadResponse;
-
-								downloadResponse = downloader.GetHeader( resourceUrl, params.compressionCalculationSettings.downloadSettings.retryCount, params.compressionCalculationSettings.downloadSettings.retrySeconds, response );
-
-								if( downloadResponse == ResourceTools::Response::SUCCESS )
-								{
-									resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Attempting to get compression data from remote: " + resourceUrl );
-
-									// Parse the header for the content size
-									std::string contentLengthStr;
-
-									if( ResourceTools::Downloader::GetAttributeValueFromHeader( response, "Content-Length", contentLengthStr ) )
+									std::string info;
+									if( calculateCompressions )
 									{
-										// Parse content length
-										try
-										{
-											unsigned long in = std::stoul( contentLengthStr );
-											if( in > std::numeric_limits<uint32_t>::max() )
-											{
-												resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
-											}
-											else
-											{
-												// Compression is from the existing file rather than new one.
-												compressedDataSize = static_cast<uint32_t>( in );
-												calculateCompressions = false;
-												exportResource = false;
-											}
-										}
-										catch( std::invalid_argument& )
-										{
-											resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
-										}
-										catch( std::out_of_range& )
-										{
-											resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
-										}
+										info += "Compressing";
 									}
+
+									if( exportResource )
+									{
+										if( info != "" )
+										{
+											info += " & ";
+										}
+
+										info += "Exporting";
+									}
+
+									info += " Resource: ";
+
+									resourceProcessGranular.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentage, step, info + entryPathString );
 								}
-								else if( downloadResponse == ResourceTools::Response::DOWNLOAD_ERROR )
+
+								std::string fileData;
+
+								if( !( fileStreamIn >> fileData ) )
 								{
-									std::stringstream ss;
-
-									ss << "Error while downloading header from: "
-									   << resourceUrl
-									   << " Response:\n"
-									   << response;
-
-									return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
+									return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
 								}
 
 								if( calculateCompressions )
 								{
-									resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Resource not found at remote location, compression calculation will continue: " + resourceUrl );
-								}
-							}
-
-							if( exportResource )
-							{
-								if( !exportResourceDataStreamOut.StartWrite( resourceDestinationPath ) )
-								{
-									return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
-								}
-							}
-
-							if( ( exportResource && params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN ) )
-							{
-								calculateCompressions = true;
-							}
-
-							if( calculateCompressions )
-							{
-								if( !compressionStream.Start() )
-								{
-									return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
-								}
-							}
-
-							if( calculateCompressions || exportResource )
-							{
-								while( !fileStreamIn.IsFinished() )
-								{
-									// Update status
-									if( resourceProcessGranular.RequiresStatusUpdates() )
+									if( !( compressionStream << &fileData ) )
 									{
-										float step = static_cast<float>( 100.0 / fileStreamIn.Size() );
-										float percentage = static_cast<float>( fileStreamIn.GetCurrentPosition() * step );
-
-										std::string info;
-										if( calculateCompressions )
-										{
-											info += "Compressing";
-										}
-
-										if( exportResource )
-										{
-											if( info != "" )
-											{
-												info += " & ";
-											}
-
-											info += "Exporting";
-										}
-
-										info += " Resource: ";
-
-										resourceProcessGranular.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentage, step, info + entry.path().string() );
+										return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
 									}
+								}
 
-									std::string fileData;
-
-									if( !( fileStreamIn >> fileData ) )
+								// If exporting resource then export the correct data
+								if( exportResource )
+								{
+									if( params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::LOCAL_CDN || params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
 									{
-										return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-									}
-
-									if( calculateCompressions )
-									{
-										if( !( compressionStream << &fileData ) )
+										// Output Uncompressed Data
+										if( !( exportResourceDataStreamOut << fileData ) )
 										{
-											return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+											return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
 										}
 									}
-
-									// If exporting resource then export the correct data
-									if( exportResource )
+									else
 									{
-										if( params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::LOCAL_CDN || params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
+										// Output Compressed Data
+										if( !( exportResourceDataStreamOut << compressedData ) )
 										{
-											// Output Uncompressed Data
-											if( !( exportResourceDataStreamOut << fileData ) )
-											{
-												return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-											}
-										}
-										else
-										{
-											// Output Compressed Data
-											if( !( exportResourceDataStreamOut << compressedData ) )
-											{
-												return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-											}
+											return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
 										}
 									}
-
-									compressedDataSize += compressedData.size();
-									compressedData.clear();
-								}
-							}
-
-							// Finish stream read in
-							fileStreamIn.Finish();
-
-							if( calculateCompressions )
-							{
-								if( !compressionStream.Finish() )
-								{
-									return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
 								}
 
-								// Add remaining compression data
 								compressedDataSize += compressedData.size();
-							}
-
-							if( params.compressionCalculationSettings.calculateCompressions )
-							{
-								// Set compressed size only if compression is calculated
-								// If export requires compression but calculation is skipped
-								// Then the calculations are not set as this may be unexpected
-								resource->SetCompressedSize( compressedDataSize );
-							}
-
-							if( exportResource )
-							{
-								if( params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
-								{
-									// Add remaining compression data
-									if( !( exportResourceDataStreamOut << compressedData ) )
-									{
-										return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-									}
-								}
-
-								if( !exportResourceDataStreamOut.Finish() )
-								{
-									return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-								}
+								compressedData.clear();
 							}
 						}
 
-						// Add resource to group
-						Result addResourceResult = AddResource( resource.release() );
+						// Finish stream read in
+						fileStreamIn.Finish();
 
-						if( addResourceResult.type != ResultType::SUCCESS )
+						if( calculateCompressions )
 						{
-							return addResourceResult;
+							if( !compressionStream.Finish() )
+							{
+								return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+							}
+
+							// Add remaining compression data
+							compressedDataSize += compressedData.size();
+						}
+
+						if( params.compressionCalculationSettings.calculateCompressions )
+						{
+							// Set compressed size only if compression is calculated
+							// If export requires compression but calculation is skipped
+							// Then the calculations are not set as this may be unexpected
+							resource.SetCompressedSize( compressedDataSize );
+						}
+
+						if( exportResource )
+						{
+							if( params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
+							{
+								// Add remaining compression data
+								if( !( exportResourceDataStreamOut << compressedData ) )
+								{
+									return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+								}
+							}
+
+							if( !exportResourceDataStreamOut.Finish() )
+							{
+								return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+							}
 						}
 					}
-				}
 
-				if( !params.compressionCalculationSettings.calculateCompressions )
-				{
-					m_totalResourcesSizeCompressed.Reset();
+					// Add entry to all relevant resource groups
+					for( auto& filterGroup : matchedFilters )
+					{
+						// Resource group takes ownership of resource info
+						filterGroup->resourceGroup->AddResource( new ResourceInfo( resource ) );
+					}
 				}
 			}
 		}

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -10,6 +10,7 @@
 #include <CompressedFileDataStreamOut.h>
 #include <Md5ChecksumStream.h>
 #include <GzipCompressionStream.h>
+#include <cctype>
 #include "ResourceInfo/PatchResourceGroupInfo.h"
 #include "ResourceInfo/BundleResourceGroupInfo.h"
 #include "ResourceInfo/ResourceGroupInfo.h"
@@ -19,6 +20,7 @@
 #include "BundleResourceGroupImpl.h"
 #include "ChunkIndex.h"
 #include "ResourceGroupFactory.h"
+#include "ResourceFilter.h"
 
 namespace CarbonResources
 {
@@ -149,7 +151,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromDirectory( const CreateResour
 
 					ResourceTools::GzipCompressionStream compressionStream( &compressedData );
 
-					ResourceTools::FileDataStreamIn fileStreamIn( params.resourceStreamThreshold );
+					ResourceTools::FileDataStreamIn fileStreamIn( params.fileStreamChunkSize );
 
 					if( params.calculateCompressions )
 					{
@@ -327,6 +329,543 @@ Result ResourceGroup::ResourceGroupImpl::CreateFromDirectory( const CreateResour
 	}
 
 	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::CreateFromFilter( const CreateResourceGroupFromFilterParams& params, StatusSettings& statusSettings )
+{
+	// Update status
+	statusSettings.Update( StatusProgressType::PERCENTAGE, 0, 5, "Creating resource group from filters" );
+
+	// Ensure document version is valid
+	VersionInternal documentVersion( params.outputDocumentVersion );
+
+	if( !documentVersion.isVersionValid() )
+	{
+		return Result{ ResultType::DOCUMENT_VERSION_UNSUPPORTED };
+	}
+
+	// Initialize ResourceFilter
+	if( params.filterSettings.filterFilePaths.empty() )
+	{
+		std::string errorMsg = "No filter files provided.";
+		return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER, errorMsg };
+	}
+
+	statusSettings.Update( StatusProgressType::PERCENTAGE, 0, 5, "Loading filter files" );
+
+	std::vector<std::unique_ptr<ResourceTools::ResourceFilter>> filters;
+
+	for( auto filterPath : params.filterSettings.filterFilePaths )
+	{
+		// Get filter file data
+		std::string filterData;
+
+		if( !ResourceTools::GetLocalFileData( filterPath, filterData ) )
+		{
+			std::string errorMsg = "Failed to open filter file: " + filterPath.string();
+			return Result{ ResultType::FAILED_TO_OPEN_FILE, errorMsg };
+		}
+
+		ResourceTools::FilterFile fileData;
+
+		try
+		{
+			ResourceTools::FilterFileReader::LoadFromIniFileData( filterData.data(), filterData.size(), fileData );
+		}
+		catch( const std::exception& e )
+		{
+			std::string errorMsg = "Failed to read filter file: " + std::string( e.what() );
+
+			return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER, errorMsg };
+		}
+
+		std::unique_ptr<ResourceTools::ResourceFilter> filter = std::make_unique<ResourceTools::ResourceFilter>();
+
+		if( !filter->SetFromFilterFileData( fileData ) )
+		{
+			return Result{ ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER };
+		}
+
+		filters.emplace_back( std::move( filter ) );
+	}
+
+	// Populate the directories from the filter files
+	std::vector<std::filesystem::path> searchPaths;
+
+	for( auto& filter : filters )
+	{
+		const std::vector<std::filesystem::path>& filterPaths = filter->GetPrefixPaths();
+
+		for( auto& filterPath : filterPaths )
+		{
+			searchPaths.push_back( filterPath );
+		}
+	}
+
+	// Process all directories
+	// Apply filters if supplied
+	{
+		StatusSettings inputDirectoryStatus;
+		statusSettings.Update( StatusProgressType::PERCENTAGE, 10, 90, "Creating resource group from directories", &inputDirectoryStatus );
+
+		int i = 0;
+		for( auto searchPath : searchPaths )
+		{
+			std::filesystem::path inputDirectory = params.filterSettings.prefixMapBasePath / searchPath;
+
+			StatusSettings fileProcessingInnerStatusSettings;
+
+			if( inputDirectoryStatus.RequiresStatusUpdates() )
+			{
+				float step = static_cast<float>( 100.0 / searchPaths.size() );
+				float progress = static_cast<float>( i * step );
+				i++;
+				inputDirectoryStatus.Update( StatusProgressType::PERCENTAGE, progress, step, "Processing Directory: " + inputDirectory.string(), &fileProcessingInnerStatusSettings );
+			}
+
+			if( !std::filesystem::exists( inputDirectory ) )
+			{
+				if( params.skipNonExistentInputDirectories )
+				{
+					inputDirectoryStatus.Update( StatusProgressType::WARNING, 0, 0, "Skipping input directory as it doesn't exist." );
+
+					continue;
+				}
+				else
+				{
+					return Result{ ResultType::INPUT_DIRECTORY_DOESNT_EXIST, inputDirectory.string() };
+				}
+			}
+
+			// Walk directory and create a resource from each file using data
+			auto recursiveDirectoryIter = std::filesystem::recursive_directory_iterator( inputDirectory );
+			{
+
+				for( const std::filesystem::directory_entry& entry : recursiveDirectoryIter )
+				{
+					if( entry.is_regular_file() )
+					{
+						std::filesystem::path filePathRelativeToInputDirectory = std::filesystem::relative( entry.path(), params.filterSettings.prefixMapBasePath );
+
+						bool filterMatchDetected = false;
+						std::string matchSection = "";
+						std::string matchPath = "";
+						for( auto& filter : filters )
+						{
+							// Ensure that the search path is relevant to the filter
+							const std::vector<std::filesystem::path>& filterSearchPaths = filter->GetPrefixPaths();
+
+							bool searchPathInFilter = false;
+
+							for( auto& filterPath : filterSearchPaths )
+							{
+								if( searchPath == filterPath )
+								{
+									searchPathInFilter = true;
+									break;
+								}
+							}
+
+							if( !searchPathInFilter )
+							{
+								// The current search path isn't one that is present in the current filter
+								continue;
+							}
+
+							if( filter->CheckPath( filePathRelativeToInputDirectory, matchSection, matchPath ) )
+							{
+								filterMatchDetected = true;
+								break;
+							}
+						}
+
+						if( !filterMatchDetected )
+						{
+							//File doesn't meet any of the filters
+							fileProcessingInnerStatusSettings.Update( CarbonResources::StatusProgressType::UNBOUNDED, 0, 0, "Skipping File that didn't match filters: " + entry.path().string() );
+							continue;
+						}
+
+						// Create resource
+						std::stringstream ss;
+
+						ss << "Processing file: "
+						   << filePathRelativeToInputDirectory.string()
+						   << ", Match filter: "
+						   << matchSection
+						   << ", Match path: "
+						   << matchPath;
+
+						StatusSettings resourceProcessGranular;
+						fileProcessingInnerStatusSettings.Update( CarbonResources::StatusProgressType::UNBOUNDED, 0, 0, ss.str(), &resourceProcessGranular );
+
+						// Process data via streaming
+						ResourceTools::FileDataStreamIn fileStreamIn( params.fileStreamChunkSize );
+
+						ResourceTools::Md5ChecksumStream checksumStream;
+
+						std::filesystem::path resourceRelativePath = std::filesystem::relative( entry.path(), inputDirectory );
+
+						if( !fileStreamIn.StartRead( entry.path() ) )
+						{
+							return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
+						}
+
+						// Calculate without compression to get checksum
+						while( !fileStreamIn.IsFinished() )
+						{
+							// Update status
+							if( resourceProcessGranular.RequiresStatusUpdates() )
+							{
+								float step = static_cast<float>( 100.0 / fileStreamIn.Size() );
+								float percentage = static_cast<float>( fileStreamIn.GetCurrentPosition() * step );
+								resourceProcessGranular.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentage, step, "Stream processing file attributes: " + entry.path().string() );
+							}
+
+							std::string fileData;
+
+							if( !( fileStreamIn >> fileData ) )
+							{
+								return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+							}
+
+							if( !( checksumStream << fileData ) )
+							{
+								return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+							}
+						}
+
+						// Get Checksum
+						std::string checksum;
+
+						if( !checksumStream.FinishAndRetrieve( checksum ) )
+						{
+							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+						}
+
+						// Create resource from parameters
+						ResourceInfoParams resourceParams;
+
+						resourceParams.relativePath = resourceRelativePath;
+
+						resourceParams.prefix = params.resourcePrefix;
+
+						resourceParams.uncompressedSize = entry.file_size();
+
+						resourceParams.compressedSize = 0; // If required this will be calculated later
+
+						resourceParams.checksum = checksum;
+
+						if( params.calculateBinaryOperation )
+						{
+							resourceParams.binaryOperation = ResourceTools::CalculateBinaryOperation( entry.path() );
+						}
+
+						Location l;
+
+						// Document version 0 requires lowercase relative paths
+						std::string relativePathNormalised = resourceParams.relativePath.string();
+						if( ( params.outputDocumentVersion.major == 0 ) && ( params.outputDocumentVersion.minor == 0 ) && ( params.outputDocumentVersion.patch == 0 ) )
+						{
+							std::transform( relativePathNormalised.begin(), relativePathNormalised.end(), relativePathNormalised.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+						}
+
+
+						Result calculateLocationResult = l.SetFromRelativePathAndDataChecksum( relativePathNormalised, resourceParams.checksum, resourceParams.prefix );
+
+						if( calculateLocationResult.type != ResultType::SUCCESS )
+						{
+							return calculateLocationResult;
+						}
+
+						resourceParams.location = l.ToString();
+
+						std::unique_ptr<ResourceInfo> resource;
+						resource = std::make_unique<ResourceInfo>( resourceParams );
+
+						// If resource already exists in other include path then skip this resource
+						if( ResourceExists( *resource ) )
+						{
+							resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Skipping file as it was found in multiple paths: " + entry.path().string() );
+							continue;
+						}
+
+						// Setup export
+						std::filesystem::path resourceDestinationPath;
+
+						Result constructDestinationPathResult = resource->GetDestinationPath( params.exportSettings.destinationSettings, resourceDestinationPath );
+
+						if( constructDestinationPathResult.type != ResultType::SUCCESS )
+						{
+							return constructDestinationPathResult;
+						}
+
+						// If further calculation is required on the data then calculate here
+						if( params.compressionCalculationSettings.calculateCompressions || params.exportSettings.enabled )
+						{
+							if( !fileStreamIn.StartRead( entry.path() ) )
+							{
+								return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
+							}
+
+							ResourceTools::FileDataStreamOut exportResourceDataStreamOut;
+
+							std::filesystem::path resourceDestinationPath;
+
+							Result getDestionationResult = resource->GetDestinationPath( params.exportSettings.destinationSettings, resourceDestinationPath );
+
+							if( getDestionationResult.type != ResultType::SUCCESS )
+							{
+								return getDestionationResult;
+							}
+
+							std::string compressedData;
+
+							uintmax_t compressedDataSize = 0;
+
+							ResourceTools::GzipCompressionStream compressionStream( &compressedData );
+
+							// Compression will need to be calculated if specified or an exported resource requires it
+							bool calculateCompressions = params.compressionCalculationSettings.calculateCompressions;
+							bool exportResource = params.exportSettings.enabled;
+
+							// Check url for compression information if supplied
+							// If argument set to skip if file already exists in destination then
+							// Check for file and if to skip
+							if( params.compressionCalculationSettings.remoteUrlToAttemptToGetCompression != "" )
+							{
+
+								std::string location;
+
+								Result getLocationResult = resource->GetLocation( location );
+
+								if( getLocationResult.type != ResultType::SUCCESS )
+								{
+									return getLocationResult;
+								}
+
+								std::string resourceUrl = params.compressionCalculationSettings.remoteUrlToAttemptToGetCompression.string() + "/" + location;
+								std::replace( resourceUrl.begin(), resourceUrl.end(), '\\', '/' );
+
+								// Check if file exists in remote location
+								ResourceTools::Downloader downloader;
+
+								std::string response;
+
+								ResourceTools::Response downloadResponse;
+
+								downloadResponse = downloader.GetHeader( resourceUrl, params.compressionCalculationSettings.downloadSettings.retryCount, params.compressionCalculationSettings.downloadSettings.retrySeconds, response );
+
+								if( downloadResponse == ResourceTools::Response::SUCCESS )
+								{
+									resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Attempting to get compression data from remote: " + resourceUrl );
+
+									// Parse the header for the content size
+									std::string contentLengthStr;
+
+									if( ResourceTools::Downloader::GetAttributeValueFromHeader( response, "Content-Length", contentLengthStr ) )
+									{
+										// Parse content length
+										try
+										{
+											unsigned long in = std::stoul( contentLengthStr );
+											if( in > std::numeric_limits<uint32_t>::max() )
+											{
+												resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
+											}
+											else
+											{
+												// Compression is from the existing file rather than new one.
+												compressedDataSize = static_cast<uint32_t>( in );
+												calculateCompressions = false;
+												exportResource = false;
+											}
+										}
+										catch( std::invalid_argument& )
+										{
+											resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
+										}
+										catch( std::out_of_range& )
+										{
+											resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Invalid compression data from header information, compression will be calculated." + resourceUrl );
+										}
+									}
+								}
+								else if( downloadResponse == ResourceTools::Response::DOWNLOAD_ERROR )
+								{
+									std::stringstream ss;
+
+									ss << "Error while downloading header from: "
+									   << resourceUrl
+									   << " Response:\n"
+									   << response;
+
+									return Result{ ResultType::FAILED_TO_DOWNLOAD_FILE, ss.str() };
+								}
+
+								if( calculateCompressions )
+								{
+									resourceProcessGranular.Update( CarbonResources::StatusProgressType::WARNING, 0, 0, "Resource not found at remote location, compression calculation will continue: " + resourceUrl );
+								}
+							}
+
+							if( exportResource )
+							{
+								if( !exportResourceDataStreamOut.StartWrite( resourceDestinationPath ) )
+								{
+									return Result{ ResultType::FAILED_TO_OPEN_FILE_STREAM };
+								}
+							}
+
+							if( ( exportResource && params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN ) )
+							{
+								calculateCompressions = true;
+							}
+
+							if( calculateCompressions )
+							{
+								if( !compressionStream.Start() )
+								{
+									return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+								}
+							}
+
+							if( calculateCompressions || exportResource )
+							{
+								while( !fileStreamIn.IsFinished() )
+								{
+									// Update status
+									if( resourceProcessGranular.RequiresStatusUpdates() )
+									{
+										float step = static_cast<float>( 100.0 / fileStreamIn.Size() );
+										float percentage = static_cast<float>( fileStreamIn.GetCurrentPosition() * step );
+
+										std::string info;
+										if( calculateCompressions )
+										{
+											info += "Compressing";
+										}
+
+										if( exportResource )
+										{
+											if( info != "" )
+											{
+												info += " & ";
+											}
+
+											info += "Exporting";
+										}
+
+										info += " Resource: ";
+
+										resourceProcessGranular.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentage, step, info + entry.path().string() );
+									}
+
+									std::string fileData;
+
+									if( !( fileStreamIn >> fileData ) )
+									{
+										return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+									}
+
+									if( calculateCompressions )
+									{
+										if( !( compressionStream << &fileData ) )
+										{
+											return Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+										}
+									}
+
+									// If exporting resource then export the correct data
+									if( exportResource )
+									{
+										if( params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::LOCAL_CDN || params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
+										{
+											// Output Uncompressed Data
+											if( !( exportResourceDataStreamOut << fileData ) )
+											{
+												return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+											}
+										}
+										else
+										{
+											// Output Compressed Data
+											if( !( exportResourceDataStreamOut << compressedData ) )
+											{
+												return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+											}
+										}
+									}
+
+									compressedDataSize += compressedData.size();
+									compressedData.clear();
+								}
+							}
+
+							// Finish stream read in
+							fileStreamIn.Finish();
+
+							if( calculateCompressions )
+							{
+								if( !compressionStream.Finish() )
+								{
+									return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+								}
+
+								// Add remaining compression data
+								compressedDataSize += compressedData.size();
+							}
+
+							if( params.compressionCalculationSettings.calculateCompressions )
+							{
+								// Set compressed size only if compression is calculated
+								// If export requires compression but calculation is skipped
+								// Then the calculations are not set as this may be unexpected
+								resource->SetCompressedSize( compressedDataSize );
+							}
+
+							if( exportResource )
+							{
+								if( params.exportSettings.destinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
+								{
+									// Add remaining compression data
+									if( !( exportResourceDataStreamOut << compressedData ) )
+									{
+										return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+									}
+								}
+
+								if( !exportResourceDataStreamOut.Finish() )
+								{
+									return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+								}
+							}
+						}
+
+						// Add resource to group
+						Result addResourceResult = AddResource( resource.release() );
+
+						if( addResourceResult.type != ResultType::SUCCESS )
+						{
+							return addResourceResult;
+						}
+					}
+				}
+
+				if( !params.compressionCalculationSettings.calculateCompressions )
+				{
+					m_totalResourcesSizeCompressed.Reset();
+				}
+			}
+		}
+	}
+
+	return Result{ ResultType::SUCCESS };
+}
+
+bool ResourceGroup::ResourceGroupImpl::ResourceExists( ResourceInfo& resource )
+{
+	return m_resourcesParameter.Contains( &resource );
 }
 
 Result ResourceGroup::ResourceGroupImpl::ImportFromData( const std::string& data, StatusSettings& statusSettings, DocumentType documentType /* = DocumentType::YAML */ )

--- a/src/ResourceGroupImpl.h
+++ b/src/ResourceGroupImpl.h
@@ -44,7 +44,7 @@ enum class DocumentType
 	YAML
 };
 
-class ResourceGroup::ResourceGroupImpl;
+class ResourceGroupImpl;
 
 struct FilterGroup
 {

--- a/src/ResourceGroupImpl.h
+++ b/src/ResourceGroupImpl.h
@@ -133,8 +133,6 @@ private:
 
 	Result RemoveResource( ResourceInfo& relativePath );
 
-    bool ResourceExists( ResourceInfo& resource );
-
 protected:
 	// Document Parameters
 	DocumentParameter<VersionInternal> m_versionParameter = DocumentParameter<VersionInternal>( VERSION, TypeId() );

--- a/src/ResourceGroupImpl.h
+++ b/src/ResourceGroupImpl.h
@@ -8,6 +8,7 @@
 #include "ResourceGroup.h"
 #include "ResourceInfo/ResourceInfo.h"
 #include <vector>
+#include <ResourceFilter.h>
 
 #include "VersionInternal.h"
 #include "ResourceInfo/PatchResourceInfo.h"
@@ -43,6 +44,15 @@ enum class DocumentType
 	YAML
 };
 
+class ResourceGroup::ResourceGroupImpl;
+
+struct FilterGroup
+{
+	std::vector<std::unique_ptr<ResourceTools::ResourceFilter>> filters;
+
+	ResourceGroup::ResourceGroupImpl* resourceGroup;
+};
+
 class ResourceGroup::ResourceGroupImpl
 {
 public:
@@ -52,7 +62,7 @@ public:
 
 	Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params, StatusSettings& statusSettings );
 
-    Result CreateFromFilter( const CreateResourceGroupFromFilterParams& params, StatusSettings& statusSettings );
+    static Result CreateFromFilter( const CreateResourceGroupFromFilterParams& params, StatusSettings& statusSettings );
 
 	Result ImportFromFile( const ResourceGroupImportFromFileParams& params, StatusSettings& statusSettings );
 

--- a/src/ResourceGroupImpl.h
+++ b/src/ResourceGroupImpl.h
@@ -52,6 +52,8 @@ public:
 
 	Result CreateFromDirectory( const CreateResourceGroupFromDirectoryParams& params, StatusSettings& statusSettings );
 
+    Result CreateFromFilter( const CreateResourceGroupFromFilterParams& params, StatusSettings& statusSettings );
+
 	Result ImportFromFile( const ResourceGroupImportFromFileParams& params, StatusSettings& statusSettings );
 
 	Result ImportFromData( const std::string& data, StatusSettings& statusSettings, DocumentType documentType = DocumentType::YAML );
@@ -120,6 +122,8 @@ private:
 	Result ProcessChunk( ResourceTools::GetChunk& chunkData, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const;
 
 	Result RemoveResource( ResourceInfo& relativePath );
+
+    bool ResourceExists( ResourceInfo& resource );
 
 protected:
 	// Document Parameters

--- a/src/ResourceInfo/ResourceInfo.cpp
+++ b/src/ResourceInfo/ResourceInfo.cpp
@@ -41,7 +41,7 @@ Result Location::SetFromRelativePathAndDataChecksum( const std::filesystem::path
 
 	if( prefix != "" )
 	{
-		ss << ":/" << prefix;
+		ss << prefix  << ":/";
 	}
 
 	ss << relativePath.generic_string();
@@ -86,6 +86,34 @@ ResourceInfo::ResourceInfo( const ResourceInfoParams& params )
 	else
 	{
 		m_prefix.Reset();
+	}
+}
+
+ResourceInfo::ResourceInfo( const ResourceInfo& resourceInfo )
+{
+	m_relativePath = resourceInfo.m_relativePath;
+
+	m_location = resourceInfo.m_location;
+
+	m_type = resourceInfo.m_type;
+
+	m_checksum = resourceInfo.m_checksum;
+
+	if( resourceInfo.m_compressedSize.HasValue() )
+	{
+		m_compressedSize = resourceInfo.m_compressedSize;
+	}
+
+	m_uncompressedSize = resourceInfo.m_uncompressedSize;
+
+	if( resourceInfo.m_binaryOperation.HasValue() )
+	{
+		m_binaryOperation = resourceInfo.m_binaryOperation;
+	}
+
+	if( resourceInfo.m_prefix.HasValue() )
+	{
+		m_prefix = resourceInfo.m_prefix;
 	}
 }
 

--- a/src/ResourceInfo/ResourceInfo.cpp
+++ b/src/ResourceInfo/ResourceInfo.cpp
@@ -33,11 +33,20 @@ std::string Location::CalculateLocationFromChecksums( const std::string& relativ
 	return ss.str();
 }
 
-Result Location::SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum )
+Result Location::SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum, const std::string& prefix /*=""*/ )
 {
 	std::string relativePathChecksum = "";
 
-	if( !ResourceTools::GenerateFowlerNollVoChecksum( relativePath.generic_string(), relativePathChecksum ) )
+    std::stringstream ss;
+
+	if( prefix != "" )
+	{
+		ss << ":/" << prefix;
+	}
+
+	ss << relativePath.generic_string();
+
+	if( !ResourceTools::GenerateFowlerNollVoChecksum( ss.str(), relativePathChecksum ) )
 	{
 		return Result{ ResultType::FAILED_TO_GENERATE_RELATIVE_PATH_CHECKSUM };
 	}
@@ -199,6 +208,30 @@ Result ResourceInfo::GetCompressedSize( uintmax_t& compressedSize ) const
 
 		return Result{ ResultType::SUCCESS };
 	}
+}
+
+Result ResourceInfo::GetDestinationPath( const ResourceDestinationSettings& destinationSettings, std::filesystem::path& path ) const
+{
+	switch( destinationSettings.destinationType )
+	{
+	case ResourceDestinationType::LOCAL_RELATIVE:
+
+		path = destinationSettings.basePath / m_relativePath.GetValue();
+
+		break;
+
+	case ResourceDestinationType::LOCAL_CDN:
+	case ResourceDestinationType::REMOTE_CDN:
+
+		path = destinationSettings.basePath / m_location.GetValue().ToString();
+
+		break;
+
+	default:
+		return Result{ ResultType::FAIL };
+	}
+
+	return Result{ ResultType::SUCCESS };
 }
 
 Result ResourceInfo::PutDataStream( ResourcePutDataStreamParams& params ) const

--- a/src/ResourceInfo/ResourceInfo.h
+++ b/src/ResourceInfo/ResourceInfo.h
@@ -277,6 +277,8 @@ class ResourceInfo
 public:
 	ResourceInfo( const ResourceInfoParams& params );
 
+    ResourceInfo( const ResourceInfo& resourceInfo );
+
 	virtual ~ResourceInfo();
 
 	void SetRelativePath( const std::filesystem::path& relativePath );

--- a/src/ResourceInfo/ResourceInfo.h
+++ b/src/ResourceInfo/ResourceInfo.h
@@ -199,7 +199,7 @@ public:
 	{
 	}
 
-	Result SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum );
+	Result SetFromRelativePathAndDataChecksum( const std::filesystem::path& relativePath, const std::string& dataChecksum, const std::string& prefix = "" );
 
 	std::string ToString()
 	{
@@ -328,6 +328,8 @@ public:
 	bool operator<( const ResourceInfo& other ) const;
 
 	static std::string TypeId();
+
+    Result GetDestinationPath( const ResourceDestinationSettings& destinationSettings, std::filesystem::path& path ) const;
 
 private:
 	Result GetDataLocalRelative( ResourceGetDataParams& params, const int basePathId ) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ set(SRC_FILES
         src/ResourcesLibraryTest.cpp
         src/ResourcesCliTest.cpp
         src/ResourceToolsLibraryTest.cpp
+        src/ResourceToolsFilterTest.cpp
+        src/ResourceToolsTest.h
 )
 
 add_executable(resources-test ${SRC_FILES})

--- a/tests/src/ResourceToolsFilterTest.cpp
+++ b/tests/src/ResourceToolsFilterTest.cpp
@@ -45,15 +45,15 @@ TEST_F(ResourceToolsTest, Filtering_LoadValidFilterFile)
 	
 	}
 
-    auto prefixIter = fileData.prefixes.find( "prefix1" );
+    ASSERT_NE( fileData.prefixes.size(), 0 );
 
-    ASSERT_NE( prefixIter, fileData.prefixes.end() );
+    std::shared_ptr<ResourceTools::Prefix> prefix = *fileData.prefixes.begin();
 
-    EXPECT_EQ( prefixIter->second->id, "prefix1" );
+    EXPECT_EQ( prefix->id, "prefix1" );
 
-    ASSERT_EQ( prefixIter->second->paths.size(), 1 );
+    ASSERT_EQ( prefix->paths.size(), 1 );
 
-    EXPECT_EQ( prefixIter->second->paths.at( 0 ), "." );
+    EXPECT_EQ( prefix->paths.at( 0 ), "." );
 
     ASSERT_EQ( fileData.filterSections.size(), 1 );
 
@@ -252,6 +252,10 @@ TEST_F( ResourceToolsTest, Filtering_FilterOverlappingIncludeExcludeRule1 )
 
 	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
 
+    std::filesystem::path invalidPath2 = "File.type2";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath2 ) );
+
 }
 
 TEST_F( ResourceToolsTest, Filtering_FilterOverlappingIncludeExcludeRule2 )
@@ -270,6 +274,10 @@ TEST_F( ResourceToolsTest, Filtering_FilterOverlappingIncludeExcludeRule2 )
 	std::filesystem::path invalidPath = "File.type1";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+
+    std::filesystem::path invalidPath2 = "File.type2";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath2 ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_FilterRespathExcludeRule )
@@ -287,6 +295,10 @@ TEST_F( ResourceToolsTest, Filtering_FilterRespathExcludeRule )
 	std::filesystem::path invalidPath = "File";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+
+    std::filesystem::path validPath = "Another";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_FilterRespathIncludeRule )
@@ -304,6 +316,10 @@ TEST_F( ResourceToolsTest, Filtering_FilterRespathIncludeRule )
 	std::filesystem::path validPath = "File";
 
 	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+
+    std::filesystem::path invalidPath = "Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_FilterIncludeRuleWithOverlappingRespathExcludeRule )
@@ -322,6 +338,10 @@ TEST_F( ResourceToolsTest, Filtering_FilterIncludeRuleWithOverlappingRespathExcl
 	std::filesystem::path invalidPath = "File";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+
+    std::filesystem::path invalidPath2 = "Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath2 ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_FilterExcludeRuleWithOverlappingRespathIncludeRule )
@@ -340,6 +360,10 @@ TEST_F( ResourceToolsTest, Filtering_FilterExcludeRuleWithOverlappingRespathIncl
 	std::filesystem::path invalidPath = "File";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+
+    std::filesystem::path invalidPath2 = "Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath2 ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_MultiPrefixMatch )
@@ -385,6 +409,14 @@ TEST_F( ResourceToolsTest, Filtering_MultiPrefixExcludeAppliesAcrossBoth )
 	std::filesystem::path prefix2InvalidPath = "Path2/File";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( prefix2InvalidPath ) );
+
+    std::filesystem::path prefix1ValidPath = "Path1/Another";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix1ValidPath ) );
+
+	std::filesystem::path prefix2ValidPath = "Path2/Another";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix2ValidPath ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_MultiPrefixIncludeAppliesAcrossBoth )
@@ -408,6 +440,14 @@ TEST_F( ResourceToolsTest, Filtering_MultiPrefixIncludeAppliesAcrossBoth )
 	std::filesystem::path prefix2ValidPath = "Path2/File";
 
 	ASSERT_TRUE( resourceFilter.CheckPath( prefix2ValidPath ) );
+
+    std::filesystem::path prefix1InvalidPath = "Path1/Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix1InvalidPath ) );
+
+	std::filesystem::path prefix2inValidPath = "Path2/Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix2inValidPath ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeOverrideExcludeAppliesAccrossBoth )
@@ -431,6 +471,14 @@ TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeOverrideExcludeAppl
 	std::filesystem::path prefix2InvalidPath = "Path2/File";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( prefix2InvalidPath ) );
+
+    std::filesystem::path prefix1InvalidPath2 = "Path1/Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix1InvalidPath2 ) );
+
+	std::filesystem::path prefix2InvalidPath2 = "Path2/Another";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix2InvalidPath2 ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeAddedPathIncludeAppliesToLaterPaths )
@@ -505,7 +553,8 @@ TEST_F( ResourceToolsTest, Filtering_SpecificFileWithNonMatchingExclude )
 	std::string iniFile = "[DEFAULT]\n"
 						  "prefixmap = prefix1:.\n"
 						  "[testSection]\n"
-						  "respaths = prefix1:/File ![ NONMatch ]";
+						  "respaths = prefix1:/File ![ NONMatch ]\n"
+	                      "           prefix1:/File2";
 
 
 	ResourceTools::ResourceFilter resourceFilter;
@@ -515,6 +564,10 @@ TEST_F( ResourceToolsTest, Filtering_SpecificFileWithNonMatchingExclude )
 	std::filesystem::path invalidPath = "File";
 
 	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+
+    std::filesystem::path validPath = "File2";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
 }
 
 TEST_F( ResourceToolsTest, Filtering_SpecificFileWithOverlappingExcludeRule )

--- a/tests/src/ResourceToolsFilterTest.cpp
+++ b/tests/src/ResourceToolsFilterTest.cpp
@@ -1,0 +1,558 @@
+// Copyright © 2025 CCP ehf.
+
+#include "ResourceToolsTest.h"
+
+#include "FilterFileReader.h"
+#include "ResourceFilter.h"
+
+void LoadResourceFilterFromIniFileData(const std::string& iniData, ResourceTools::ResourceFilter& resourceFilter)
+{
+	try
+	{
+		ResourceTools::FilterFile fileData;
+
+		ResourceTools::FilterFileReader::LoadFromIniFileData( iniData.data(), iniData.size(), fileData );
+
+        EXPECT_TRUE(resourceFilter.SetFromFilterFileData( fileData ));
+	}
+	catch( const std::exception& e )
+	{
+		std::string errorMsg = "Failed to read filter file: " + std::string( e.what() );
+
+		FAIL() << errorMsg;
+	}
+}
+
+TEST_F(ResourceToolsTest, Filtering_LoadValidFilterFile)
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+                          "[testSection]\n"
+                          "filter = [.type1] ![.type2]\n"
+                          "respaths = prefix1:/* [.type3] ![.type4]";
+
+    ResourceTools::FilterFile fileData;
+
+    try
+    {
+		ResourceTools::FilterFileReader::LoadFromIniFileData( iniFile.data(), iniFile.size(), fileData );
+    }
+	catch( const std::exception& e )
+	{
+		std::string errorMsg = "Failed to read filter file: " + std::string( e.what() );
+
+		FAIL() << errorMsg;
+	
+	}
+
+    auto prefixIter = fileData.prefixes.find( "prefix1" );
+
+    ASSERT_NE( prefixIter, fileData.prefixes.end() );
+
+    EXPECT_EQ( prefixIter->second->id, "prefix1" );
+
+    ASSERT_EQ( prefixIter->second->paths.size(), 1 );
+
+    EXPECT_EQ( prefixIter->second->paths.at( 0 ), "." );
+
+    ASSERT_EQ( fileData.filterSections.size(), 1 );
+
+    //Note: INI reader lib is turning all section headers to lowercase 
+    EXPECT_EQ( fileData.filterSections.at(0)->id, "testsection" );  
+	
+    ASSERT_EQ( fileData.filterSections.at( 0 )->includeRules.size(), 1 );
+	
+    EXPECT_EQ( *fileData.filterSections.at( 0 )->includeRules.begin(), ".type1" );
+	
+    ASSERT_EQ( fileData.filterSections.at( 0 )->excludeRules.size(), 1 );
+	
+	EXPECT_EQ( *fileData.filterSections.at( 0 )->excludeRules.begin(), ".type2" );
+	
+    ASSERT_EQ( fileData.filterSections.at( 0 )->respaths.size(), 1 );
+
+    EXPECT_EQ( fileData.filterSections.at( 0 )->respaths.at( 0 )->prefix->id, "prefix1" );
+
+    ASSERT_EQ( fileData.filterSections.at( 0 )->respaths.at( 0 )->path, "/*" );
+
+    ASSERT_EQ( fileData.filterSections.at( 0 )->respaths.at( 0 )->includeRules.size(), 1 );
+
+	EXPECT_EQ( *fileData.filterSections.at( 0 )->respaths.at( 0 )->includeRules.begin(), ".type3" );
+
+	ASSERT_EQ( fileData.filterSections.at( 0 )->respaths.at( 0 )->excludeRules.size(), 1 );
+
+	EXPECT_EQ( *fileData.filterSections.at( 0 )->respaths.at( 0 )->excludeRules.begin(), ".type4" );
+
+}
+TEST_F( ResourceToolsTest, Filtering_AddFilterFile )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = [.type1] ![.type2]\n"
+						  "respaths = prefix1:/* [.type1]![type2]";
+
+    ResourceTools::FilterFile fileData;
+
+	try
+	{
+		ResourceTools::FilterFileReader::LoadFromIniFileData( iniFile.data(), iniFile.size(), fileData );
+	}
+	catch( const std::exception& e )
+	{
+		std::string errorMsg = "Failed to read filter file: " + std::string( e.what() );
+
+		FAIL() << errorMsg;
+	}
+
+
+    ResourceTools::ResourceFilter resourceFilter;
+
+    ASSERT_TRUE( resourceFilter.SetFromFilterFileData( fileData ) );
+}
+TEST_F( ResourceToolsTest, Filtering_AsteriskPatternMatch )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/*";
+
+
+    ResourceTools::ResourceFilter resourceFilter;
+
+    LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+    std::filesystem::path validPath = "File";
+
+    ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+
+}
+
+TEST_F( ResourceToolsTest, Filtering_AsteriskPatternMissmatch )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/*";
+
+
+
+    ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path validPath = "Subfolder/File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( validPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_ElipsisPatternMatch )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/...";
+
+
+    ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+    std::vector<std::filesystem::path> validPaths = {
+		"File",
+		"Subfolder1/File",
+		"Subfolder2/File"
+	};
+
+    for (auto path : validPaths)
+	{
+		ASSERT_TRUE( resourceFilter.CheckPath( path ) );
+    }
+	
+}
+
+TEST_F( ResourceToolsTest, Filtering_SpecificFile )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/File";
+
+    ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path validPath = "File";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+
+    std::filesystem::path invalidPath = "NonMatching";
+
+    ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterIncludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = [ .type1 ]\n"
+						  "respaths = prefix1:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path validPath = "File.type1";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+
+    std::filesystem::path invalidPath = "File.type2";
+
+    ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterExcludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = ![ .type1 ]\n"
+						  "respaths = prefix1:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+    std::filesystem::path validPath = "File.type2";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+
+	std::filesystem::path invalidPath = "File.type1";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+	
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterOverlappingIncludeExcludeRule1 )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = [ .type1 ]![ .type1 ]\n"
+						  "respaths = prefix1:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File.type1";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterOverlappingIncludeExcludeRule2 )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = ![ .type1 ][ .type1 ]\n"
+						  "respaths = prefix1:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File.type1";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterRespathExcludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/* ![ File ]";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterRespathIncludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/* [ File ]";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path validPath = "File";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterIncludeRuleWithOverlappingRespathExcludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = [ File ]\n"
+						  "respaths = prefix1:/* ![ File ]";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterExcludeRuleWithOverlappingRespathIncludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = ![ File ]\n"
+						  "respaths = prefix1:/* [ File ]";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_MultiPrefixMatch )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:Path1 prefix2:Path2\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/*\n"
+						  "           prefix2:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path prefix1ValidPath = "Path1/File";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix1ValidPath ) );
+
+    std::filesystem::path prefix2ValidPath = "Path2/File";
+
+    ASSERT_TRUE( resourceFilter.CheckPath( prefix2ValidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_MultiPrefixExcludeAppliesAcrossBoth )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:Path1 prefix2:Path2\n"
+						  "[testSection]\n"
+						  "filter = ![ File ]\n"
+						  "respaths = prefix1:/*\n"
+						  "           prefix2:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path prefix1InvalidPath = "Path1/File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix1InvalidPath ) );
+
+	std::filesystem::path prefix2InvalidPath = "Path2/File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix2InvalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_MultiPrefixIncludeAppliesAcrossBoth )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:Path1 prefix2:Path2\n"
+						  "[testSection]\n"
+						  "filter = [ File ]\n"
+						  "respaths = prefix1:/*\n"
+						  "           prefix2:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path prefix1ValidPath = "Path1/File";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix1ValidPath ) );
+
+	std::filesystem::path prefix2ValidPath = "Path2/File";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix2ValidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeOverrideExcludeAppliesAccrossBoth )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:Path1 prefix2:Path2\n"
+						  "[testSection]\n"
+						  "filter = [ File ]\n"
+						  "respaths = prefix1:/* ![ File ]\n"
+						  "           prefix2:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path prefix1InvalidPath = "Path1/File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix1InvalidPath ) );
+
+	std::filesystem::path prefix2InvalidPath = "Path2/File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix2InvalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeAddedPathIncludeAppliesToLaterPaths )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:Path1 prefix2:Path2\n"
+						  "[testSection]\n"
+						  "filter = [ .type1 ]\n"
+						  "respaths = prefix1:/* [ .type2 ]\n"
+						  "           prefix2:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path prefix1ValidPath = "Path1/File.type1";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix1ValidPath ) );
+
+	std::filesystem::path prefix2ValidPath = "Path2/File.type2";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix2ValidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeWithLaterRespathExclude )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:Path1 prefix2:Path2\n"
+						  "[testSection]\n"
+						  "filter = [ .type1 ]\n"
+						  "respaths = prefix1:/*\n"
+						  "           prefix1:/* ![ .type1 ]\n";
+						  "           prefix2:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path prefix1ValidPath = "Path1/File.type1";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( prefix1ValidPath ) );
+
+	std::filesystem::path prefix2InvalidPath = "Path2/File.type1";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( prefix2InvalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_SpecificFileWithInclude )
+{
+    // Surprisingly this should result in not a match
+    // A warning would probably be useful
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/File [ File ]";
+
+    ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_SpecificFileWithNonMatchingExclude )
+{
+	// Surprisingly this should result in not a match
+	// A warning would probably be useful
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/File ![ NONMatch ]";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path invalidPath = "File";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_SpecificFileWithOverlappingExcludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "[testSection]\n"
+						  "filter = ![ File ]\n"
+						  "respaths = prefix1:/File";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path validPath = "File";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+}
+
+TEST_F( ResourceToolsTest, Filtering_FilterGlobalIncludeRule )
+{
+	std::string iniFile = "[DEFAULT]\n"
+						  "prefixmap = prefix1:.\n"
+						  "filter = [ .type1 ]\n"
+						  "[testSection]\n"
+						  "respaths = prefix1:/*";
+
+
+	ResourceTools::ResourceFilter resourceFilter;
+
+	LoadResourceFilterFromIniFileData( iniFile, resourceFilter );
+
+	std::filesystem::path validPath = "File.type1";
+
+	ASSERT_TRUE( resourceFilter.CheckPath( validPath ) );
+
+	std::filesystem::path invalidPath = "File.type2";
+
+	ASSERT_FALSE( resourceFilter.CheckPath( invalidPath ) );
+}

--- a/tests/src/ResourceToolsFilterTest.cpp
+++ b/tests/src/ResourceToolsFilterTest.cpp
@@ -463,7 +463,7 @@ TEST_F( ResourceToolsTest, Filtering_MultiPrefixFilterIncludeWithLaterRespathExc
 						  "[testSection]\n"
 						  "filter = [ .type1 ]\n"
 						  "respaths = prefix1:/*\n"
-						  "           prefix1:/* ![ .type1 ]\n";
+						  "           prefix1:/* ![ .type1 ]\n"
 						  "           prefix2:/*";
 
 

--- a/tests/src/ResourceToolsLibraryTest.cpp
+++ b/tests/src/ResourceToolsLibraryTest.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-#include "ResourcesTestFixture.h"
+#include "ResourceToolsTest.h"
 #include "ChunkIndex.h"
 #include "FileDataStreamIn.h"
 #include "FileDataStreamOut.h"
@@ -20,10 +20,6 @@
 #include "Md5ChecksumStream.h"
 #include "Patching.h"
 #include "RollingChecksum.h"
-
-struct ResourceToolsTest : public ResourcesTestFixture
-{
-};
 
 TEST_F( ResourceToolsTest, Md5ChecksumGeneration )
 {
@@ -126,6 +122,52 @@ TEST_F( ResourceToolsTest, DownloadFile )
 	std::string checksum;
 	ResourceTools::GenerateMd5Checksum( downloadedData, checksum );
 	EXPECT_STREQ( checksum.c_str(), "6ccf6b7e2e263646f5a78e77b9ba3168" );
+}
+
+TEST_F( ResourceToolsTest, DownloadHeader )
+{
+	const char* FOLDER_NAME = "a9";
+	const char* FILE_NAME = "a9d1721dd5cc6d54_e6bbb2df307e5a9527159a4c971034b5";
+
+	const char* testDataPathStr = TEST_DATA_BASE_PATH;
+	ASSERT_TRUE( testDataPathStr );
+	ResourceTools::Downloader downloader;
+	std::filesystem::path testDataPath( testDataPathStr );
+
+	std::filesystem::path sourcePath = testDataPath / "resourcesLocal" / FOLDER_NAME / FILE_NAME;
+	std::string sourcePathString( sourcePath.string() );
+	std::string url = "file://" + sourcePathString;
+
+	std::chrono::seconds retrySeconds{ 0 };
+	int retryCount = 3;
+	std::string response = "";
+	EXPECT_EQ( downloader.GetHeader( url, retryCount, retrySeconds, response ), ResourceTools::Response::SUCCESS );
+
+	EXPECT_NE( response, "" );
+
+	std::string contentLength;
+
+	EXPECT_TRUE( ResourceTools::Downloader::GetAttributeValueFromHeader( response, "Content-Length", contentLength ) );
+
+	// Get size of file from filesystem
+	auto fileSize = std::filesystem::file_size( sourcePath );
+
+	auto contentLengthNum = -1;
+
+	try
+	{
+		contentLengthNum = std::atoi( contentLength.c_str() );
+	}
+	catch( std::invalid_argument& )
+	{
+		FAIL();
+	}
+	catch( std::out_of_range& )
+	{
+		FAIL();
+	}
+
+	EXPECT_EQ( contentLengthNum, fileSize );
 }
 
 TEST_F( ResourceToolsTest, GZipCompressString )

--- a/tests/src/ResourceToolsLibraryTest.cpp
+++ b/tests/src/ResourceToolsLibraryTest.cpp
@@ -227,12 +227,12 @@ TEST_F( ResourceToolsTest, FileDataStremOut )
 
 	EXPECT_TRUE( out.Finish() );
 
-	EXPECT_TRUE( FilesMatch( outputPath, GetTestFileFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
+	EXPECT_TRUE( FilesMatch( outputPath, GetTestFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
 }
 
 TEST_F( ResourceToolsTest, CompressedFileDataStremOut )
 {
-	std::filesystem::path goldFileUncompressedPath = GetTestFileFileAbsolutePath( "FileStream/FileDataStreamOut.txt" );
+	std::filesystem::path goldFileUncompressedPath = GetTestFileAbsolutePath( "FileStream/FileDataStreamOut.txt" );
 
 	ResourceTools::CompressedFileDataStreamOut out;
 
@@ -264,7 +264,7 @@ TEST_F( ResourceToolsTest, CompressedFileDataStremOut )
 
 	EXPECT_TRUE( ResourceTools::SaveFile( outputPathUncompressed, uncompressedData ) );
 
-	EXPECT_TRUE( FilesMatch( outputPathUncompressed, GetTestFileFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
+	EXPECT_TRUE( FilesMatch( outputPathUncompressed, GetTestFileAbsolutePath( "FileStream/FileDataStreamOut.txt" ) ) );
 }
 TEST_F( ResourceToolsTest, ResourceChunking )
 {
@@ -277,7 +277,7 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 	// Add test resource1 data
 	std::string resource1Data;
 
-	std::filesystem::path resource1Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/One.png" );
+	std::filesystem::path resource1Path = GetTestFileAbsolutePath( "Bundle/TestResources/One.png" );
 
 	EXPECT_TRUE( ResourceTools::GetLocalFileData( resource1Path, resource1Data ) );
 
@@ -294,7 +294,7 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 	// Add test resource2 data
 	std::string resource2Data;
 
-	std::filesystem::path resource2Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/Two.png" );
+	std::filesystem::path resource2Path = GetTestFileAbsolutePath( "Bundle/TestResources/Two.png" );
 
 	EXPECT_TRUE( ResourceTools::GetLocalFileData( resource2Path, resource2Data ) );
 
@@ -311,7 +311,7 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 	// Add test resource3 data
 	std::string resource3Data;
 
-	std::filesystem::path resource3Path = GetTestFileFileAbsolutePath( "Bundle/TestResources/Three.png" );
+	std::filesystem::path resource3Path = GetTestFileAbsolutePath( "Bundle/TestResources/Three.png" );
 
 	EXPECT_TRUE( ResourceTools::GetLocalFileData( resource3Path, resource3Data ) );
 
@@ -465,7 +465,7 @@ TEST_F( ResourceToolsTest, ResourceChunking )
 TEST_F( ResourceToolsTest, GZipUncompressTestFile )
 {
 
-	std::filesystem::path resourcePath = GetTestFileFileAbsolutePath( "CompressedFiles/ab5cde4fbbf82fb6_6a9d6d4c6015616877b77865209c5064" );
+	std::filesystem::path resourcePath = GetTestFileAbsolutePath( "CompressedFiles/ab5cde4fbbf82fb6_6a9d6d4c6015616877b77865209c5064" );
 
 	std::string resourceData;
 

--- a/tests/src/ResourceToolsTest.h
+++ b/tests/src/ResourceToolsTest.h
@@ -1,0 +1,13 @@
+// Copyright © 2025 CCP ehf.
+
+#pragma once
+#ifndef ResourceToolsTest_H
+#define ResourceToolsTest_H
+
+#include "ResourcesTestFixture.h"
+
+struct ResourceToolsTest : public ResourcesTestFixture
+{
+};
+
+#endif // ResourceToolsTest_H

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -746,7 +746,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromFilter )
 
 	std::filesystem::path filterPath = GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" );
 
-	arguments.push_back( "--filter-file " );
+	arguments.push_back( "--filter-file" );
 
 	arguments.push_back( filterPath.string() );
 
@@ -790,7 +790,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromFilterExportResources )
 
 	std::filesystem::path filterPath = GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" );
 
-	arguments.push_back( "--filter-file " );
+	arguments.push_back( "--filter-file" );
 
 	arguments.push_back( filterPath.string() );
 

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -137,7 +137,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectory )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	std::filesystem::path inputDirectory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 	arguments.push_back( inputDirectory.string() );
 
 	arguments.push_back( "--output-file" );
@@ -149,9 +149,9 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectory )
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -178,7 +178,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryExportResources )
 	std::string exportOutputPath = "ExportedResources";
 	arguments.push_back( exportOutputPath );
 
-	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	std::filesystem::path inputDirectory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 	arguments.push_back( inputDirectory.string() );
 
 	arguments.push_back( "--output-file" );
@@ -190,9 +190,9 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryExportResources )
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -214,7 +214,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryWithSkipCompression )
 
     arguments.push_back( "--skip-compression" );
 
-	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	std::filesystem::path inputDirectory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 	arguments.push_back( inputDirectory.string() );
 
 	arguments.push_back( "--output-file" );
@@ -226,9 +226,9 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryWithSkipCompression )
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -246,7 +246,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	std::filesystem::path inputDirectory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 	arguments.push_back( inputDirectory.string() );
 
 	arguments.push_back( "--output-file" );
@@ -261,9 +261,9 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormat )
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.csv" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.csv" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.csv" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.csv" );
 #else
 #error Unsupported platform
 #endif
@@ -281,7 +281,7 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithP
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::filesystem::path inputDirectory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	std::filesystem::path inputDirectory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 	arguments.push_back( inputDirectory.string() );
 
 	arguments.push_back( "--output-file" );
@@ -299,9 +299,9 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromDirectoryOldDocumentFormatWithP
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindowsPrefixed.csv" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindowsPrefixed.csv" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOSPrefixed.csv" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOSPrefixed.csv" );
 #else
 #error Unsupported platform
 #endif
@@ -319,10 +319,10 @@ TEST_F( ResourcesCliTest, CreateBundle )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	arguments.push_back( GetTestFileFileAbsolutePath( "Bundle/resfileindexShort.txt" ).string() );
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" ).string() );
 
 	arguments.push_back( "--resource-source-path" );
-	arguments.push_back( GetTestFileFileAbsolutePath( "Bundle/Res" ).string() );
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/Res" ).string() );
 
 	arguments.push_back( "--bundle-resourcegroup-relative-path" );
 	arguments.push_back( "BundleResourceGroup.yaml" );
@@ -348,10 +348,10 @@ TEST_F( ResourcesCliTest, CreateBundle )
 	EXPECT_EQ( res, 0 );
 
 	// Check expected outcome
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" );
 	EXPECT_TRUE( FilesMatch( goldFile, "BundleOut/BundleResourceGroup.yaml" ) );
 
-	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "CreateBundle/CreateBundleOut" );
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" );
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "CreateBundleOut" ) );
 }
 
@@ -366,11 +366,11 @@ TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResourceIgnoreOnResourceNotF
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string resourceGroupPath = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
+	std::string resourceGroupPath = GetTestFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
 
 	arguments.push_back( resourceGroupPath );
 
-	std::string resourcesToRemoveFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourcesToRemoveListWithUnknownResource.txt" ).string();
+	std::string resourcesToRemoveFile = GetTestFileAbsolutePath( "RemoveResource/ResourcesToRemoveListWithUnknownResource.txt" ).string();
 
 	arguments.push_back( resourcesToRemoveFile );
 
@@ -398,11 +398,11 @@ TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResourceWithInvalidPathToRes
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string resourceGroupPath = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
+	std::string resourceGroupPath = GetTestFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
 
 	arguments.push_back( resourceGroupPath );
 
-	std::string resourcesToRemoveFile = GetTestFileFileAbsolutePath( "INVALID_PATH" ).string();
+	std::string resourcesToRemoveFile = GetTestFileAbsolutePath( "INVALID_PATH" ).string();
 
 	arguments.push_back( resourcesToRemoveFile );
 
@@ -428,11 +428,11 @@ TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResource )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string resourceGroupPath = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
+	std::string resourceGroupPath = GetTestFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
 
 	arguments.push_back( resourceGroupPath );
 
-	std::string resourcesToRemoveFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourcesToRemoveListWithUnknownResource.txt" ).string();
+	std::string resourcesToRemoveFile = GetTestFileAbsolutePath( "RemoveResource/ResourcesToRemoveListWithUnknownResource.txt" ).string();
 
 	arguments.push_back( resourcesToRemoveFile );
 
@@ -458,11 +458,11 @@ TEST_F( ResourcesCliTest, RemoveResources )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string resourceGroupPath = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
+	std::string resourceGroupPath = GetTestFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" ).string();
 
 	arguments.push_back( resourceGroupPath );
 
-	std::string resourcesToRemoveFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourcesToRemoveList.txt" ).string();
+	std::string resourcesToRemoveFile = GetTestFileAbsolutePath( "RemoveResource/ResourcesToRemoveList.txt" ).string();
 
 	arguments.push_back( resourcesToRemoveFile );
 
@@ -477,7 +477,7 @@ TEST_F( ResourcesCliTest, RemoveResources )
 	EXPECT_EQ( res, 0 );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, resourceGroupAfterRemovePath ) );
 }
@@ -493,11 +493,11 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string baseResourceGroupPath = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndex.txt" ).string();
+	std::string baseResourceGroupPath = GetTestFileAbsolutePath( "DiffGroups/resFileIndex.txt" ).string();
 
 	arguments.push_back( baseResourceGroupPath );
 
-	std::string diffResourceGroupPath = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndexWithAdditions.txt" ).string();
+	std::string diffResourceGroupPath = GetTestFileAbsolutePath( "DiffGroups/resFileIndexWithAdditions.txt" ).string();
 
 	arguments.push_back( diffResourceGroupPath );
 
@@ -512,7 +512,7 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoAdditions )
 	EXPECT_EQ( res, 0 );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "DiffGroups/ExpectedDiffWithAdditions.txt" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "DiffGroups/ExpectedDiffWithAdditions.txt" );
 
 	EXPECT_TRUE( FileExists( goldFile ) );
 
@@ -532,11 +532,11 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoChanges )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string baseResourceGroupPath = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndex.txt" ).string();
+	std::string baseResourceGroupPath = GetTestFileAbsolutePath( "DiffGroups/resFileIndex.txt" ).string();
 
 	arguments.push_back( baseResourceGroupPath );
 
-	std::string diffResourceGroupPath = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndexWithChanges.txt" ).string();
+	std::string diffResourceGroupPath = GetTestFileAbsolutePath( "DiffGroups/resFileIndexWithChanges.txt" ).string();
 
 	arguments.push_back( diffResourceGroupPath );
 
@@ -551,7 +551,7 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoChanges )
 	EXPECT_EQ( res, 0 );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "DiffGroups/ExpectedDiffWithChanges.txt" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "DiffGroups/ExpectedDiffWithChanges.txt" );
 
 	EXPECT_TRUE( FileExists( goldFile ) );
 
@@ -571,11 +571,11 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoSubtractions )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string baseResourceGroupPath = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndex.txt" ).string();
+	std::string baseResourceGroupPath = GetTestFileAbsolutePath( "DiffGroups/resFileIndex.txt" ).string();
 
 	arguments.push_back( baseResourceGroupPath );
 
-	std::string diffResourceGroupPath = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndexWithSubtractions.txt" ).string();
+	std::string diffResourceGroupPath = GetTestFileAbsolutePath( "DiffGroups/resFileIndexWithSubtractions.txt" ).string();
 
 	arguments.push_back( diffResourceGroupPath );
 
@@ -590,7 +590,7 @@ TEST_F( ResourcesCliTest, DiffResourceGroupsWithTwoSubtractions )
 	EXPECT_EQ( res, 0 );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "DiffGroups/ExpectedDiffWithSubtractions.txt" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "DiffGroups/ExpectedDiffWithSubtractions.txt" );
 
 	EXPECT_TRUE( FileExists( goldFile ) );
 
@@ -610,11 +610,11 @@ TEST_F( ResourcesCliTest, MergeGroup )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string baseResourceGroupPath = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/BaseResourceGroup.yaml" ).string();
+	std::string baseResourceGroupPath = GetTestFileAbsolutePath( "MergeGroups/YamlAdditive/BaseResourceGroup.yaml" ).string();
 
 	arguments.push_back( baseResourceGroupPath );
 
-	std::string mergeResourceGroupPath = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" ).string();
+	std::string mergeResourceGroupPath = GetTestFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" ).string();
 
 	arguments.push_back( mergeResourceGroupPath );
 
@@ -629,7 +629,7 @@ TEST_F( ResourcesCliTest, MergeGroup )
 	EXPECT_EQ( res, 0 );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/ExpectedMergedResourceGroup.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "MergeGroups/YamlAdditive/ExpectedMergedResourceGroup.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, mergedOutputPath ) );
 }
@@ -645,23 +645,23 @@ TEST_F( ResourcesCliTest, CreatePatch )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string previousResourceGroupPath = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" ).string();
+	std::string previousResourceGroupPath = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" ).string();
 
 	arguments.push_back( previousResourceGroupPath );
 
-	std::string nextResourceGroupPath = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" ).string();
+	std::string nextResourceGroupPath = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" ).string();
 
 	arguments.push_back( nextResourceGroupPath );
 
 	arguments.push_back( "--resource-source-type-previous" );
 	arguments.push_back( "LOCAL_RELATIVE" );
 
-	std::string nextResourcesLocation = GetTestFileFileAbsolutePath( "Patch/NextBuildResources" ).string();
+	std::string nextResourcesLocation = GetTestFileAbsolutePath( "Patch/NextBuildResources" ).string();
 
 	arguments.push_back( "--resource-source-base-path-next" );
 	arguments.push_back( nextResourcesLocation );
 
-	std::string previousResourcesLocation = GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ).string();
+	std::string previousResourcesLocation = GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ).string();
 
 	arguments.push_back( "--resource-source-base-path-previous" );
 	arguments.push_back( previousResourcesLocation );
@@ -683,10 +683,10 @@ TEST_F( ResourcesCliTest, CreatePatch )
 	EXPECT_EQ( res, 0 );
 
 	// Check expected outcome
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
 	EXPECT_TRUE( FilesMatch( goldFile, "PatchOut/PatchResourceGroup.yaml" ) );
 
-	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches" );
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/LocalCDNPatches" );
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "PatchOut/Patches" ) );
 }
 
@@ -701,7 +701,7 @@ TEST_F( ResourcesCliTest, CreateGroup )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string directoryIn = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" ).string();
+	std::string directoryIn = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" ).string();
 
 	arguments.push_back( directoryIn );
 
@@ -717,9 +717,9 @@ TEST_F( ResourcesCliTest, CreateGroup )
 
 // Check expected outcome
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -738,35 +738,39 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromFilter )
 
 	arguments.push_back( "-1" );
 
-	std::filesystem::path basePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+    arguments.push_back( "--filter-index-mapping-file" );
 
-	arguments.push_back( "--filter-file-basepath" );
+    std::filesystem::path filterMappingFile = GetTestFileAbsolutePath( "FilterFiles/resFilterIndexMapping.yaml" );
 
-	arguments.push_back( basePath.string() );
+    arguments.push_back( filterMappingFile.string() );
 
-	std::filesystem::path filterPath = GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" );
+	std::filesystem::path filterFileBasepath = GetTestFileAbsolutePath( "FilterFiles/" );
 
-	arguments.push_back( "--filter-file" );
+    arguments.push_back( "--filter-file-basepath" );
 
-	arguments.push_back( filterPath.string() );
+	arguments.push_back( filterFileBasepath.string() );
 
-	std::filesystem::path outputFile = "ResourceGroups/ResourceGroup.yaml";
+    arguments.push_back( "--prefix-map-basepath" );
 
-	arguments.push_back( "--output-file" );
+    std::filesystem::path prefixBasePath = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
-	arguments.push_back( outputFile.string() );
+    arguments.push_back( prefixBasePath.string() );
 
 	int res = RunCli( arguments, output );
 
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
+
+    // Value is asertained from yaml mapping file
+    std::filesystem::path outputFile = "ResourceGroup.yaml";
+
 	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 }
 
@@ -782,23 +786,23 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromFilterExportResources )
 
 	arguments.push_back( "-1" );
 
-	std::filesystem::path basePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	arguments.push_back( "--filter-index-mapping-file" );
+
+	std::filesystem::path filterMappingFile = GetTestFileAbsolutePath( "FilterFiles/resFilterIndexMapping.yaml" );
+
+	arguments.push_back( filterMappingFile.string() );
+
+	std::filesystem::path filterFileBasepath = GetTestFileAbsolutePath( "FilterFiles/" );
 
 	arguments.push_back( "--filter-file-basepath" );
 
-	arguments.push_back( basePath.string() );
+	arguments.push_back( filterFileBasepath.string() );
 
-	std::filesystem::path filterPath = GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" );
+	arguments.push_back( "--prefix-map-basepath" );
 
-	arguments.push_back( "--filter-file" );
+	std::filesystem::path prefixBasePath = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
-	arguments.push_back( filterPath.string() );
-
-	std::filesystem::path outputFile = "ResourceGroups/ResourceGroup.yaml";
-
-	arguments.push_back( "--output-file" );
-
-	arguments.push_back( outputFile.string() );
+	arguments.push_back( prefixBasePath.string() );
 
 	arguments.push_back( "--export-resources" );
 
@@ -817,15 +821,18 @@ TEST_F( ResourcesCliTest, CreateResourceGroupFromFilterExportResources )
 	ASSERT_EQ( res, 0 );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
+
+	std::filesystem::path outputFile = "ResourceGroup.yaml";
+
 	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
 
-	EXPECT_TRUE( DirectoryIsSubset( exportedResourcesPath, basePath ) );
+	EXPECT_TRUE( DirectoryIsSubset( exportedResourcesPath, prefixBasePath ) );
 }
 
 #ifdef DEV_FEATURES
@@ -841,25 +848,25 @@ TEST_F( ResourcesCliTest, ApplyPatch )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string directoryIn = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" ).string();
+	std::string directoryIn = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" ).string();
 
 	arguments.push_back( directoryIn );
 
 	arguments.push_back( "--patch-binaries-base-path" );
 
-	std::string patchBinariesBasePath = GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches/" ).string();
+	std::string patchBinariesBasePath = GetTestFileAbsolutePath( "Patch/LocalCDNPatches/" ).string();
 
 	arguments.push_back( patchBinariesBasePath );
 
 	arguments.push_back( "--resources-to-patch-base-path" );
 
-	std::string resourcesToPatchBasePath = GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources/" ).string();
+	std::string resourcesToPatchBasePath = GetTestFileAbsolutePath( "Patch/PreviousBuildResources/" ).string();
 
 	arguments.push_back( resourcesToPatchBasePath );
 
 	arguments.push_back( "--next-resources-base-path" );
 
-	std::string nextResourcesBasePath = GetTestFileFileAbsolutePath( "Patch/NextBuildResources/" ).string();
+	std::string nextResourcesBasePath = GetTestFileAbsolutePath( "Patch/NextBuildResources/" ).string();
 
 	arguments.push_back( nextResourcesBasePath );
 
@@ -881,7 +888,7 @@ TEST_F( ResourcesCliTest, ApplyPatch )
 	EXPECT_EQ( res, 0 );
 
 	// Check expected outcome
-	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/NextBuildResources" );
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/NextBuildResources" );
 	EXPECT_TRUE( DirectoryIsSubset( outputBasePath, goldDirectory ) );
 }
 
@@ -896,13 +903,13 @@ TEST_F( ResourcesCliTest, UnpackBundle )
 	arguments.push_back( "--verbosity-level" );
 	arguments.push_back( "-1" );
 
-	std::string directoryIn = GetTestFileFileAbsolutePath( "Bundle/BundleResourceGroup.yaml" ).string();
+	std::string directoryIn = GetTestFileAbsolutePath( "Bundle/BundleResourceGroup.yaml" ).string();
 
 	arguments.push_back( directoryIn );
 
 	arguments.push_back( "--chunk-source-base-path" );
 
-	std::string chunkSourceBasePath = GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ).string();
+	std::string chunkSourceBasePath = GetTestFileAbsolutePath( "Bundle/LocalRemoteChunks/" ).string();
 
 	arguments.push_back( chunkSourceBasePath );
 
@@ -915,7 +922,7 @@ TEST_F( ResourcesCliTest, UnpackBundle )
 	EXPECT_EQ( res, 0 );
 
 	// Check expected outcome
-	EXPECT_TRUE( DirectoryIsSubset( GetTestFileFileAbsolutePath( "Bundle/Res" ), "UnpackBundleOut" ) );
+	EXPECT_TRUE( DirectoryIsSubset( GetTestFileAbsolutePath( "Bundle/Res" ), "UnpackBundleOut" ) );
 
 	EXPECT_TRUE( std::filesystem::exists( "UnpackBundleOut/ResourceGroup.yaml" ) );
 }

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -726,6 +726,108 @@ TEST_F( ResourcesCliTest, CreateGroup )
 	EXPECT_TRUE( FilesMatch( goldFile, outputFilename ) );
 }
 
+TEST_F( ResourcesCliTest, CreateResourceGroupFromFilter )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-group-from-filter" );
+
+	arguments.push_back( "--verbosity-level" );
+
+	arguments.push_back( "-1" );
+
+	std::filesystem::path basePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+
+	arguments.push_back( "--filter-file-basepath" );
+
+	arguments.push_back( basePath.string() );
+
+	std::filesystem::path filterPath = GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" );
+
+	arguments.push_back( "--filter-file " );
+
+	arguments.push_back( filterPath.string() );
+
+	std::filesystem::path outputFile = "ResourceGroups/ResourceGroup.yaml";
+
+	arguments.push_back( "--output-file" );
+
+	arguments.push_back( outputFile.string() );
+
+	int res = RunCli( arguments, output );
+
+	ASSERT_EQ( res, 0 );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
+}
+
+TEST_F( ResourcesCliTest, CreateResourceGroupFromFilterExportResources )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-group-from-filter" );
+
+	arguments.push_back( "--verbosity-level" );
+
+	arguments.push_back( "-1" );
+
+	std::filesystem::path basePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+
+	arguments.push_back( "--filter-file-basepath" );
+
+	arguments.push_back( basePath.string() );
+
+	std::filesystem::path filterPath = GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" );
+
+	arguments.push_back( "--filter-file " );
+
+	arguments.push_back( filterPath.string() );
+
+	std::filesystem::path outputFile = "ResourceGroups/ResourceGroup.yaml";
+
+	arguments.push_back( "--output-file" );
+
+	arguments.push_back( outputFile.string() );
+
+	arguments.push_back( "--export-resources" );
+
+	arguments.push_back( "--export-resources-destination-type" );
+
+	arguments.push_back( "LOCAL_RELATIVE" );
+
+	std::filesystem::path exportedResourcesPath = "ExportedResources";
+
+	arguments.push_back( "--export-resources-destination-path" );
+
+	arguments.push_back( exportedResourcesPath.string() );
+
+	int res = RunCli( arguments, output );
+
+	ASSERT_EQ( res, 0 );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, outputFile ) );
+
+	EXPECT_TRUE( DirectoryIsSubset( exportedResourcesPath, basePath ) );
+}
+
 #ifdef DEV_FEATURES
 
 TEST_F( ResourcesCliTest, ApplyPatch )

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -1031,21 +1031,57 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
 
 	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
-    createResourceGroupParams.callbackSettings.statusCallback = StatusUpdate;
+	createResourceGroupParams.callbackSettings.statusCallback = StatusUpdate;
 
 	EXPECT_EQ( resourceGroup.CreateFromDirectory( createResourceGroupParams ).type, CarbonResources::ResultType::SUCCESS );
 
-    EXPECT_TRUE( StatusIsValid() );
+	EXPECT_TRUE( StatusIsValid() );
 
 	CarbonResources::ResourceGroupExportToFileParams exportParams;
 
 	exportParams.filename = "ResourceGroups/ResourceGroup.yaml";
 
-    exportParams.callbackSettings.statusCallback = StatusUpdate;
+	exportParams.callbackSettings.statusCallback = StatusUpdate;
 
 	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
 
-    EXPECT_TRUE( StatusIsValid() );
+	EXPECT_TRUE( StatusIsValid() );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
+}
+
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryWithStreaming )
+{
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
+
+	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+
+	createResourceGroupParams.callbackSettings.statusCallback = StatusUpdate;
+
+	createResourceGroupParams.resourceStreamThreshold = 0;
+
+	EXPECT_EQ( resourceGroup.CreateFromDirectory( createResourceGroupParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
+
+	exportParams.filename = "ResourceGroups/ResourceGroup.yaml";
+
+	exportParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
@@ -1679,4 +1715,83 @@ TEST_F( ResourcesLibraryTest, RemoveResource )
 	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
+}
+
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFromFilter )
+{
+
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::CreateResourceGroupFromFilterParams params;
+
+	params.filterSettings.prefixMapBasePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+
+	params.filterSettings.filterFilePaths.push_back( GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" ) );
+
+	params.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.CreateFromFilter( params ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
+
+	exportParams.filename = "ResourceGroups/ResourceGroup.yaml";
+
+	exportParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
+}
+
+TEST_F( ResourcesLibraryTest, CreateResourceGroupFromFilterExportResources )
+{
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::CreateResourceGroupFromFilterParams params;
+
+	params.filterSettings.prefixMapBasePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+
+	params.filterSettings.filterFilePaths.push_back( GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" ) );
+
+	params.exportSettings.enabled = true;
+
+	params.exportSettings.destinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	params.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.CreateFromFilter( params ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	CarbonResources::ResourceGroupExportToFileParams exportParams;
+
+	exportParams.filename = "ResourceGroups/ResourceGroup.yaml";
+
+	exportParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.ExportToFile( exportParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+#if _WIN64
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+#elif __APPLE__
+	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+#else
+#error Unsupported platform
+#endif
+	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
+
+	EXPECT_TRUE( DirectoryIsSubset( params.exportSettings.destinationSettings.basePath, params.filterSettings.prefixMapBasePath ) );
 }

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -3,12 +3,13 @@
 #include <ResourceGroup.h>
 #include <BundleResourceGroup.h>
 #include <PatchResourceGroup.h>
+#include <gtest/gtest.h>
+#include <FileDataStreamOut.h>
+#include <FilterIndexMappingFile.h>
 
 #include "ResourcesTestFixture.h"
 
-#include <gtest/gtest.h>
 
-#include <FileDataStreamOut.h>
 
 struct ResourcesLibraryTest : public ResourcesTestFixture
 {
@@ -24,7 +25,7 @@ TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_0_0_To_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/binaryFileIndex_v0_0_0.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/binaryFileIndex_v0_0_0.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -42,7 +43,7 @@ TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_0_0_To_V_0_1_0 )
 
     EXPECT_TRUE( StatusIsValid() );
 
-	std::filesystem::path goldStandardFilename = GetTestFileFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
+	std::filesystem::path goldStandardFilename = GetTestFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
 
 	EXPECT_TRUE( FilesMatch( exportParams.filename, goldStandardFilename ) );
 }
@@ -54,7 +55,7 @@ TEST_F( ResourcesLibraryTest, BinaryGroupImportExport_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/BinaryResourceGroup_v0_1_0.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -84,7 +85,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/resFileIndex_v0_0_0.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -102,7 +103,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_0_0_To_V_0_1_0 )
 
     EXPECT_TRUE( StatusIsValid() );
 
-	std::filesystem::path goldStandardFilename = GetTestFileFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
+	std::filesystem::path goldStandardFilename = GetTestFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
 
 	EXPECT_TRUE( FilesMatch( exportParams.filename, goldStandardFilename ) );
 }
@@ -111,7 +112,7 @@ TEST_F( ResourcesLibraryTest, ImportEmptyResourceGroup )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
-	importParams.filename = GetTestFileFileAbsolutePath( "ResourceGroups/EmptyResourceGroup.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "ResourceGroups/EmptyResourceGroup.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -124,7 +125,7 @@ TEST_F( ResourcesLibraryTest, ImportResourceGroupWithOutOfBoundsBinaryOperation 
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0-OutOfBoundsBinaryOp.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/resFileIndex_v0_0_0-OutOfBoundsBinaryOp.txt" );
 
 	importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -166,7 +167,7 @@ CarbonResources::Result AttemptImportResourceGroupMissingParameter( const std::s
 // This should fail gracefully and give appropriate feedback to user
 TEST_F( ResourcesLibraryTest, ResourceGroupHandleImportMissingParametersForVersion )
 {
-	std::filesystem::path emptyResourceGroupPath = GetTestFileFileAbsolutePath( "ResourceGroups/EmptyResourceGroup.yaml" );
+	std::filesystem::path emptyResourceGroupPath = GetTestFileAbsolutePath( "ResourceGroups/EmptyResourceGroup.yaml" );
 	EXPECT_EQ( AttemptImportResourceGroupMissingParameter( "Version", emptyResourceGroupPath ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_GROUP );
 	EXPECT_EQ( AttemptImportResourceGroupMissingParameter( "Type", emptyResourceGroupPath ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_GROUP );
 	EXPECT_EQ( AttemptImportResourceGroupMissingParameter( "NumberOfResources", emptyResourceGroupPath ).type, CarbonResources::ResultType::MALFORMED_RESOURCE_GROUP );
@@ -181,7 +182,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadInvalidYaml )
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
 	// Should try to load the group but fail to parse the yaml
-	importParams.filename = GetTestFileFileAbsolutePath( "ResourcesRemote/a9/a9d1721dd5cc6d54_4d7a8d216f4c8c5c6379476c0668fe84" );
+	importParams.filename = GetTestFileAbsolutePath( "ResourcesRemote/a9/a9d1721dd5cc6d54_4d7a8d216f4c8c5c6379476c0668fe84" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -197,7 +198,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadInvalidCsv )
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
 	// Try and load group but fail to parse csv
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_NONESENSE.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_NONESENSE.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -213,7 +214,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadCsvWithInvalidCompressedSizeField
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
 	// Try and load group but fail to parse csv
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_INVALID.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_INVALID.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -229,7 +230,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadEmptyCsv )
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
 	// Try and load group, results in success but empty list
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_EMPTY.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/resFileIndex_v0_0_0_EMPTY.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -245,7 +246,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupLoadNonexistantFileFails )
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
 	// Load a file that does not exist
-	importParams.filename = GetTestFileFileAbsolutePath( "ResourcesRemote/a9/a9d1721dd5cc6d54_4d7a8d216f4c8c5c6379476c0668fe84.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "ResourcesRemote/a9/a9d1721dd5cc6d54_4d7a8d216f4c8c5c6379476c0668fe84.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -260,7 +261,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupWithInvalidExtensionFails )
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
 	// Load a file with a file extension indicating an unsupported format
-	importParams.filename = GetTestFileFileAbsolutePath( "Bundle/TestResources/One.png" );
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/TestResources/One.png" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -276,7 +277,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportNewerMinorVersion )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
-	importParams.filename = GetTestFileFileAbsolutePath( "ResourceGroups/HigherMinorVersion.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "ResourceGroups/HigherMinorVersion.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -291,7 +292,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportNewerMajorVersion )
 {
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
-	importParams.filename = GetTestFileFileAbsolutePath( "ResourceGroups/HigherMajorVersion.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "ResourceGroups/HigherMajorVersion.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -308,7 +309,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportNonExistantFile )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "NonexistentFiles/ResourceGroup_which_does_not_exist.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "NonexistentFiles/ResourceGroup_which_does_not_exist.yaml" );
     
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -325,7 +326,7 @@ TEST_F( ResourcesLibraryTest, ResourceGroupImportExport_V_0_1_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "Indicies/ResourceGroup_v0_1_0.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -353,7 +354,7 @@ TEST_F( ResourcesLibraryTest, UnpackBundle )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Bundle/BundleResourceGroup.yaml" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Bundle/BundleResourceGroup.yaml" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -366,7 +367,7 @@ TEST_F( ResourcesLibraryTest, UnpackBundle )
 
 	bundleUnpackParams.chunkSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
 
-	bundleUnpackParams.chunkSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ) };
+	bundleUnpackParams.chunkSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/LocalRemoteChunks/" ) };
 
 	bundleUnpackParams.resourceDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
@@ -378,7 +379,7 @@ TEST_F( ResourcesLibraryTest, UnpackBundle )
 
     EXPECT_TRUE( StatusIsValid() );
 
-	EXPECT_TRUE( DirectoryIsSubset( GetTestFileFileAbsolutePath( "Bundle/Res" ), "UnpackBundleOut" ) );
+	EXPECT_TRUE( DirectoryIsSubset( GetTestFileAbsolutePath( "Bundle/Res" ), "UnpackBundleOut" ) );
 
 	EXPECT_TRUE( std::filesystem::exists( "UnpackBundleOut/ResourceGroup.yaml" ) );
 }
@@ -390,7 +391,7 @@ TEST_F( ResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Bundle/BundleResourceGroup.yaml" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Bundle/BundleResourceGroup.yaml" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -403,7 +404,7 @@ TEST_F( ResourcesLibraryTest, UnpackBundleExpectingRemoteCdnButPassedLocalCdn )
 
 	bundleUnpackParams.chunkSourceSettings.sourceType = CarbonResources::ResourceSourceType::REMOTE_CDN; // source is LOCAL_CDN
 
-	bundleUnpackParams.chunkSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/LocalRemoteChunks/" ) };
+	bundleUnpackParams.chunkSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/LocalRemoteChunks/" ) };
 
 	bundleUnpackParams.resourceDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
@@ -422,7 +423,7 @@ TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 	// Import ResourceGroup
 	CarbonResources::ResourceGroup resourceGroup;
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
-	importParams.filename = GetTestFileFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -435,7 +436,7 @@ TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 	bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
 	bundleCreateParams.resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
 	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
-	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
 	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::REMOTE_CDN;
 	bundleCreateParams.chunkDestinationSettings.basePath = "UnpackRemoteBundleAsLocal/Chunks";
 	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
@@ -478,7 +479,7 @@ TEST_F( ResourcesLibraryTest, CreateBundleWithZeroChunkSize )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -496,7 +497,7 @@ TEST_F( ResourcesLibraryTest, CreateBundleWithZeroChunkSize )
 
 	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
 
 	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -522,7 +523,7 @@ TEST_F( ResourcesLibraryTest, CreateBundle )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -540,7 +541,7 @@ TEST_F( ResourcesLibraryTest, CreateBundle )
 
 	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
 
 	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -558,8 +559,8 @@ TEST_F( ResourcesLibraryTest, CreateBundle )
 
     EXPECT_TRUE( StatusIsValid() );
 
-	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroup.yaml", GetTestFileFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" ) ) );
-	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileFileAbsolutePath( "CreateBundle/CreateBundleOut" ) ) );
+	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroup.yaml", GetTestFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" ) ) );
+	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" ) ) );
 }
 
 TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
@@ -569,7 +570,7 @@ TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -587,7 +588,7 @@ TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
 
 	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Bundle/Res/" ) };
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
 
 	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -650,7 +651,7 @@ TEST_F( ResourcesLibraryTest, ApplyPatch )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -664,15 +665,15 @@ TEST_F( ResourcesLibraryTest, ApplyPatch )
 
 	patchApplyParams.nextBuildResourcesSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchApplyParams.nextBuildResourcesSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/NextBuildResources/" ) };
+	patchApplyParams.nextBuildResourcesSourceSettings.basePaths = { GetTestFileAbsolutePath( "Patch/NextBuildResources/" ) };
 
 	patchApplyParams.patchBinarySourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
 
-	patchApplyParams.patchBinarySourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches/" ) };
+	patchApplyParams.patchBinarySourceSettings.basePaths = { GetTestFileAbsolutePath( "Patch/LocalCDNPatches/" ) };
 
 	patchApplyParams.resourcesToPatchSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchApplyParams.resourcesToPatchSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources/" ) };
+	patchApplyParams.resourcesToPatchSourceSettings.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources/" ) };
 
 	patchApplyParams.resourcesToPatchDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
@@ -694,7 +695,7 @@ TEST_F( ResourcesLibraryTest, ApplyPatch )
     EXPECT_TRUE( StatusIsValid() );
 
 	// Check Expected Outcome
-	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/NextBuildResources" );
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/NextBuildResources" );
 	EXPECT_TRUE( DirectoryIsSubset( patchApplyParams.resourcesToPatchDestinationSettings.basePath, goldDirectory ) );
 }
 TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
@@ -704,7 +705,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -717,7 +718,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsLatest;
 
-	importParamsLatest.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
+	importParamsLatest.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
 
     importParamsLatest.callbackSettings.statusCallback = StatusUpdate;
 
@@ -734,11 +735,11 @@ TEST_F( ResourcesLibraryTest, CreatePatchWhereBuildsHaveNoChanges )
 
 	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ) };
 
 	patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ) };
 
 	patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -770,7 +771,7 @@ TEST_F( ResourcesLibraryTest, CreatePatch )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -784,7 +785,7 @@ TEST_F( ResourcesLibraryTest, CreatePatch )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsLatest;
 
-	importParamsLatest.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
+	importParamsLatest.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
 
     importParamsLatest.callbackSettings.statusCallback = StatusUpdate;
 
@@ -801,11 +802,11 @@ TEST_F( ResourcesLibraryTest, CreatePatch )
 
 	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ) };
 
 	patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileFileAbsolutePath( "Patch/NextBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileAbsolutePath( "Patch/NextBuildResources" ) };
 
 	patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -828,10 +829,10 @@ TEST_F( ResourcesLibraryTest, CreatePatch )
     EXPECT_TRUE( StatusIsValid() );
 
 	// Check expected outcome
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
 	EXPECT_TRUE( FilesMatch( goldFile, patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath / "PatchResourceGroup.yaml" ) );
 
-	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "Patch/LocalCDNPatches" );
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/LocalCDNPatches" );
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
 }
 
@@ -842,7 +843,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -856,7 +857,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsLatest;
 
-	importParamsLatest.filename = GetTestFileFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
+	importParamsLatest.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
 
     importParamsLatest.callbackSettings.statusCallback = StatusUpdate;
 
@@ -873,11 +874,11 @@ TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )
 
 	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileFileAbsolutePath( "Patch/PreviousBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ) };
 
 	patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileFileAbsolutePath( "Patch/NextBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileAbsolutePath( "Patch/NextBuildResources" ) };
 
 	patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -907,7 +908,7 @@ TEST_F( ResourcesLibraryTest, ApplyPatchWithChunking )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "PatchWithInputChunk/PatchResourceGroup_previousBuild_latestBuild.yaml" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "PatchWithInputChunk/PatchResourceGroup_previousBuild_latestBuild.yaml" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -921,15 +922,15 @@ TEST_F( ResourcesLibraryTest, ApplyPatchWithChunking )
 
 	patchApplyParams.nextBuildResourcesSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchApplyParams.nextBuildResourcesSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/" ) };
+	patchApplyParams.nextBuildResourcesSourceSettings.basePaths = { GetTestFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/" ) };
 
 	patchApplyParams.patchBinarySourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_CDN;
 
-	patchApplyParams.patchBinarySourceSettings.basePaths = { GetTestFileFileAbsolutePath( "PatchWithInputChunk/LocalCDNPatches/" ) };
+	patchApplyParams.patchBinarySourceSettings.basePaths = { GetTestFileAbsolutePath( "PatchWithInputChunk/LocalCDNPatches/" ) };
 
 	patchApplyParams.resourcesToPatchSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchApplyParams.resourcesToPatchSourceSettings.basePaths = { GetTestFileFileAbsolutePath( "PatchWithInputChunk/PreviousBuildResources/" ) };
+	patchApplyParams.resourcesToPatchSourceSettings.basePaths = { GetTestFileAbsolutePath( "PatchWithInputChunk/PreviousBuildResources/" ) };
 
 	patchApplyParams.resourcesToPatchDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
 
@@ -943,11 +944,11 @@ TEST_F( ResourcesLibraryTest, ApplyPatchWithChunking )
 
     EXPECT_TRUE( StatusIsValid() );
 
-	std::filesystem::path nextIntroMovie = GetTestFileFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/introMovie.txt" );
+	std::filesystem::path nextIntroMovie = GetTestFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/introMovie.txt" );
 	EXPECT_TRUE( FilesMatch( nextIntroMovie, patchApplyParams.resourcesToPatchDestinationSettings.basePath / "introMovie.txt" ) );
-	std::filesystem::path nextIntroMoviePrefixed = GetTestFileFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/introMoviePrefixed.txt" );
+	std::filesystem::path nextIntroMoviePrefixed = GetTestFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/introMoviePrefixed.txt" );
 	EXPECT_TRUE( FilesMatch( nextIntroMoviePrefixed, patchApplyParams.resourcesToPatchDestinationSettings.basePath / "introMoviePrefixed.txt" ) );
-	std::filesystem::path nextTestResource = GetTestFileFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/testresource2.txt" );
+	std::filesystem::path nextTestResource = GetTestFileAbsolutePath( "PatchWithInputChunk/NextBuildResources/testresource2.txt" );
 	EXPECT_TRUE( FilesMatch( nextTestResource, patchApplyParams.resourcesToPatchDestinationSettings.basePath / "testresource2.txt" ) );
 }
 
@@ -958,7 +959,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchWithChunking )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
 
-	importParamsPrevious.filename = GetTestFileFileAbsolutePath( "PatchWithInputChunk/resfileindexShort_build_previous.txt" );
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "PatchWithInputChunk/resfileindexShort_build_previous.txt" );
 
     importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
 
@@ -971,7 +972,7 @@ TEST_F( ResourcesLibraryTest, CreatePatchWithChunking )
 
 	CarbonResources::ResourceGroupImportFromFileParams importParamsLatest;
 
-	importParamsLatest.filename = GetTestFileFileAbsolutePath( "PatchWithInputChunk/resfileindexShort_build_next.txt" );
+	importParamsLatest.filename = GetTestFileAbsolutePath( "PatchWithInputChunk/resfileindexShort_build_next.txt" );
 
     importParamsLatest.callbackSettings.statusCallback = StatusUpdate;
 
@@ -990,11 +991,11 @@ TEST_F( ResourcesLibraryTest, CreatePatchWithChunking )
 
 	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileFileAbsolutePath( "PatchWithInputChunk/PreviousBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileAbsolutePath( "PatchWithInputChunk/PreviousBuildResources" ) };
 
 	patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
-	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileFileAbsolutePath( "PatchWithInputChunk/NextBuildResources" ) };
+	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileAbsolutePath( "PatchWithInputChunk/NextBuildResources" ) };
 
 	patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
 
@@ -1016,10 +1017,10 @@ TEST_F( ResourcesLibraryTest, CreatePatchWithChunking )
 
     EXPECT_TRUE( StatusIsValid() );
 
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "PatchWithInputChunk/PatchResourceGroup_previousBuild_latestBuild.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "PatchWithInputChunk/PatchResourceGroup_previousBuild_latestBuild.yaml" );
 	EXPECT_TRUE( FilesMatch( goldFile, patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath / "PatchResourceGroup_previousBuild_latestBuild.yaml" ) );
 
-	std::filesystem::path goldDirectory = GetTestFileFileAbsolutePath( "PatchWithInputChunk/LocalCDNPatches" );
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "PatchWithInputChunk/LocalCDNPatches" );
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
 }
 
@@ -1029,7 +1030,7 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
 
 	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
 
-	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	createResourceGroupParams.directory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
 	createResourceGroupParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1048,9 +1049,9 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectory )
 	EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -1063,7 +1064,7 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryWithStreaming )
 
 	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
 
-	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	createResourceGroupParams.directory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
 	createResourceGroupParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1084,9 +1085,9 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryWithStreaming )
 	EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -1099,7 +1100,7 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryExportResources )
 
 	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
 
-	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	createResourceGroupParams.directory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
     createResourceGroupParams.exportResources = true;
 
@@ -1122,9 +1123,9 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryExportResources )
     EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -1139,7 +1140,7 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectorySkipCompression )
 
 	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
 
-	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	createResourceGroupParams.directory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
     createResourceGroupParams.calculateCompressions = false;
 
@@ -1160,9 +1161,9 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectorySkipCompression )
     EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupSkipCompressionMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -1175,7 +1176,7 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromDirectoryOutputPathIsInvali
 
 	CarbonResources::CreateResourceGroupFromDirectoryParams createResourceGroupParams;
 
-	createResourceGroupParams.directory = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	createResourceGroupParams.directory = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
     createResourceGroupParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1216,7 +1217,7 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndex.txt" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "DiffGroups/resFileIndex.txt" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1232,7 +1233,7 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoAdditions )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParamsWithAdditions;
 
-	importFromFileParamsWithAdditions.filename = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndexWithAdditions.txt" );
+	importFromFileParamsWithAdditions.filename = GetTestFileAbsolutePath( "DiffGroups/resFileIndexWithAdditions.txt" );
 
     importFromFileParamsWithAdditions.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1276,7 +1277,7 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoChanges )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndex.txt" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "DiffGroups/resFileIndex.txt" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1292,7 +1293,7 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoChanges )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParamsWithChanges;
 
-	importFromFileParamsWithChanges.filename = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndexWithChanges.txt" );
+	importFromFileParamsWithChanges.filename = GetTestFileAbsolutePath( "DiffGroups/resFileIndexWithChanges.txt" );
 
     importFromFileParamsWithChanges.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1336,7 +1337,7 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoSubtractions )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndex.txt" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "DiffGroups/resFileIndex.txt" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1352,7 +1353,7 @@ TEST_F( ResourcesLibraryTest, DiffResourceGroupsWithTwoSubtractions )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParamsWithSubtractions;
 
-	importFromFileParamsWithSubtractions.filename = GetTestFileFileAbsolutePath( "DiffGroups/resFileIndexWithSubtractions.txt" );
+	importFromFileParamsWithSubtractions.filename = GetTestFileAbsolutePath( "DiffGroups/resFileIndexWithSubtractions.txt" );
 
     importFromFileParamsWithSubtractions.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1395,7 +1396,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/BaseResourceGroup.yaml" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/YamlAdditive/BaseResourceGroup.yaml" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1410,7 +1411,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive )
 
 	CarbonResources::ResourceGroupImportFromFileParams mergeImportFromFileParams;
 
-	mergeImportFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" );
+	mergeImportFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/YamlAdditive/MergeResourceGroup.yaml" );
 
     mergeImportFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1451,7 +1452,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive )
 	EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/YamlAdditive/ExpectedMergedResourceGroup.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "MergeGroups/YamlAdditive/ExpectedMergedResourceGroup.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
@@ -1462,7 +1463,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsIdentical )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/YamlIdentical/BaseResourceGroup.yaml" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/YamlIdentical/BaseResourceGroup.yaml" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1477,7 +1478,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsIdentical )
 
 	CarbonResources::ResourceGroupImportFromFileParams mergeImportFromFileParams;
 
-	mergeImportFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/YamlIdentical/MergeResourceGroup.yaml" );
+	mergeImportFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/YamlIdentical/MergeResourceGroup.yaml" );
 
     mergeImportFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1518,7 +1519,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsIdentical )
 	EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/YamlIdentical/ExpectedMergedResourceGroup.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "MergeGroups/YamlIdentical/ExpectedMergedResourceGroup.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
@@ -1529,7 +1530,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/CSVWithIntersect/BaseResourceGroup.txt" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/CSVWithIntersect/BaseResourceGroup.txt" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1544,7 +1545,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams mergeImportFromFileParams;
 
-	mergeImportFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/CSVWithIntersect/MergeResourceGroup.txt" );
+	mergeImportFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/CSVWithIntersect/MergeResourceGroup.txt" );
 
     mergeImportFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1587,7 +1588,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsWithIntersect_V_0_0_0 )
 	EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/CSVWithIntersect/ExpectedMergedResourceGroup.txt" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "MergeGroups/CSVWithIntersect/ExpectedMergedResourceGroup.txt" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
@@ -1598,7 +1599,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams importFromFileParams;
 
-	importFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/CSVAdditive/BaseResourceGroup.txt" );
+	importFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/CSVAdditive/BaseResourceGroup.txt" );
 
     importFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1613,7 +1614,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
 
 	CarbonResources::ResourceGroupImportFromFileParams mergeImportFromFileParams;
 
-	mergeImportFromFileParams.filename = GetTestFileFileAbsolutePath( "MergeGroups/CSVAdditive/MergeResourceGroup.txt" );
+	mergeImportFromFileParams.filename = GetTestFileAbsolutePath( "MergeGroups/CSVAdditive/MergeResourceGroup.txt" );
 
     mergeImportFromFileParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1656,7 +1657,7 @@ TEST_F( ResourcesLibraryTest, MergeResourceGroupsAdditive_V_0_0_0 )
 	EXPECT_EQ( exportResult.type, CarbonResources::ResultType::SUCCESS );
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "MergeGroups/CSVAdditive/ExpectedMergedResourceGroup.txt" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "MergeGroups/CSVAdditive/ExpectedMergedResourceGroup.txt" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
@@ -1668,7 +1669,7 @@ TEST_F( ResourcesLibraryTest, RemoveResource )
 	// Import ResourceGroup
 	CarbonResources::ResourceGroupImportFromFileParams importParams;
 
-	importParams.filename = GetTestFileFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" );
+	importParams.filename = GetTestFileAbsolutePath( "RemoveResource/BaseResourceGroup.yaml" );
 
     importParams.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1712,7 +1713,7 @@ TEST_F( ResourcesLibraryTest, RemoveResource )
 
 
 	// Check output matches expected
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "RemoveResource/ResourceGroupAfterRemove.yaml" );
 
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 }
@@ -1724,9 +1725,15 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromFilter )
 
 	CarbonResources::CreateResourceGroupFromFilterParams params;
 
-	params.filterSettings.prefixMapBasePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	params.filterSettings.prefixMapBasePath = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
-	params.filterSettings.filterFilePaths.push_back( GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" ) );
+    std::unique_ptr<CarbonResources::Filter> filter = std::make_unique<CarbonResources::Filter>();
+
+    filter->filterFilePaths.push_back( GetTestFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" ) );
+
+    filter->outputResourceGroup = &resourceGroup;
+
+    params.filterSettings.filters.push_back( std::move( filter ) );
 
 	params.callbackSettings.statusCallback = StatusUpdate;
 
@@ -1745,9 +1752,9 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromFilter )
 	EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
@@ -1760,9 +1767,15 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromFilterExportResources )
 
 	CarbonResources::CreateResourceGroupFromFilterParams params;
 
-	params.filterSettings.prefixMapBasePath = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
+	params.filterSettings.prefixMapBasePath = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceFiles" );
 
-	params.filterSettings.filterFilePaths.push_back( GetTestFileFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" ) );
+    std::unique_ptr<CarbonResources::Filter> filter = std::make_unique<CarbonResources::Filter>();
+
+    filter->filterFilePaths.push_back( GetTestFileAbsolutePath( "FilterFiles/filterToIncludeAllAtBaseDirectory.ini" ) );
+
+    filter->outputResourceGroup = &resourceGroup;
+
+    params.filterSettings.filters.push_back( std::move( filter ) );
 
 	params.exportSettings.enabled = true;
 
@@ -1785,13 +1798,33 @@ TEST_F( ResourcesLibraryTest, CreateResourceGroupFromFilterExportResources )
 	EXPECT_TRUE( StatusIsValid() );
 
 #if _WIN64
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupWindows.yaml" );
 #elif __APPLE__
-	std::filesystem::path goldFile = GetTestFileFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateResourceFiles/ResourceGroupMacOS.yaml" );
 #else
 #error Unsupported platform
 #endif
 	EXPECT_TRUE( FilesMatch( goldFile, exportParams.filename ) );
 
 	EXPECT_TRUE( DirectoryIsSubset( params.exportSettings.destinationSettings.basePath, params.filterSettings.prefixMapBasePath ) );
+}
+
+TEST_F( ResourcesLibraryTest, LoadValidFilterIndexMappingFile )
+{
+	FilterIndexMappingFile file;
+
+    ASSERT_TRUE( file.LoadFromFile( GetTestFileAbsolutePath( "FilterFiles/resFilterIndexMapping.yaml" ) ) );
+
+    auto& mappings = file.GetFilterMappings();
+
+    ASSERT_EQ( mappings.size(), 1 );
+
+	const std::unique_ptr<FilterMapping>& mapping = mappings.at(0);
+
+    ASSERT_EQ( mapping->filterFilePaths.size(), 1 );
+
+	EXPECT_EQ(mapping->filterFilePaths.at(0),"filterToIncludeAllAtBaseDirectory.ini");
+
+	EXPECT_EQ( mapping->outputPath, "ResourceGroup.yaml" );
+
 }

--- a/tests/src/ResourcesTestFixture.cpp
+++ b/tests/src/ResourcesTestFixture.cpp
@@ -267,7 +267,7 @@ void ResourcesTestFixture::StatusUpdate( CarbonResources::StatusProgressType typ
     }
 }
 
-std::filesystem::path ResourcesTestFixture::GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath )
+std::filesystem::path ResourcesTestFixture::GetTestFileAbsolutePath( const std::filesystem::path& relativePath )
 {
 	std::filesystem::path basePath( TEST_DATA_BASE_PATH );
 

--- a/tests/src/ResourcesTestFixture.h
+++ b/tests/src/ResourcesTestFixture.h
@@ -76,7 +76,7 @@ struct ResourcesTestFixture : public ::testing::Test
 
 	void TearDown();
 
-	std::filesystem::path GetTestFileFileAbsolutePath( const std::filesystem::path& relativePath );
+	std::filesystem::path GetTestFileAbsolutePath( const std::filesystem::path& relativePath );
 
 	bool FileExists( const std::filesystem::path& filePath );
 

--- a/tests/testData/FilterFiles/filterToIncludeAllAtBaseDirectory.ini
+++ b/tests/testData/FilterFiles/filterToIncludeAllAtBaseDirectory.ini
@@ -1,0 +1,5 @@
+[DEFAULT]
+	prefixmap = prefix1:.
+
+[testSection]
+	respaths = prefix1:/*

--- a/tests/testData/FilterFiles/resFilterIndexMapping.yaml
+++ b/tests/testData/FilterFiles/resFilterIndexMapping.yaml
@@ -1,0 +1,8 @@
+# Filter index mappings used by resources job in CI
+Version: 1.0.0
+FilterIndexMappings:
+
+  - FilterMapping:
+    - FilterFile: filterToIncludeAllAtBaseDirectory.ini
+    OutputIndexFilename: ResourceGroup.yaml
+    

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SRC_FILES
         include/FileDataStreamIn.h
         include/FileDataStreamOut.h
         include/FilterFileReader.h
+        include/FilterIndexMappingFile.h
         include/GzipCompressionStream.h
         include/GzipDecompressionStream.h
         include/Md5ChecksumStream.h
@@ -31,6 +32,7 @@ set(SRC_FILES
         src/FileDataStreamIn.cpp
         src/FileDataStreamOut.cpp
         src/FilterFileReader.cpp
+        src/FilterIndexMappingFile.cpp
         src/GzipCompressionStream.cpp
         src/GzipDecompressionStream.cpp
         src/Md5ChecksumStream.cpp

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,6 +3,7 @@
 find_package(cryptopp CONFIG REQUIRED)
 find_package(CURL CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(unofficial-inih CONFIG REQUIRED)
 
 set(SRC_FILES
         include/BundleStreamIn.h
@@ -12,10 +13,12 @@ set(SRC_FILES
         include/Downloader.h
         include/FileDataStreamIn.h
         include/FileDataStreamOut.h
+        include/FilterFileReader.h
         include/GzipCompressionStream.h
         include/GzipDecompressionStream.h
         include/Md5ChecksumStream.h
         include/Patching.h
+        include/ResourceFilter.h
         include/ResourceTools.h
         include/RollingChecksum.h
         include/ScopedFile.h
@@ -27,9 +30,11 @@ set(SRC_FILES
         src/Downloader.cpp
         src/FileDataStreamIn.cpp
         src/FileDataStreamOut.cpp
+        src/FilterFileReader.cpp
         src/GzipCompressionStream.cpp
         src/GzipDecompressionStream.cpp
         src/Md5ChecksumStream.cpp
+        src/ResourceFilter.cpp
         src/ResourceTools.cpp
         src/ScopedFile.cpp
         src/Patching.cpp
@@ -50,6 +55,6 @@ if (WIN32)
     target_compile_definitions(resources-tools PRIVATE NOMINMAX) # Do not define min/max macros.
 endif ()
 
-target_link_libraries(resources-tools PRIVATE cryptopp::cryptopp CURL::libcurl ZLIB::ZLIB static_bsdiff)
+target_link_libraries(resources-tools PRIVATE cryptopp::cryptopp CURL::libcurl ZLIB::ZLIB static_bsdiff unofficial::inih::inireader)
 
 target_include_directories(resources-tools PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/tools/include/Downloader.h
+++ b/tools/include/Downloader.h
@@ -9,6 +9,14 @@
 
 namespace ResourceTools
 {
+
+enum class Response
+{
+	SUCCESS,
+	FILE_NOT_FOUND,
+	DOWNLOAD_ERROR,
+};
+
 // Utility class for downloading files.
 // Reuse is encouraged for multiple downloads, but do not share across threads.
 class Downloader
@@ -17,6 +25,10 @@ public:
 	Downloader();
 	~Downloader();
 	bool DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds );
+
+    Response GetHeader( const std::string& url, uintmax_t retryCount, const std::chrono::seconds& retrySeconds, std::string& response );
+
+	static bool GetAttributeValueFromHeader( const std::string& header, const std::string& attributeName, std::string& value );
 
 private:
 	CURL* m_curlHandle{ nullptr };

--- a/tools/include/FilterFileReader.h
+++ b/tools/include/FilterFileReader.h
@@ -40,11 +40,13 @@ struct FilterSection
 	std::set<std::string> excludeRules;
 
 	std::vector<std::unique_ptr<ResPath>> respaths;
+
+    bool containsNonWildcardResPath;
 };
 
 struct FilterFile
 {
-	std::unordered_map<std::string, std::shared_ptr<Prefix>> prefixes;
+	std::vector<std::shared_ptr<Prefix>> prefixes;
 
 	std::set<std::string> includeRules;
 
@@ -60,16 +62,16 @@ public:
 
 	~FilterFileReader();
 
-	static void LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData );
+	static void LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData, bool ignoreCase = false );
 
 private:
-	static void ParsePrefixMappings( const std::string& prefixStr, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes );
+	static void ParsePrefixMappings( const std::string& prefixStr, std::vector<std::shared_ptr<Prefix>>& prefixes );
 
 	static void ParsePrefixPaths( const std::string& prefixPathsStr, std::vector<std::filesystem::path>& paths );
 
-	static void ParseIncludeExcludeRules( const std::string& rulesStr, std::set<std::string>& includeRules, std::set<std::string>& excludeRules );
+	static void ParseIncludeExcludeRules( const std::string& rulesStr, std::set<std::string>& includeRules, std::set<std::string>& excludeRules, bool ignoreCase );
 
-	static void ParseSectionResPathEntry( const std::string& filterStr, std::vector<std::unique_ptr<ResPath>>& resPaths, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes );
+	static void ParseSectionResPathEntry( const std::string& filterStr, std::vector<std::unique_ptr<ResPath>>& resPaths, std::vector<std::shared_ptr<Prefix>>& prefixes, bool ignoreCase );
 };
 }
 

--- a/tools/include/FilterFileReader.h
+++ b/tools/include/FilterFileReader.h
@@ -1,0 +1,76 @@
+// Copyright © 2025 CCP ehf.
+
+#pragma once
+#ifndef FilterFileReader_H
+#define FilterFileReader_H
+
+#include <filesystem>
+#include <vector>
+#include <unordered_map>
+#include <set>
+#include <memory>
+
+namespace ResourceTools
+{
+
+struct Prefix
+{
+	std::string id;
+
+	std::vector<std::filesystem::path> paths;
+};
+
+struct ResPath
+{
+	std::shared_ptr<Prefix> prefix;
+
+	std::filesystem::path path = "";
+
+	std::set<std::string> includeRules;
+
+	std::set<std::string> excludeRules;
+};
+
+struct FilterSection
+{
+	std::string id;
+
+	std::set<std::string> includeRules;
+
+	std::set<std::string> excludeRules;
+
+	std::vector<std::unique_ptr<ResPath>> respaths;
+};
+
+struct FilterFile
+{
+	std::unordered_map<std::string, std::shared_ptr<Prefix>> prefixes;
+
+	std::set<std::string> includeRules;
+
+	std::set<std::string> excludeRules;
+
+	std::vector<std::unique_ptr<FilterSection>> filterSections;
+};
+
+class FilterFileReader
+{
+public:
+	FilterFileReader();
+
+	~FilterFileReader();
+
+	static void LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData );
+
+private:
+	static void ParsePrefixMappings( const std::string& prefixStr, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes );
+
+	static void ParsePrefixPaths( const std::string& prefixPathsStr, std::vector<std::filesystem::path>& paths );
+
+	static void ParseIncludeExcludeRules( const std::string& rulesStr, std::set<std::string>& includeRules, std::set<std::string>& excludeRules );
+
+	static void ParseSectionResPathEntry( const std::string& filterStr, std::vector<std::unique_ptr<ResPath>>& resPaths, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes );
+};
+}
+
+#endif //FilterFileReader_H

--- a/tools/include/FilterFileReader.h
+++ b/tools/include/FilterFileReader.h
@@ -58,9 +58,9 @@ struct FilterFile
 class FilterFileReader
 {
 public:
-	FilterFileReader();
+	FilterFileReader() = default;
 
-	~FilterFileReader();
+	~FilterFileReader() = default;
 
 	static void LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData, bool ignoreCase = false );
 

--- a/tools/include/FilterIndexMappingFile.h
+++ b/tools/include/FilterIndexMappingFile.h
@@ -17,9 +17,9 @@ struct FilterMapping
 class FilterIndexMappingFile
 {
 public:
-	FilterIndexMappingFile();
+	FilterIndexMappingFile() = default;
 
-	~FilterIndexMappingFile( );
+	~FilterIndexMappingFile( ) = default;
 
     bool LoadFromFile( const std::filesystem::path& path );
 

--- a/tools/include/FilterIndexMappingFile.h
+++ b/tools/include/FilterIndexMappingFile.h
@@ -1,0 +1,34 @@
+// Copyright © 2025 CCP ehf.
+
+#pragma once
+#ifndef FilterIndexMappingFile_H
+#define FilterIndexMappingFile_H
+
+#include <filesystem>
+#include <vector>
+
+struct FilterMapping
+{
+	std::vector<std::filesystem::path> filterFilePaths;
+
+	std::filesystem::path outputPath;
+};
+
+class FilterIndexMappingFile
+{
+public:
+	FilterIndexMappingFile();
+
+	~FilterIndexMappingFile( );
+
+    bool LoadFromFile( const std::filesystem::path& path );
+
+    const std::vector<std::unique_ptr<FilterMapping>>& GetFilterMappings() const;
+
+private:
+
+	std::vector<std::unique_ptr<FilterMapping>> m_filterMappings;
+
+};
+
+#endif // FilterIndexMappingFile_H

--- a/tools/include/ResourceFilter.h
+++ b/tools/include/ResourceFilter.h
@@ -36,9 +36,9 @@ struct FilterPath
 class ResourceFilter
 {
 public:
-	ResourceFilter();
+	ResourceFilter() = default;
 
-	~ResourceFilter();
+	~ResourceFilter() = default;
 
 	bool SetFromFilterFileData( const FilterFile& fileData );
 

--- a/tools/include/ResourceFilter.h
+++ b/tools/include/ResourceFilter.h
@@ -8,6 +8,8 @@
 
 #include <filesystem>
 #include <vector>
+#include <map>
+#include <regex>
 
 namespace ResourceTools
 {
@@ -15,11 +17,19 @@ namespace ResourceTools
 struct FilterPath
 {
 	std::string sectionId;
+
 	std::string prefixId;
+
 	std::string path;
+
 	std::string matchPattern;
+
+	std::regex matchPatternRegex;
+
 	std::set<std::string> includeRules;
+
 	std::set<std::string> excludeRules;
+
 	bool containsLocalIncludeExcludeRules;
 };
 
@@ -39,10 +49,10 @@ public:
 	const std::vector<std::filesystem::path>& GetPrefixPaths() const;
 
 private:
-	void ConvertResPathToPattern( const std::string& resPath, std::string& pattern ) const;
+	void ConvertResPathToPattern( std::string resPath, std::string& pattern ) const;
 
 private:
-	std::vector<std::unique_ptr<FilterPath>> m_paths;
+	std::map<std::string,std::vector<std::unique_ptr<FilterPath>>> m_paths;
 
 	std::vector<std::filesystem::path> m_prefixPaths;
 };

--- a/tools/include/ResourceFilter.h
+++ b/tools/include/ResourceFilter.h
@@ -1,0 +1,51 @@
+// Copyright © 2025 CCP ehf.
+
+#pragma once
+#ifndef ResourceFilter_H
+#define ResourceFilter_H
+
+#include "FilterFileReader.h"
+
+#include <filesystem>
+#include <vector>
+
+namespace ResourceTools
+{
+
+struct FilterPath
+{
+	std::string sectionId;
+	std::string prefixId;
+	std::string path;
+	std::string matchPattern;
+	std::set<std::string> includeRules;
+	std::set<std::string> excludeRules;
+	bool containsLocalIncludeExcludeRules;
+};
+
+class ResourceFilter
+{
+public:
+	ResourceFilter();
+
+	~ResourceFilter();
+
+	bool SetFromFilterFileData( const FilterFile& fileData );
+
+	bool CheckPath( const std::filesystem::path& path ) const;
+
+	bool CheckPath( const std::filesystem::path& path, std::string& matchSectionId, std::string& matchPath ) const;
+
+	const std::vector<std::filesystem::path>& GetPrefixPaths() const;
+
+private:
+	void ConvertResPathToPattern( const std::string& resPath, std::string& pattern ) const;
+
+private:
+	std::vector<std::unique_ptr<FilterPath>> m_paths;
+
+	std::vector<std::filesystem::path> m_prefixPaths;
+};
+}
+
+#endif //ResourceFilter_H

--- a/tools/src/Downloader.cpp
+++ b/tools/src/Downloader.cpp
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <set>
 #include <thread>
+#include <sstream>
+#include <iostream>
 
 int s_activeDownloaders{ 0 };
 std::set<int> s_curl_retry_errors{
@@ -43,6 +45,16 @@ size_t WriteToFileStreamCallback( void* contents, size_t size, size_t nmemb, voi
 	return realSize;
 }
 
+size_t WriteToFileStringCallback( void* contents, size_t size, size_t nmemb, void* context )
+{
+	const char* charString = static_cast<const char*>( contents );
+	const size_t realSize = size * nmemb;
+	std::stringstream* out = static_cast<std::stringstream*>( context );
+	std::string str( charString, realSize );
+	*out << str;
+	return realSize;
+}
+
 namespace ResourceTools
 {
 Downloader::Downloader()
@@ -62,6 +74,44 @@ Downloader::~Downloader()
 	{
 		ShutDownCurl();
 	}
+}
+
+Response Downloader::GetHeader( const std::string& url, uintmax_t retryCount, const std::chrono::seconds& retrySeconds, std::string& response )
+{
+	std::stringstream out;
+	curl_easy_setopt( m_curlHandle, CURLOPT_URL, url.c_str() );
+	curl_easy_setopt( m_curlHandle, CURLOPT_NOBODY, 1L );
+	curl_easy_setopt( m_curlHandle, CURLOPT_HEADER, 1L );
+	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEDATA, &out );
+	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEFUNCTION, WriteToFileStringCallback );
+
+	for( unsigned int i = 0; i < retryCount; i++ )
+	{
+		CURLcode cc = curl_easy_perform( m_curlHandle );
+
+		if( cc == CURLE_OK )
+		{
+			// File exists
+			response = out.str();
+
+			return Response::SUCCESS;
+		}
+
+		if( cc == CURLE_REMOTE_FILE_NOT_FOUND )
+		{
+			// File doesn't exist
+			response = out.str();
+
+			return Response::FILE_NOT_FOUND;
+		}
+
+		// Wait and retry with simple backoff
+		std::this_thread::sleep_for( retrySeconds * ( i + 1 ) );
+	}
+
+	response = out.str();
+
+	return Response::DOWNLOAD_ERROR;
 }
 
 bool Downloader::DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds )
@@ -105,6 +155,36 @@ bool Downloader::DownloadFile( const std::string& url, const std::filesystem::pa
 		}
 		sleepSeconds *= 2;
 	} while( true );
+}
+
+bool Downloader::GetAttributeValueFromHeader( const std::string& header, const std::string& attributeName, std::string& value )
+{
+	const std::string DELIMITER = ":";
+
+	std::string attributeNameMatch = attributeName + DELIMITER;
+
+	std::stringstream ss( header );
+
+	std::string line;
+	while( std::getline( ss, line ) )
+	{
+		auto findResult = line.find( attributeNameMatch );
+
+		if( findResult != std::string::npos )
+		{
+			// Attribute found
+			auto findResult = line.find( DELIMITER );
+
+			if( findResult != std::string::npos )
+			{
+				// Delimiter found
+				value = line.substr( findResult + 2 );
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 }

--- a/tools/src/FilterFileReader.cpp
+++ b/tools/src/FilterFileReader.cpp
@@ -5,6 +5,7 @@
 #include <INIReader.h>
 #include <cctype>
 #include <sstream>
+#include <algorithm>
 
 namespace ResourceTools
 {
@@ -17,7 +18,7 @@ FilterFileReader::~FilterFileReader()
 {
 }
 
-void FilterFileReader::LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData )
+void FilterFileReader::LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData, bool ignoreCase /*= false*/ )
 {
 
 	INIReader reader( data, dataSize );
@@ -39,9 +40,9 @@ void FilterFileReader::LoadFromIniFileData( const char* data, size_t dataSize, F
 
 	std::string globalFiltersStr = reader.Get( "DEFAULT", "filter", "" );
 
-	ParseIncludeExcludeRules( globalFiltersStr, fileData.includeRules, fileData.excludeRules );
+	ParseIncludeExcludeRules( globalFiltersStr, fileData.includeRules, fileData.excludeRules, ignoreCase );
 
-	// Get section infomration
+	// Get section information
 	for( const auto& sectionName : reader.Sections() )
 	{
 		if( sectionName == "default" || sectionName == "DEFAULT" )
@@ -56,18 +57,18 @@ void FilterFileReader::LoadFromIniFileData( const char* data, size_t dataSize, F
 		// Filter is optional
 		std::string filter = reader.Get( sectionName, "filter", "" );
 
-		ParseIncludeExcludeRules( filter, filterSection->includeRules, filterSection->excludeRules );
+		ParseIncludeExcludeRules( filter, filterSection->includeRules, filterSection->excludeRules, ignoreCase );
 
 		// Respaths is required
 		std::string respathsStr = reader.Get( sectionName, "respaths", "" );
 
-		ParseSectionResPathEntry( respathsStr, filterSection->respaths, fileData.prefixes );
+		ParseSectionResPathEntry( respathsStr, filterSection->respaths, fileData.prefixes, ignoreCase );
 
 		fileData.filterSections.push_back( std::move( filterSection ) );
 	}
 }
 
-void FilterFileReader::ParsePrefixMappings( const std::string& prefixStr, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes )
+void FilterFileReader::ParsePrefixMappings( const std::string& prefixStr, std::vector<std::shared_ptr<Prefix>>& prefixes )
 {
 
 	std::size_t pos = 0;
@@ -100,16 +101,30 @@ void FilterFileReader::ParsePrefixMappings( const std::string& prefixStr, std::u
 			throw std::invalid_argument( "Invalid prefixmap format: No paths defined for prefix: " + prefix );
 		}
 
-		auto it = prefixes.find( prefix );
-		if( it == prefixes.end() )
+        bool prefixFound = false;
+
+		std::shared_ptr<Prefix> currentPrefix;
+
+		for( auto iter = prefixes.begin(); iter != prefixes.end(); iter++ )
 		{
-			prefixes.emplace( prefix, std::make_shared<Prefix>() );
-			it = prefixes.find( prefix );
+			if( ( *iter )->id == prefix )
+			{
+				prefixFound = true;
+				currentPrefix = *iter;
+				break;
+			}
 		}
 
-		it->second->id = prefix;
+		if( !prefixFound )
+		{
+			currentPrefix = std::make_shared<Prefix>();
 
-		ParsePrefixPaths( rawPaths, it->second->paths );
+			currentPrefix->id = prefix;
+
+			prefixes.push_back( currentPrefix );
+		}
+
+		ParsePrefixPaths( rawPaths, currentPrefix->paths );
 
 		// Go to the next token in the rawPrefixMap (or break if at end)
 		if( nextSpace == std::string::npos )
@@ -151,48 +166,47 @@ void FilterFileReader::ParsePrefixPaths( const std::string& prefixPathsStr, std:
 	}
 }
 
-void FilterFileReader::ParseIncludeExcludeRules( const std::string& rulesStr, std::set<std::string>& includeRules, std::set<std::string>& excludeRules )
+void FilterFileReader::ParseIncludeExcludeRules( const std::string& rulesStr, std::set<std::string>& includeRules, std::set<std::string>& excludeRules, bool ignoreCase )
 {
 
-	std::string s = rulesStr;
 	size_t pos = 0;
-	while( pos < s.size() )
+	while( pos < rulesStr.size() )
 	{
 		// Skip whitespaces
-		while( pos < s.size() && std::isspace( static_cast<unsigned char>( s[pos] ) ) )
+		while( pos < rulesStr.size() && std::isspace( static_cast<unsigned char>( rulesStr[pos] ) ) )
 		{
 			++pos;
 		}
-		if( pos >= s.size() )
+		if( pos >= rulesStr.size() )
 		{
 			break;
 		}
 
 		// Check for exclude filter marker '!'
 		bool isExclude = false;
-		if( s[pos] == '!' )
+		if( rulesStr[pos] == '!' )
 		{
 			// We have an exclude filter, advance the position by one and skip whitespace(s)
 			isExclude = true;
 			++pos;
-			while( pos < s.size() && std::isspace( static_cast<unsigned char>( s[pos] ) ) )
+			while( pos < rulesStr.size() && std::isspace( static_cast<unsigned char>( rulesStr[pos] ) ) )
 			{
 				++pos;
 			}
-			if( pos >= s.size() )
+			if( pos >= rulesStr.size() )
 			{
 				throw std::invalid_argument( "Invalid filter format: exclude filter marker found without a [ token ] section" );
 			}
 		}
 
-		if( pos >= s.size() || s[pos] != '[' )
+		if( pos >= rulesStr.size() || rulesStr[pos] != '[' )
 		{
 			throw std::invalid_argument( "Invalid filter format: missing '['" );
 		}
 		++pos; // skip '['
 
-		size_t endBracket = s.find( ']', pos );
-		size_t nextStartBracket = s.find( '[', pos );
+		size_t endBracket = rulesStr.find( ']', pos );
+		size_t nextStartBracket = rulesStr.find( '[', pos );
 		if( nextStartBracket != std::string::npos && nextStartBracket < endBracket )
 		{
 			throw std::invalid_argument( "Invalid filter format: matching end bracket ']' not present before the next start bracket '['" );
@@ -203,7 +217,7 @@ void FilterFileReader::ParseIncludeExcludeRules( const std::string& rulesStr, st
 			throw std::invalid_argument( "Invalid filter format: missing ']'" );
 		}
 
-		std::string entries = s.substr( pos, endBracket - pos );
+		std::string entries = rulesStr.substr( pos, endBracket - pos );
 		std::istringstream iss( entries );
 		std::string token;
 		while( iss >> token )
@@ -222,6 +236,11 @@ void FilterFileReader::ParseIncludeExcludeRules( const std::string& rulesStr, st
 				continue;
 			}
 
+            if (ignoreCase)
+            {
+				std::transform( token.begin(), token.end(), token.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+            }
+
 			if( isExclude )
 			{
 				excludeRules.insert( token );
@@ -235,7 +254,7 @@ void FilterFileReader::ParseIncludeExcludeRules( const std::string& rulesStr, st
 	}
 }
 
-void FilterFileReader::ParseSectionResPathEntry( const std::string& filterStr, std::vector<std::unique_ptr<ResPath>>& resPaths, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes )
+void FilterFileReader::ParseSectionResPathEntry( const std::string& filterStr, std::vector<std::unique_ptr<ResPath>>& resPaths, std::vector<std::shared_ptr<Prefix>>& prefixes, bool ignoreCase )
 {
 
 	// Split rawPathFileAttrib into lines (in case of multiline attribute)
@@ -280,16 +299,29 @@ void FilterFileReader::ParseSectionResPathEntry( const std::string& filterStr, s
 
 		std::unique_ptr resPath = std::make_unique<ResPath>();
 
+        if (ignoreCase)
+        {
+			std::transform( pathPart.begin(), pathPart.end(), pathPart.begin(), []( unsigned char c ) { return std::tolower( c ); } );
+        }
+
 		resPath->path = pathPart;
 
-		auto prefixIter = prefixes.find( prefixPart );
+        auto prefixIter = prefixes.begin();
+
+		for( prefixIter; prefixIter != prefixes.end(); prefixIter++ )
+		{
+			if( ( *prefixIter )->id == prefixPart )
+			{
+				break;
+			}
+		}
 
 		if( prefixIter == prefixes.end() )
 		{
 			throw std::invalid_argument( "Respath referencing unknown prefix: " + rawPathLine );
 		}
 
-		resPath->prefix = prefixIter->second;
+		resPath->prefix = *prefixIter;
 
 		if( !iss.eof() )
 		{
@@ -297,7 +329,7 @@ void FilterFileReader::ParseSectionResPathEntry( const std::string& filterStr, s
 			std::string rawOptionalFilterPart;
 			std::getline( iss, rawOptionalFilterPart );
 
-			ParseIncludeExcludeRules( rawOptionalFilterPart, resPath->includeRules, resPath->excludeRules );
+			ParseIncludeExcludeRules( rawOptionalFilterPart, resPath->includeRules, resPath->excludeRules, ignoreCase );
 		}
 
 		resPaths.push_back( std::move( resPath ) );

--- a/tools/src/FilterFileReader.cpp
+++ b/tools/src/FilterFileReader.cpp
@@ -308,7 +308,7 @@ void FilterFileReader::ParseSectionResPathEntry( const std::string& filterStr, s
 
         auto prefixIter = prefixes.begin();
 
-		for( prefixIter; prefixIter != prefixes.end(); prefixIter++ )
+		for( ; prefixIter != prefixes.end(); prefixIter++ )
 		{
 			if( ( *prefixIter )->id == prefixPart )
 			{

--- a/tools/src/FilterFileReader.cpp
+++ b/tools/src/FilterFileReader.cpp
@@ -1,0 +1,307 @@
+// Copyright © 2025 CCP ehf.
+
+#include "FilterFileReader.h"
+
+#include <INIReader.h>
+#include <cctype>
+#include <sstream>
+
+namespace ResourceTools
+{
+
+FilterFileReader::FilterFileReader()
+{
+}
+
+FilterFileReader::~FilterFileReader()
+{
+}
+
+void FilterFileReader::LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData )
+{
+
+	INIReader reader( data, dataSize );
+
+	if( reader.ParseError() != 0 )
+	{
+		throw std::runtime_error( "Failed to parse INI file - " + reader.ParseErrorMessage() );
+	}
+
+	if( !reader.HasSection( "DEFAULT" ) )
+	{
+		throw std::invalid_argument( "Required [DEFAULT] section not present in INI file. " );
+	}
+
+	// Get prefix information
+	std::string prefixMappingsStr = reader.Get( "DEFAULT", "prefixmap", "" );
+
+	ParsePrefixMappings( prefixMappingsStr, fileData.prefixes );
+
+	std::string globalFiltersStr = reader.Get( "DEFAULT", "filter", "" );
+
+	ParseIncludeExcludeRules( globalFiltersStr, fileData.includeRules, fileData.excludeRules );
+
+	// Get section infomration
+	for( const auto& sectionName : reader.Sections() )
+	{
+		if( sectionName == "default" || sectionName == "DEFAULT" )
+		{
+			continue; // Already loaded, skip it
+		}
+
+		std::unique_ptr filterSection = std::make_unique<FilterSection>();
+
+		filterSection->id = sectionName;
+
+		// Filter is optional
+		std::string filter = reader.Get( sectionName, "filter", "" );
+
+		ParseIncludeExcludeRules( filter, filterSection->includeRules, filterSection->excludeRules );
+
+		// Respaths is required
+		std::string respathsStr = reader.Get( sectionName, "respaths", "" );
+
+		ParseSectionResPathEntry( respathsStr, filterSection->respaths, fileData.prefixes );
+
+		fileData.filterSections.push_back( std::move( filterSection ) );
+	}
+}
+
+void FilterFileReader::ParsePrefixMappings( const std::string& prefixStr, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes )
+{
+
+	std::size_t pos = 0;
+	while( pos < prefixStr.size() )
+	{
+		// Find the prefix (or error out if missing a colon ":")
+		std::size_t colon = prefixStr.find( ':', pos );
+		if( colon == std::string::npos )
+		{
+			throw std::invalid_argument( "Invalid prefixmap format: missing ':'" );
+		}
+
+		std::string prefix = prefixStr.substr( pos, colon - pos );
+		if( prefix.empty() )
+		{
+			throw std::invalid_argument( "Invalid prefixmap format: empty prefix" );
+		}
+
+		// Move position past the colon
+		pos = colon + 1;
+
+		// Find end of paths (next whitespace or end of string)
+		std::size_t nextSpace = prefixStr.find_first_of( " \t\r\n", pos );
+		std::string rawPaths = ( nextSpace == std::string::npos ) ?
+			prefixStr.substr( pos ) :
+			prefixStr.substr( pos, nextSpace - pos );
+
+		if( rawPaths.empty() )
+		{
+			throw std::invalid_argument( "Invalid prefixmap format: No paths defined for prefix: " + prefix );
+		}
+
+		auto it = prefixes.find( prefix );
+		if( it == prefixes.end() )
+		{
+			prefixes.emplace( prefix, std::make_shared<Prefix>() );
+			it = prefixes.find( prefix );
+		}
+
+		it->second->id = prefix;
+
+		ParsePrefixPaths( rawPaths, it->second->paths );
+
+		// Go to the next token in the rawPrefixMap (or break if at end)
+		if( nextSpace == std::string::npos )
+		{
+			break;
+		}
+		pos = nextSpace + 1;
+
+		// There was a whitespace, skip any additional spaces as well
+		while( pos < prefixStr.size() && std::isspace( static_cast<unsigned char>( prefixStr[pos] ) ) )
+		{
+			++pos;
+		}
+	}
+}
+
+void FilterFileReader::ParsePrefixPaths( const std::string& prefixPathsStr, std::vector<std::filesystem::path>& paths )
+{
+	std::size_t pos = 0;
+	// Loop through rawPaths and split by semicolons to extract individual paths (in case there are many)
+	while( pos < prefixPathsStr.size() )
+	{
+		// Split the string up by semicolons (in case of multiple paths)
+		std::size_t semicolon = prefixPathsStr.find( ';', pos );
+		std::string path = ( semicolon == std::string::npos ) ?
+			prefixPathsStr.substr( pos ) :
+			prefixPathsStr.substr( pos, semicolon - pos );
+
+		if( !path.empty() )
+		{
+			paths.push_back( path );
+		}
+
+		if( semicolon == std::string::npos )
+		{
+			break;
+		}
+		pos = semicolon + 1;
+	}
+}
+
+void FilterFileReader::ParseIncludeExcludeRules( const std::string& rulesStr, std::set<std::string>& includeRules, std::set<std::string>& excludeRules )
+{
+
+	std::string s = rulesStr;
+	size_t pos = 0;
+	while( pos < s.size() )
+	{
+		// Skip whitespaces
+		while( pos < s.size() && std::isspace( static_cast<unsigned char>( s[pos] ) ) )
+		{
+			++pos;
+		}
+		if( pos >= s.size() )
+		{
+			break;
+		}
+
+		// Check for exclude filter marker '!'
+		bool isExclude = false;
+		if( s[pos] == '!' )
+		{
+			// We have an exclude filter, advance the position by one and skip whitespace(s)
+			isExclude = true;
+			++pos;
+			while( pos < s.size() && std::isspace( static_cast<unsigned char>( s[pos] ) ) )
+			{
+				++pos;
+			}
+			if( pos >= s.size() )
+			{
+				throw std::invalid_argument( "Invalid filter format: exclude filter marker found without a [ token ] section" );
+			}
+		}
+
+		if( pos >= s.size() || s[pos] != '[' )
+		{
+			throw std::invalid_argument( "Invalid filter format: missing '['" );
+		}
+		++pos; // skip '['
+
+		size_t endBracket = s.find( ']', pos );
+		size_t nextStartBracket = s.find( '[', pos );
+		if( nextStartBracket != std::string::npos && nextStartBracket < endBracket )
+		{
+			throw std::invalid_argument( "Invalid filter format: matching end bracket ']' not present before the next start bracket '['" );
+		}
+
+		if( endBracket == std::string::npos )
+		{
+			throw std::invalid_argument( "Invalid filter format: missing ']'" );
+		}
+
+		std::string entries = s.substr( pos, endBracket - pos );
+		std::istringstream iss( entries );
+		std::string token;
+		while( iss >> token )
+		{
+			// Trim whitespace from token
+			size_t start = token.find_first_not_of( " \t\r\n" );
+			size_t end = token.find_last_not_of( " \t\r\n" );
+			if( start == std::string::npos || end == std::string::npos )
+			{
+				continue;
+			}
+			token = token.substr( start, end - start + 1 );
+
+			if( token.empty() )
+			{
+				continue;
+			}
+
+			if( isExclude )
+			{
+				excludeRules.insert( token );
+			}
+			else
+			{
+				includeRules.insert( token );
+			}
+		}
+		pos = endBracket + 1;
+	}
+}
+
+void FilterFileReader::ParseSectionResPathEntry( const std::string& filterStr, std::vector<std::unique_ptr<ResPath>>& resPaths, std::unordered_map<std::string, std::shared_ptr<Prefix>>& prefixes )
+{
+
+	// Split rawPathFileAttrib into lines (in case of multiline attribute)
+	std::istringstream stream( filterStr );
+	std::string line;
+
+	while( std::getline( stream, line ) )
+	{
+		// Trim whitespace from both ends
+		size_t first = line.find_first_not_of( " \t\r" );
+		if( first == std::string::npos )
+		{
+			continue; // skip if empty line
+		}
+
+		size_t last = line.find_last_not_of( " \t\r" );
+		std::string rawPathLine = line.substr( first, last - first + 1 );
+
+		// Skip commented out lines (in case there is "inline" comment within the .ini file attribute value)
+		if( rawPathLine.empty() || rawPathLine[0] == '#' || rawPathLine[0] == ';' )
+		{
+			continue;
+		}
+
+		std::istringstream iss( rawPathLine );
+		std::string rawPrefixPathToken;
+		iss >> rawPrefixPathToken;
+
+		size_t colon = rawPrefixPathToken.find( ':' );
+		if( colon == std::string::npos )
+		{
+			throw std::invalid_argument( std::string( "Missing prefix in path for: " ) + rawPathLine );
+		}
+		std::string prefixPart = rawPrefixPathToken.substr( 0, colon );
+		std::string pathPart = rawPrefixPathToken.substr( colon + 1 );
+
+		if( pathPart.find( "../" ) != std::string::npos )
+		{
+			// Escaping is not supported in respaths
+			throw std::invalid_argument( "Escaping paths not supported for respaths: " + rawPathLine );
+		}
+
+		std::unique_ptr resPath = std::make_unique<ResPath>();
+
+		resPath->path = pathPart;
+
+		auto prefixIter = prefixes.find( prefixPart );
+
+		if( prefixIter == prefixes.end() )
+		{
+			throw std::invalid_argument( "Respath referencing unknown prefix: " + rawPathLine );
+		}
+
+		resPath->prefix = prefixIter->second;
+
+		if( !iss.eof() )
+		{
+			// Read optional filters
+			std::string rawOptionalFilterPart;
+			std::getline( iss, rawOptionalFilterPart );
+
+			ParseIncludeExcludeRules( rawOptionalFilterPart, resPath->includeRules, resPath->excludeRules );
+		}
+
+		resPaths.push_back( std::move( resPath ) );
+	}
+}
+
+}

--- a/tools/src/FilterFileReader.cpp
+++ b/tools/src/FilterFileReader.cpp
@@ -10,13 +10,6 @@
 namespace ResourceTools
 {
 
-FilterFileReader::FilterFileReader()
-{
-}
-
-FilterFileReader::~FilterFileReader()
-{
-}
 
 void FilterFileReader::LoadFromIniFileData( const char* data, size_t dataSize, FilterFile& fileData, bool ignoreCase /*= false*/ )
 {

--- a/tools/src/FilterIndexMappingFile.cpp
+++ b/tools/src/FilterIndexMappingFile.cpp
@@ -1,0 +1,89 @@
+// Copyright © 2025 CCP ehf.
+
+#include "FilterIndexMappingFile.h"
+
+#include <yaml-cpp/yaml.h>
+
+FilterIndexMappingFile::FilterIndexMappingFile()
+{
+}
+
+FilterIndexMappingFile::~FilterIndexMappingFile()
+{
+}
+
+bool FilterIndexMappingFile::LoadFromFile( const std::filesystem::path& path )
+{
+
+	// TODO add returns for invalid file
+	YAML::Node file;
+	try
+	{
+		file = YAML::LoadFile( path.string() );
+	}
+	catch( YAML::ParserException& )
+	{
+		return false;
+	}
+
+	YAML::Node version = file["Version"];
+
+	if( !version.IsDefined() )
+	{
+		return false;
+	}
+
+	YAML::Node filterIndexMappings = file["FilterIndexMappings"];
+
+	if( !filterIndexMappings.IsDefined() )
+	{
+		return false;
+	}
+
+	// Iterate through all the mappings
+	for( auto iter = filterIndexMappings.begin(); iter != filterIndexMappings.end(); iter++ )
+	{
+		std::unique_ptr<FilterMapping> mapping = std::make_unique<FilterMapping>();
+
+		YAML::Node filterIndexMapping = ( *iter );
+
+		YAML::Node outputIndexFilename = filterIndexMapping["OutputIndexFilename"];
+
+		if( !outputIndexFilename.IsDefined() )
+		{
+			return false;
+		}
+
+		mapping->outputPath = outputIndexFilename.as<std::string>();
+
+		YAML::Node filterMapping = filterIndexMapping["FilterMapping"];
+
+		for( auto iter = filterMapping.begin(); iter != filterMapping.end(); iter++ )
+		{
+			YAML::Node filterFilePath = ( *iter );
+
+			YAML::Node filterFile = filterFilePath["FilterFile"];
+
+			mapping->filterFilePaths.push_back( filterFile.as<std::string>() );
+		}
+
+		if( mapping->filterFilePaths.size() == 0 )
+		{
+			return false;
+		}
+
+		m_filterMappings.push_back( std::move( mapping ) );
+	}
+
+	if( m_filterMappings.size() == 0 )
+	{
+		return false;
+	}
+
+	return true;
+}
+
+const std::vector<std::unique_ptr<FilterMapping>>& FilterIndexMappingFile::GetFilterMappings() const
+{
+	return m_filterMappings;
+}

--- a/tools/src/FilterIndexMappingFile.cpp
+++ b/tools/src/FilterIndexMappingFile.cpp
@@ -4,18 +4,9 @@
 
 #include <yaml-cpp/yaml.h>
 
-FilterIndexMappingFile::FilterIndexMappingFile()
-{
-}
-
-FilterIndexMappingFile::~FilterIndexMappingFile()
-{
-}
-
 bool FilterIndexMappingFile::LoadFromFile( const std::filesystem::path& path )
 {
 
-	// TODO add returns for invalid file
 	YAML::Node file;
 	try
 	{

--- a/tools/src/ResourceFilter.cpp
+++ b/tools/src/ResourceFilter.cpp
@@ -1,8 +1,6 @@
 // Copyright © 2025 CCP ehf.
 
 #include "ResourceFilter.h"
-
-#include <regex>
 #include <algorithm>
 
 namespace ResourceTools
@@ -23,7 +21,7 @@ bool ResourceFilter::SetFromFilterFileData( const FilterFile& fileData )
 	// Populate prefix paths
 	for( auto& prefix : fileData.prefixes )
 	{
-		for( auto& prefixPath : prefix.second->paths )
+		for( auto& prefixPath : prefix->paths )
 		{
 			m_prefixPaths.push_back( prefixPath );
 		}
@@ -38,6 +36,8 @@ bool ResourceFilter::SetFromFilterFileData( const FilterFile& fileData )
 		// Add section rules
 		includeRules.insert( filterSection->includeRules.begin(), filterSection->includeRules.end() );
 		excludeRules.insert( filterSection->excludeRules.begin(), filterSection->excludeRules.end() );
+
+        bool containsNonWildcardResPath = false;
 
 		for( auto& resPath : filterSection->respaths )
 		{
@@ -71,7 +71,16 @@ bool ResourceFilter::SetFromFilterFileData( const FilterFile& fileData )
 					filterPath->path = filterPath->path.substr( 1 );
 				}
 
-				ConvertResPathToPattern( filterPath->path, filterPath->matchPattern );
+                bool wildcardReplacedInMatchPattern = false;
+
+				ConvertResPathToPattern( filterPath->path, filterPath->matchPattern);
+
+                if( wildcardReplacedInMatchPattern )
+                {
+					containsNonWildcardResPath = true;
+                }
+
+                filterPath->matchPatternRegex = std::regex( filterPath->matchPattern, std::regex::ECMAScript | std::regex::icase );
 
 				filterPath->prefixId = resPath->prefix->id;
 
@@ -85,46 +94,47 @@ bool ResourceFilter::SetFromFilterFileData( const FilterFile& fileData )
 				// Very specific behaviour is triggered in this case
 				filterPath->containsLocalIncludeExcludeRules = ( resPath->includeRules.size() + resPath->excludeRules.size() ) > 0;
 
-				m_paths.emplace_back( std::move( filterPath ) );
+				m_paths[filterSection->id].emplace_back( std::move( filterPath ) );
 			}
 		}
+
+        filterSection->containsNonWildcardResPath = containsNonWildcardResPath;
 	}
 
 	return true;
 }
 
-void ResourceFilter::ConvertResPathToPattern( const std::string& resPath, std::string& pattern ) const
+void ResourceFilter::ConvertResPathToPattern( std::string resPath, std::string& pattern ) const
 {
-	std::string resPathString = resPath;
 
 	// Replace any "..." with a unique token (RECURSIVE_FOLDER_ELLIPSES_WILDCARD)
 	constexpr char RECURSIVE_FOLDER_ELLIPSES_WILDCARD = '\x01';
 	size_t pos;
-	while( ( pos = resPathString.find( "..." ) ) != std::string::npos )
+	while( ( pos = resPath.find( "..." ) ) != std::string::npos )
 	{
-		resPathString.replace( pos, 3, std::string( 1, RECURSIVE_FOLDER_ELLIPSES_WILDCARD ) );
+		resPath.replace( pos, 3, std::string( 1, RECURSIVE_FOLDER_ELLIPSES_WILDCARD ) );
 	}
 
 	// Escape special characters and deal with wildcards ("*" and "..." i.e. RECURSIVE_FOLDER_ELLIPSES_WILDCARD)
-	for( size_t i = 0; i < resPathString.size(); ++i )
+	for( size_t i = 0; i < resPath.size(); ++i )
 	{
-		if( resPathString[i] == '*' )
+		if( resPath[i] == '*' )
 		{
 			pattern += "[^/]*";
 		}
-		else if( resPathString[i] == RECURSIVE_FOLDER_ELLIPSES_WILDCARD )
+		else if( resPath[i] == RECURSIVE_FOLDER_ELLIPSES_WILDCARD )
 		{
 			pattern += ".*";
 		}
-		else if( std::string( ".^$|()[]{}+?\\" ).find( resPathString[i] ) != std::string::npos )
+		else if( std::string( ".^$|()[]{}+?\\" ).find( resPath[i] ) != std::string::npos )
 		{
 			// Regex special characters that need escaping
 			pattern += '\\';
-			pattern += resPathString[i];
+			pattern += resPath[i];
 		}
 		else
 		{
-			pattern += resPathString[i];
+			pattern += resPath[i];
 		}
 	}
 }
@@ -138,100 +148,116 @@ bool ResourceFilter::CheckPath( const std::filesystem::path& path ) const
 
 bool ResourceFilter::CheckPath( const std::filesystem::path& path, std::string& matchSectionId, std::string& matchPath ) const
 {
-	for( auto& filterPath : m_paths )
+	std::string resolvedPathStr = path.generic_string();
+
+	for( auto& sectionFilterPath : m_paths )
 	{
-		std::string resolvedPathStr = path.string();
+		bool includeOrExcludeRulesFailedForSection = false;
 
-		std::replace( resolvedPathStr.begin(), resolvedPathStr.end(), '\\', '/' );
-
-		// Check for directly specified file
-		bool specificFileMatch = filterPath->path == resolvedPathStr;
-
-		if( !specificFileMatch )
+		for( auto& filterPath : sectionFilterPath.second )
 		{
-			// Attempt to match using pattern
-			try
+			// Check for directly specified file
+			bool specificFileMatch = filterPath->path == resolvedPathStr;
+
+			if( specificFileMatch )
 			{
-				std::regex re( filterPath->matchPattern, std::regex::ECMAScript | std::regex::icase );
-				if( !std::regex_match( resolvedPathStr, re ) )
+				if( filterPath->containsLocalIncludeExcludeRules )
 				{
+					// If a local include or exclude is defined here then always fail
+					// This is to match behaviour in current system, likely a bug
 					continue;
 				}
-			}
-			catch( const std::regex_error& e )
-			{
-				std::string errorMsg = "Regex Exception during WildcardMatching - regexPattern: " + filterPath->matchPattern + " checkString: " + resolvedPathStr + " - error details: " + e.what();
-				throw std::runtime_error( errorMsg );
-			}
-			catch( const std::exception& e )
-			{
-				std::string errorMsg = "Standard Exception during WildcardMatching - regexPattern: " + filterPath->matchPattern + " checkString: " + resolvedPathStr + " - error details: " + e.what();
-				throw std::runtime_error( errorMsg );
-			}
-		}
-
-		// Apply include/exclude rules
-		if( specificFileMatch )
-		{
-			if( filterPath->containsLocalIncludeExcludeRules )
-			{
-				// If a local include or exclude is defined here then always fail
-				// This is to match behaviour in current system, likely a bug
-				continue;
+				else
+				{
+					// Ignore all other rules and match this file
+					matchSectionId = filterPath->sectionId;
+					matchPath = filterPath->path;
+					return true;
+				}
 			}
 			else
 			{
-				// Ignore all other rules and match this file
-				matchSectionId = filterPath->sectionId;
-				matchPath = filterPath->path;
-				return true;
-			}
-		}
+                // If a previous include or exclude rule was failed
+                // Then the rest will also fail
+                // The section cannot be completely skipped as
+                // There may be specific files specified by full path
+                // That don't have to match filter rules.
+                if (includeOrExcludeRulesFailedForSection)
+                {
+					continue;
+                }
 
-		// Includes
-		if( !filterPath->includeRules.empty() )
-		{
-			bool includeRulesPassed = false;
+				// Check exclude rules
+				bool excludeRulesPassed = true;
 
-			for( auto& includeRule : filterPath->includeRules )
-			{
-				if( resolvedPathStr.find( includeRule ) != std::string::npos )
+				for( auto& excludeRule : filterPath->excludeRules )
 				{
-					includeRulesPassed = true;
-					break;
+					if( resolvedPathStr.find( excludeRule ) != std::string::npos )
+					{
+						// Exclude rule met
+						excludeRulesPassed = false;
+						break;
+					}
+				}
+
+				if( !excludeRulesPassed )
+				{
+					// exclude rules are present and have not been met
+					includeOrExcludeRulesFailedForSection = true;
+					continue;
+				}
+
+				// Check include rules
+				if( !filterPath->includeRules.empty() )
+				{
+					bool includeRulesPassed = false;
+
+					for( auto& includeRule : filterPath->includeRules )
+					{
+						if( resolvedPathStr.find( includeRule ) != std::string::npos )
+						{
+							includeRulesPassed = true;
+							break;
+						}
+					}
+
+					if( !includeRulesPassed )
+					{
+						// Include rules are present and have not been met
+						includeOrExcludeRulesFailedForSection = true;
+						continue;
+					}
+				}
+
+				// Perform regex on filter pattern
+				try
+				{
+					if( !std::regex_match( resolvedPathStr, filterPath->matchPatternRegex ) )
+					{
+						continue;
+					}
+					else
+					{
+						matchSectionId = filterPath->sectionId;
+
+						matchPath = filterPath->path;
+
+						return true;
+					}
+				}
+				catch( const std::regex_error& e )
+				{
+					std::string errorMsg = "Regex Exception during WildcardMatching - regexPattern: " + filterPath->matchPattern + " checkString: " + resolvedPathStr + " - error details: " + e.what();
+					throw std::runtime_error( errorMsg );
+				}
+				catch( const std::exception& e )
+				{
+					std::string errorMsg = "Standard Exception during WildcardMatching - regexPattern: " + filterPath->matchPattern + " checkString: " + resolvedPathStr + " - error details: " + e.what();
+					throw std::runtime_error( errorMsg );
 				}
 			}
-
-			if( !includeRulesPassed )
-			{
-				// Include rules are present and have not been met
-				continue;
-			}
 		}
 
-		// Excludes
-		bool excludeRulesPassed = true;
-
-		for( auto& excludeRule : filterPath->excludeRules )
-		{
-			if( resolvedPathStr.find( excludeRule ) != std::string::npos )
-			{
-				// Exclude rule met
-				excludeRulesPassed = false;
-				break;
-			}
-		}
-
-		if( !excludeRulesPassed )
-		{
-			// Include rules are present and have not been met
-			continue;
-		}
-
-		// Pattern matched and include/exclude rules met
-		matchSectionId = filterPath->sectionId;
-		matchPath = filterPath->path;
-		return true;
 	}
 
 	return false;

--- a/tools/src/ResourceFilter.cpp
+++ b/tools/src/ResourceFilter.cpp
@@ -1,0 +1,245 @@
+// Copyright © 2025 CCP ehf.
+
+#include "ResourceFilter.h"
+
+#include <regex>
+#include <algorithm>
+
+namespace ResourceTools
+{
+
+ResourceFilter::ResourceFilter()
+{
+}
+
+ResourceFilter::~ResourceFilter()
+{
+}
+
+bool ResourceFilter::SetFromFilterFileData( const FilterFile& fileData )
+{
+	m_paths.clear();
+
+	// Populate prefix paths
+	for( auto& prefix : fileData.prefixes )
+	{
+		for( auto& prefixPath : prefix.second->paths )
+		{
+			m_prefixPaths.push_back( prefixPath );
+		}
+	}
+
+	// Populate search paths from filter data
+	for( auto& filterSection : fileData.filterSections )
+	{
+		std::set<std::string> includeRules = fileData.includeRules;
+		std::set<std::string> excludeRules = fileData.excludeRules;
+
+		// Add section rules
+		includeRules.insert( filterSection->includeRules.begin(), filterSection->includeRules.end() );
+		excludeRules.insert( filterSection->excludeRules.begin(), filterSection->excludeRules.end() );
+
+		for( auto& resPath : filterSection->respaths )
+		{
+			for( auto& prefixPath : resPath->prefix->paths )
+			{
+				// Add include rules to section rules
+				includeRules.insert( resPath->includeRules.begin(), resPath->includeRules.end() );
+
+				excludeRules.insert( resPath->excludeRules.begin(), resPath->excludeRules.end() );
+
+				// Create a filter path
+				std::unique_ptr<FilterPath> filterPath = std::make_unique<FilterPath>();
+
+				// Normalise path and convert to pattern
+				std::string prefixPathStr = prefixPath.string();
+
+				// Remove current directory dot if supplied
+				if( prefixPathStr == "." )
+				{
+					prefixPathStr = "";
+				}
+
+				// ResolvePath
+				filterPath->path = prefixPathStr + resPath->path.string();
+
+				std::replace( filterPath->path.begin(), filterPath->path.end(), '\\', '/' );
+
+				// Remove leading slash
+				if( ( filterPath->path.size() > 0 ) && filterPath->path.at( 0 ) == '/' )
+				{
+					filterPath->path = filterPath->path.substr( 1 );
+				}
+
+				ConvertResPathToPattern( filterPath->path, filterPath->matchPattern );
+
+				filterPath->prefixId = resPath->prefix->id;
+
+				filterPath->sectionId = filterSection->id;
+
+				filterPath->includeRules = includeRules;
+
+				filterPath->excludeRules = excludeRules;
+
+				// This is important to match files that are matched directly
+				// Very specific behaviour is triggered in this case
+				filterPath->containsLocalIncludeExcludeRules = ( resPath->includeRules.size() + resPath->excludeRules.size() ) > 0;
+
+				m_paths.emplace_back( std::move( filterPath ) );
+			}
+		}
+	}
+
+	return true;
+}
+
+void ResourceFilter::ConvertResPathToPattern( const std::string& resPath, std::string& pattern ) const
+{
+	std::string resPathString = resPath;
+
+	// Replace any "..." with a unique token (RECURSIVE_FOLDER_ELLIPSES_WILDCARD)
+	constexpr char RECURSIVE_FOLDER_ELLIPSES_WILDCARD = '\x01';
+	size_t pos;
+	while( ( pos = resPathString.find( "..." ) ) != std::string::npos )
+	{
+		resPathString.replace( pos, 3, std::string( 1, RECURSIVE_FOLDER_ELLIPSES_WILDCARD ) );
+	}
+
+	// Escape special characters and deal with wildcards ("*" and "..." i.e. RECURSIVE_FOLDER_ELLIPSES_WILDCARD)
+	for( size_t i = 0; i < resPathString.size(); ++i )
+	{
+		if( resPathString[i] == '*' )
+		{
+			pattern += "[^/]*";
+		}
+		else if( resPathString[i] == RECURSIVE_FOLDER_ELLIPSES_WILDCARD )
+		{
+			pattern += ".*";
+		}
+		else if( std::string( ".^$|()[]{}+?\\" ).find( resPathString[i] ) != std::string::npos )
+		{
+			// Regex special characters that need escaping
+			pattern += '\\';
+			pattern += resPathString[i];
+		}
+		else
+		{
+			pattern += resPathString[i];
+		}
+	}
+}
+
+bool ResourceFilter::CheckPath( const std::filesystem::path& path ) const
+{
+	std::string sectionId;
+	std::string matchPath;
+	return CheckPath( path, sectionId, matchPath );
+}
+
+bool ResourceFilter::CheckPath( const std::filesystem::path& path, std::string& matchSectionId, std::string& matchPath ) const
+{
+	for( auto& filterPath : m_paths )
+	{
+		std::string resolvedPathStr = path.string();
+
+		std::replace( resolvedPathStr.begin(), resolvedPathStr.end(), '\\', '/' );
+
+		// Check for directly specified file
+		bool specificFileMatch = filterPath->path == resolvedPathStr;
+
+		if( !specificFileMatch )
+		{
+			// Attempt to match using pattern
+			try
+			{
+				std::regex re( filterPath->matchPattern, std::regex::ECMAScript | std::regex::icase );
+				if( !std::regex_match( resolvedPathStr, re ) )
+				{
+					continue;
+				}
+			}
+			catch( const std::regex_error& e )
+			{
+				std::string errorMsg = "Regex Exception during WildcardMatching - regexPattern: " + filterPath->matchPattern + " checkString: " + resolvedPathStr + " - error details: " + e.what();
+				throw std::runtime_error( errorMsg );
+			}
+			catch( const std::exception& e )
+			{
+				std::string errorMsg = "Standard Exception during WildcardMatching - regexPattern: " + filterPath->matchPattern + " checkString: " + resolvedPathStr + " - error details: " + e.what();
+				throw std::runtime_error( errorMsg );
+			}
+		}
+
+		// Apply include/exclude rules
+		if( specificFileMatch )
+		{
+			if( filterPath->containsLocalIncludeExcludeRules )
+			{
+				// If a local include or exclude is defined here then always fail
+				// This is to match behaviour in current system, likely a bug
+				continue;
+			}
+			else
+			{
+				// Ignore all other rules and match this file
+				matchSectionId = filterPath->sectionId;
+				matchPath = filterPath->path;
+				return true;
+			}
+		}
+
+		// Includes
+		if( !filterPath->includeRules.empty() )
+		{
+			bool includeRulesPassed = false;
+
+			for( auto& includeRule : filterPath->includeRules )
+			{
+				if( resolvedPathStr.find( includeRule ) != std::string::npos )
+				{
+					includeRulesPassed = true;
+					break;
+				}
+			}
+
+			if( !includeRulesPassed )
+			{
+				// Include rules are present and have not been met
+				continue;
+			}
+		}
+
+		// Excludes
+		bool excludeRulesPassed = true;
+
+		for( auto& excludeRule : filterPath->excludeRules )
+		{
+			if( resolvedPathStr.find( excludeRule ) != std::string::npos )
+			{
+				// Exclude rule met
+				excludeRulesPassed = false;
+				break;
+			}
+		}
+
+		if( !excludeRulesPassed )
+		{
+			// Include rules are present and have not been met
+			continue;
+		}
+
+		// Pattern matched and include/exclude rules met
+		matchSectionId = filterPath->sectionId;
+		matchPath = filterPath->path;
+		return true;
+	}
+
+	return false;
+}
+
+const std::vector<std::filesystem::path>& ResourceFilter::GetPrefixPaths() const
+{
+	return m_prefixPaths;
+}
+
+}

--- a/tools/src/ResourceFilter.cpp
+++ b/tools/src/ResourceFilter.cpp
@@ -6,14 +6,6 @@
 namespace ResourceTools
 {
 
-ResourceFilter::ResourceFilter()
-{
-}
-
-ResourceFilter::~ResourceFilter()
-{
-}
-
 bool ResourceFilter::SetFromFilterFileData( const FilterFile& fileData )
 {
 	m_paths.clear();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,6 +17,10 @@
       "version>=": "8.11.1#1"
     },
     {
+      "name": "inih",
+      "version>=": "62"
+    },
+    {
       "name": "yaml-cpp",
       "version>=": "0.8.0#1"
     },


### PR DESCRIPTION
Changes
-------
* Filter file rules loading through legacy INI file format support added.
* Filter logic matched from resfileserver and eve-resparser.
* Documentation of filter file format added.
* Documentation covering filter logic added.
* Test coverage added for all known filter include scenarios.
* Added new global filter rule which is useful for excluding .red files.
* Filter logic for 'resfile' field not covered as it is covered by respaths logic.
* New publicly exposed library function added to create Resource Groups with filtering.
* Logic added to library function to allow skipping empty search directories.
* Logic added to library to allow ascertaining compression size from remote filesystem.
* Test coverage for library function added.
* CLI extended to add Resource Group creation with filters.
* Test coverage for CLI operation added.

Version
-------
Rather than changing 'CreateFromDirectory' in library and 'create-group' in CLI. A new function and operation was added to create Resource Groups using filters. This was to keep the API stable as there are now other parties working with the origional commands. Version minor was bumped.

Extra
-----
Filter ini file parsing logic is from PR16