### PR TITLE
Add download status callback, address minor bugs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright © 2025 CCP ehf.
 
 cmake_minimum_required(VERSION 3.31.0)
-project(resources VERSION 4.2.0)
+project(resources VERSION 4.3.0)
 
 include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)

--- a/cli/src/CreateBundleCliOperation.cpp
+++ b/cli/src/CreateBundleCliOperation.cpp
@@ -22,7 +22,8 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
 	m_bundleResourceGroupDestinationTypeArgumentId( "--bundle-resourcegroup-destination-type" ),
 	m_bundleResourceGroupDestinationBasePathArgumentId( "--bundle-resourcegroup-destination-path" ),
 	m_chunkSizeArgumentId( "--chunk-size" ),
-	m_downloadRetrySecondsArgumentId( "--download-retry-seconds" )
+	m_networkRetryBackoffMultiplierId( "--download-retry-seconds" ),
+	m_networkRetryCountId( "--network-retry-count" )
 {
 	AddRequiredPositionalArgument( m_inputResourceGroupPathArgumentId, "Path to ResourceGroup to bundle." );
 
@@ -49,7 +50,9 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
 
 	AddArgument( m_chunkSizeArgumentId, "Represents the maximum size of the produced chunks in bytes.", false, false, SizeToString( defaultParams.chunkSize ) );
 
-	AddArgument( m_downloadRetrySecondsArgumentId, "The number of seconds before attempt to download a resource fails with a network related error", false, false, SecondsToString( defaultParams.downloadRetrySeconds ) );
+    AddArgument( m_networkRetryCountId, "Number of retries to attempt when encountering a failed download.", false, false, SizeToString( defaultParams.downloadSettings.retryCount ) );
+
+	AddArgument( m_networkRetryBackoffMultiplierId, "Multiplier in seconds to wait for when retrying, value will multiply on each retry to backoff.", false, false, SecondsToString( defaultParams.downloadSettings.retrySeconds ) );
 }
 
 bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -100,11 +103,9 @@ bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = m_argumentParser->get<std::string>( m_bundleResourceGroupDestinationBasePathArgumentId );
 
-	long long retrySeconds{ 120 };
 	try
 	{
 		bundleCreateParams.chunkSize = std::stoull( m_argumentParser->get( m_chunkSizeArgumentId ) );
-		retrySeconds = std::stoll( m_argumentParser->get( m_downloadRetrySecondsArgumentId ) );
 	}
 	catch( std::invalid_argument& )
 	{
@@ -114,7 +115,41 @@ bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 	{
 		return false;
 	}
-	bundleCreateParams.downloadRetrySeconds = std::chrono::seconds( retrySeconds );
+
+    try
+	{
+		unsigned long long networkRetryCountUnsignedLongLong = std::stoull( m_argumentParser->get( m_networkRetryCountId ) );
+
+		if( networkRetryCountUnsignedLongLong > std::numeric_limits<uint32_t>::max() )
+		{
+			return false;
+		}
+
+		bundleCreateParams.downloadSettings.retryCount = static_cast<uint32_t>( networkRetryCountUnsignedLongLong );
+	}
+	catch( std::invalid_argument& )
+	{
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		return false;
+	}
+
+	try
+	{
+		unsigned long long networkRetryBackoffMultiplierLongLong = std::stoull( m_argumentParser->get( m_networkRetryBackoffMultiplierId ) );
+
+		bundleCreateParams.downloadSettings.retrySeconds = std::chrono::seconds( networkRetryBackoffMultiplierLongLong );
+	}
+	catch( std::invalid_argument& )
+	{
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		return false;
+	}
 
 	if( ShowCliStatusUpdates() )
 	{
@@ -153,7 +188,9 @@ void CreateBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
 
 	std::cout << "Chunk Size: " << bundleCreateParams.chunkSize << " Bytes" << std::endl;
 
-	std::cout << "Download Retry Seconds: " << bundleCreateParams.downloadRetrySeconds.count() << std::endl;
+    std::cout << "Network retry count: " << bundleCreateParams.downloadSettings.retryCount << std::endl;
+
+	std::cout << "Network retry backoff multiplier ( Seconds ): " << bundleCreateParams.downloadSettings.retrySeconds.count() << std::endl;
 
 	std::cout << "----------------------------\n"
 			  << std::endl;

--- a/cli/src/CreateBundleCliOperation.h
+++ b/cli/src/CreateBundleCliOperation.h
@@ -21,8 +21,6 @@ private:
 	void PrintStartBanner( const CarbonResources::ResourceGroupImportFromFileParams& resourceGroupParams, CarbonResources::BundleCreateParams& bundleCreateParams ) const;
 	bool CreateBundle( CarbonResources::ResourceGroupImportFromFileParams& resourceGroupParams, CarbonResources::BundleCreateParams& bundleCreateParams, std::string& returnErrorMessage ) const;
 
-private:
-	void CreateResourceGroupFromFileType();
 
 private:
 	std::string m_inputResourceGroupPathArgumentId;
@@ -45,7 +43,9 @@ private:
 
 	std::string m_chunkSizeArgumentId;
 
-	std::string m_downloadRetrySecondsArgumentId;
+    std::string m_networkRetryCountId;
+
+	std::string m_networkRetryBackoffMultiplierId;
 };
 
 #endif // CreateBundleCliOperation_H

--- a/cli/src/CreatePatchCliOperation.cpp
+++ b/cli/src/CreatePatchCliOperation.cpp
@@ -22,7 +22,8 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 	m_patchResourceGroupDestinationBasePathArgumentId( "--patch-resourcegroup-destination-path" ),
 	m_patchFileRelativePathPrefixArgumentId( "--patch-prefix" ),
 	m_maxInputChunkSizeArgumentId( "--chunk-size" ),
-	m_downloadRetrySecondsArgumentId( "--download-retry" ),
+	m_networkRetryBackoffMultiplierId( "--download-retry" ),
+	m_networkRetryCountId( "--network-retry-count" ),
 	m_indexFolderArgumentId( "--index-folder" ),
 	m_skipCompressionCalculation( "--skip-compression" )
 {
@@ -60,7 +61,9 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 
 	AddArgument( m_maxInputChunkSizeArgumentId, "Files are processed in chunks, maxInputFileChunkSize indicate the size of this chunk. Files smaller than chunk will be processed in one pass.", false, false, SizeToString( defaultParams.maxInputFileChunkSize ) );
 
-	AddArgument( m_downloadRetrySecondsArgumentId, "The number of seconds before attempt to download a resource fails with a network related error", false, false, SecondsToString( defaultParams.downloadRetrySeconds ) );
+    AddArgument( m_networkRetryCountId, "Number of retries to attempt when encountering a failed download.", false, false, SizeToString( defaultParams.downloadSettings.retryCount ) );
+
+	AddArgument( m_networkRetryBackoffMultiplierId, "Multiplier in seconds to wait for when retrying, value will multiply on each retry to backoff.", false, false, SecondsToString( defaultParams.downloadSettings.retrySeconds ) );
 
 	AddArgument( m_indexFolderArgumentId, "The folder in which to place indexes generated for patch files.", false, false, defaultParams.indexFolder.string() );
 
@@ -159,24 +162,42 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	long long retrySeconds{ 120 };
 
-	try
+    try
 	{
-		retrySeconds = std::stoll( m_argumentParser->get( m_downloadRetrySecondsArgumentId ) );
+		unsigned long long networkRetryCountUnsignedLongLong = std::stoull( m_argumentParser->get( m_networkRetryCountId ) );
+
+		if( networkRetryCountUnsignedLongLong > std::numeric_limits<uint32_t>::max() )
+		{
+			return false;
+		}
+
+		createPatchParams.downloadSettings.retryCount = static_cast<uint32_t>( networkRetryCountUnsignedLongLong );
 	}
 	catch( std::invalid_argument& )
 	{
-		returnErrorMessage = "Invalid retry seconds";
-
 		return false;
 	}
 	catch( std::out_of_range& )
 	{
-		returnErrorMessage = "Invalid retry seconds";
-
 		return false;
 	}
 
-	createPatchParams.downloadRetrySeconds = std::chrono::seconds( retrySeconds );
+	try
+	{
+		unsigned long long networkRetryBackoffMultiplierLongLong = std::stoull( m_argumentParser->get( m_networkRetryBackoffMultiplierId ) );
+
+		createPatchParams.downloadSettings.retrySeconds = std::chrono::seconds( networkRetryBackoffMultiplierLongLong );
+	}
+	catch( std::invalid_argument& )
+	{
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		return false;
+	}
+
+	createPatchParams.downloadSettings.retrySeconds = std::chrono::seconds( retrySeconds );
 
 	createPatchParams.indexFolder = m_argumentParser->get( m_indexFolderArgumentId );
 
@@ -239,7 +260,9 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 
 	std::cout << "Resource Patch Resource Group Destination Settings Destination Type: " << DestinationTypeToString( createPatchParams.resourcePatchResourceGroupDestinationSettings.destinationType ) << std::endl;
 
-	std::cout << "Download Retry Seconds: " << createPatchParams.downloadRetrySeconds.count() << std::endl;
+	std::cout << "Download Retry Seconds: " << createPatchParams.downloadSettings.retrySeconds.count() << std::endl;
+
+    std::cout << "Download Retry Count: " << createPatchParams.downloadSettings.retryCount << std::endl;
 
 	std::cout << "Index File Folder: " << createPatchParams.indexFolder << std::endl;
 

--- a/cli/src/CreatePatchCliOperation.cpp
+++ b/cli/src/CreatePatchCliOperation.cpp
@@ -260,7 +260,7 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 
 	std::cout << "Resource Patch Resource Group Destination Settings Destination Type: " << DestinationTypeToString( createPatchParams.resourcePatchResourceGroupDestinationSettings.destinationType ) << std::endl;
 
-	std::cout << "Download Retry Seconds: " << createPatchParams.downloadSettings.retrySeconds.count() << std::endl;
+	std::cout << "Network retry backoff multiplier ( Seconds ):" << createPatchParams.downloadSettings.retrySeconds.count() << std::endl;
 
     std::cout << "Download Retry Count: " << createPatchParams.downloadSettings.retryCount << std::endl;
 

--- a/cli/src/CreatePatchCliOperation.h
+++ b/cli/src/CreatePatchCliOperation.h
@@ -52,7 +52,9 @@ private:
 
 	std::string m_maxInputChunkSizeArgumentId;
 
-	std::string m_downloadRetrySecondsArgumentId;
+    std::string m_networkRetryCountId;
+
+	std::string m_networkRetryBackoffMultiplierId;
 
 	std::string m_indexFolderArgumentId;
 

--- a/cli/src/RemoveResourcesCliOperation.cpp
+++ b/cli/src/RemoveResourcesCliOperation.cpp
@@ -171,6 +171,8 @@ bool RemoveResourcesCliOperation::RemoveResources( CarbonResources::ResourceGrou
 
     removeParams.callbackSettings.statusCallback = statusCallback;
 
+    removeParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
+
     if( ShowCliStatusUpdates() )
 	{
 		CliStatusUpdate( "Removing Resources." );
@@ -186,6 +188,8 @@ bool RemoveResourcesCliOperation::RemoveResources( CarbonResources::ResourceGrou
 	}
 
     exportParams.callbackSettings.statusCallback = statusCallback;
+
+    exportParams.callbackSettings.verbosityLevel = GetVerbosityLevel();
 
     if( ShowCliStatusUpdates() )
 	{

--- a/doc/source/Tools/Api/CallbackStructures.rst
+++ b/doc/source/Tools/Api/CallbackStructures.rst
@@ -12,6 +12,8 @@ Granularity of updates can be controlled.
 
 .. doxygentypedef:: CarbonResources::StatusCallback
 
+.. doxygentypedef:: CarbonResources::DownloadCallback
+
 .. doxygenenum:: CarbonResources::StatusProgressType
 
 

--- a/doc/source/Tools/Api/FilesystemStructs.rst
+++ b/doc/source/Tools/Api/FilesystemStructs.rst
@@ -18,3 +18,5 @@ See :doc:`../../DesignDocuments/filesystemDesign` for further details.
 .. doxygenstruct:: CarbonResources::ResourceDestinationSettings
     :members:
 
+.. doxygenstruct:: CarbonResources::DownloadSettings
+    :members:

--- a/include/BundleResourceGroup.h
+++ b/include/BundleResourceGroup.h
@@ -21,6 +21,8 @@ namespace CarbonResources
     *  Location where the unpacked resources should be saved.
     *  @var BundleUnpackParams::callbackSettings
     *  Settings relating to status callback messaging
+	*  @var BundleUnpackParams::DownloadSettings
+    *  Settings relating to downloads
     */
 struct BundleUnpackParams final
 {
@@ -29,6 +31,8 @@ struct BundleUnpackParams final
 	ResourceDestinationSettings resourceDestinationSettings;
 
 	CallbackSettings callbackSettings;
+
+    DownloadSettings downloadSettings;
 };
 
 /** @class BundleResourceGroup

--- a/include/PatchResourceGroup.h
+++ b/include/PatchResourceGroup.h
@@ -28,6 +28,8 @@ namespace CarbonResources
     *  Name of a temporary filename to use when patching large files. This file will be cleaned up on process completion. 
     *  @var PatchApplyParams::callbackSettings
     *  Settings relating to status callback messaging
+    *  @var PatchApplyParams::downloadSettings
+    *  Settings relating to downloads
     */
 struct PatchApplyParams final
 {
@@ -42,6 +44,8 @@ struct PatchApplyParams final
 	std::filesystem::path temporaryFilePath = "tempFile.resource";
 
 	CallbackSettings callbackSettings;
+
+    DownloadSettings downloadSettings;
 };
 
 /** @class PatchResourceGroup

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -48,18 +48,29 @@ struct CallbackSettings
 	int verbosityLevel = -1;
 };
 
+/** Download Callback function signature.
+    * @param totalSizeBytes Total size in bytes of file being downloaded.
+    * @param currentlyDownloadedBytes Current size of data downloaded in bytes.
+    * @param bytesPerSecond Current transfer rate in bytes per second.
+    */
+using DownloadCallback = std::function<void( uintmax_t totalSizeBytes, uintmax_t currentlyDownloadedBytes, double bytesPerSecond )>;
+
 /** @struct DownloadSettings
     *  @brief Parameters relating downloading
     *  @var DownloadSettings::retrySeconds
     *  Delay before a failed download is retried (seconds)
     *  @var DownloadSettings::retryCount
     *  Number of times times a download is retried before failure. Note: a backoff is also applied before retry.
+    *  @var DownloadSettings::downloadInfoCallback
+    *  Optional callback to receive download information.
     */
 struct DownloadSettings
 {
 	std::chrono::seconds retrySeconds{ 1 };
 
 	uintmax_t retryCount = 3;
+
+    DownloadCallback downloadInfoCallback = nullptr;
 };
 
 /** @struct ResourceSourceSettings
@@ -108,8 +119,8 @@ struct ResourceDestinationSettings
     *  Where to save the resulting BundleResourceGroup
     *  @var BundleCreateParams::callbackSettings
     *  Settings relating to status callback messaging
-    *  @var BundleCreateParams::downloadRetrySeconds
-    *  Delay before a failed download is retried (seconds)
+    *  @var BundleCreateParams::downloadSettings
+    *  Settings related to downloads
     *  @var BundleCreateParams::calculateCompressions
     *  Specifies if compression will be calculated for the generated bundle chunks
     */
@@ -131,7 +142,7 @@ struct BundleCreateParams
 
 	CallbackSettings callbackSettings;
 
-	std::chrono::seconds downloadRetrySeconds{ 120 };
+	DownloadSettings downloadSettings;
 
     bool calculateCompressions = true;
 };
@@ -158,8 +169,8 @@ struct BundleCreateParams
     *  Where the produced PatchResourceGroup will be saved.
     *  @var PatchCreateParams::callbackSettings
     *  Settings relating to status callback messaging
-    *  @var PatchCreateParams::downloadRetrySeconds
-    *  Delay before a failed download is retried (seconds)
+    *  @var PatchCreateParams::downloadSettings
+    *  Settings related to downloads
     *  @var PatchCreateParams::indexFolder
     *  Directory to store index calculation files during patch creation.
     *  @var PatchCreateParams::calculateCompressions
@@ -187,7 +198,7 @@ struct PatchCreateParams
 
 	CallbackSettings callbackSettings;
 
-	std::chrono::seconds downloadRetrySeconds{ 120 };
+	DownloadSettings downloadSettings;
 
 	std::filesystem::path indexFolder = std::filesystem::temp_directory_path() / "carbonResources" / "chunkIndexes";
 

--- a/src/BundleResourceGroupImpl.cpp
+++ b/src/BundleResourceGroupImpl.cpp
@@ -68,6 +68,8 @@ Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackP
 
 	resourceGroupDataParams.data = &resourceGroupData;
 
+    resourceGroupDataParams.downloadSettings = params.downloadSettings;
+
 	Result getChecksumResult = resourceGroupResource->GetChecksum( resourceGroupDataParams.expectedChecksum );
 
 	if( getChecksumResult.type != ResultType::SUCCESS )

--- a/src/PatchResourceGroupImpl.cpp
+++ b/src/PatchResourceGroupImpl.cpp
@@ -263,6 +263,8 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 
 	resourceGroupDataParams.data = &resourceGroupData;
 
+    resourceGroupDataParams.downloadSettings = params.downloadSettings;
+
 	Result resourceGroupGetDataResult = m_resourceGroupParameter.GetValue()->GetData( resourceGroupDataParams );
 
 	if( resourceGroupGetDataResult.type != ResultType::SUCCESS )
@@ -343,6 +345,8 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 				resourceDataStreamParams.resourceSourceSettings = params.resourcesToPatchSourceSettings;
 
 				resourceDataStreamParams.dataStream = resourceDataStreamIn;
+
+                resourceDataStreamParams.downloadSettings = params.downloadSettings;
 
 				Result getResourceDataStream = resource->GetDataStream( resourceDataStreamParams );
 
@@ -489,6 +493,8 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 
 							getDataStreamParams.resourceSourceSettings = params.resourcesToPatchSourceSettings;
 
+                            getDataStreamParams.downloadSettings = params.downloadSettings;
+
 							Result getDataStreamResult = resource->GetDataStream( getDataStreamParams );
 
 							if( getDataStreamResult.type != ResultType::SUCCESS )
@@ -585,6 +591,8 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 				resourceGetDataParams.resourceSourceSettings = params.nextBuildResourcesSourceSettings;
 
 				resourceGetDataParams.dataStream = resourceStreamIn;
+
+                resourceGetDataParams.downloadSettings = params.downloadSettings;
 
 				Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
 

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -2061,7 +2061,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 
 			resourceGetDataParams.dataStream = resourceDataStream;
 
-			resourceGetDataParams.downloadRetrySeconds = params.downloadRetrySeconds;
+			resourceGetDataParams.downloadSettings = params.downloadSettings;
 
 			Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
 
@@ -2390,7 +2390,7 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 
 				previousResourceGetDataStreamParams.resourceSourceSettings = params.resourceSourceSettingsPrevious;
 
-				previousResourceGetDataStreamParams.downloadRetrySeconds = params.downloadRetrySeconds;
+				previousResourceGetDataStreamParams.downloadSettings = params.downloadSettings;
 
 				previousResourceGetDataStreamParams.dataStream = previousFileDataStream;
 
@@ -2409,6 +2409,8 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 				nextResourceGetDataStreamParams.resourceSourceSettings = params.resourceSourceSettingsNext;
 
 				nextResourceGetDataStreamParams.dataStream = nextFileDataStream;
+
+                nextResourceGetDataStreamParams.downloadSettings = params.downloadSettings;
 
 				Result getNextDataStreamResult = resourceNext->GetDataStream( nextResourceGetDataStreamParams );
 

--- a/src/ResourceInfo/ResourceInfo.cpp
+++ b/src/ResourceInfo/ResourceInfo.cpp
@@ -618,6 +618,19 @@ Result ResourceInfo::GetDataLocalCdn( ResourceGetDataParams& params, const int b
 	}
 }
 
+void FileDownloadCallback(size_t totalSizeBytes, size_t dataSizeBytes, double bytesPerSecond, void* context)
+{
+    if (context)
+    {
+		DownloadCallback userCallback = *static_cast<DownloadCallback*>( context );
+
+		if( userCallback )
+		{
+			userCallback( totalSizeBytes, dataSizeBytes, bytesPerSecond );
+		}
+    }
+}
+
 Result ResourceInfo::GetDataRemoteCdn( ResourceGetDataParams& params, const int basePathId ) const
 {
 	if( basePathId >= params.resourceSourceSettings.basePaths.size() )
@@ -649,9 +662,18 @@ Result ResourceInfo::GetDataRemoteCdn( ResourceGetDataParams& params, const int 
 
 	if( !haveFileCached )
 	{
+		uintmax_t uncompressedSize;
+
+		Result getUncompressedSizeResult = GetUncompressedSize( uncompressedSize );
+
+        if (getUncompressedSizeResult.type != ResultType::SUCCESS)
+        {
+			return getUncompressedSizeResult;
+        }
+
 		ResourceTools::Downloader downloader;
 
-		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadRetrySeconds );
+		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadSettings.retrySeconds,params.downloadSettings.retryCount, uncompressedSize, FileDownloadCallback, (void*)&params.downloadSettings.downloadInfoCallback );
 
 		if( !downloadFileResult )
 		{
@@ -761,9 +783,18 @@ Result ResourceInfo::GetDataStreamRemoteCdn( ResourceGetDataStreamParams& params
 
 	if( !haveFileCached )
 	{
+		uintmax_t uncompressedSize;
+
+		Result getUncompressedSizeResult = GetUncompressedSize( uncompressedSize );
+
+		if( getUncompressedSizeResult.type != ResultType::SUCCESS )
+		{
+			return getUncompressedSizeResult;
+		}
+
 		ResourceTools::Downloader downloader;
 
-		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadRetrySeconds );
+		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadSettings.retrySeconds, params.downloadSettings.retryCount, uncompressedSize, FileDownloadCallback, (void*)&params.downloadSettings.downloadInfoCallback );
 
 		if( !downloadFileResult )
 		{

--- a/src/ResourceInfo/ResourceInfo.cpp
+++ b/src/ResourceInfo/ResourceInfo.cpp
@@ -673,7 +673,7 @@ Result ResourceInfo::GetDataRemoteCdn( ResourceGetDataParams& params, const int 
 
 		ResourceTools::Downloader downloader;
 
-		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadSettings.retrySeconds,params.downloadSettings.retryCount, uncompressedSize, FileDownloadCallback, (void*)&params.downloadSettings.downloadInfoCallback );
+		bool downloadFileResult = downloader.DownloadFile( url, tempPath.string(), params.downloadSettings.retrySeconds, params.downloadSettings.retryCount, uncompressedSize, FileDownloadCallback, (void*)&params.downloadSettings.downloadInfoCallback );
 
 		if( !downloadFileResult )
 		{

--- a/src/ResourceInfo/ResourceInfo.h
+++ b/src/ResourceInfo/ResourceInfo.h
@@ -237,11 +237,11 @@ struct ResourceGetDataStreamParams
 
 	std::shared_ptr<ResourceTools::FileDataStreamIn> dataStream;
 
-	std::filesystem::path cacheBasePath = "cache";
+	std::filesystem::path cacheBasePath = std::filesystem::temp_directory_path();
 
 	std::string expectedChecksum = "";
 
-	std::chrono::seconds downloadRetrySeconds{ 120 };
+	DownloadSettings downloadSettings;
 };
 
 struct ResourceGetDataParams
@@ -250,11 +250,11 @@ struct ResourceGetDataParams
 
 	std::string* data = nullptr;
 
-	std::filesystem::path cacheBasePath = "cache";
+	std::filesystem::path cacheBasePath = std::filesystem::temp_directory_path();
 
 	std::string expectedChecksum = "";
 
-	std::chrono::seconds downloadRetrySeconds{ 120 };
+	DownloadSettings downloadSettings;
 };
 
 struct ResourcePutDataStreamParams

--- a/tests/src/ResourceToolsLibraryTest.cpp
+++ b/tests/src/ResourceToolsLibraryTest.cpp
@@ -83,6 +83,12 @@ TEST_F( ResourceToolsTest, FowlerNollVoChecksumGeneration )
 	EXPECT_EQ( output, "a9d1721dd5cc6d54" );
 }
 
+void DownloadCallback(size_t totalSizeBytes, size_t currentDownloadedBytes, double bytesPerSecond, void* context)
+{
+	size_t* contextInt = static_cast<size_t*>( context );
+	*contextInt = currentDownloadedBytes;
+}
+
 TEST_F( ResourceToolsTest, DownloadFile )
 {
 	const char* FOLDER_NAME = "a9";
@@ -106,7 +112,14 @@ TEST_F( ResourceToolsTest, DownloadFile )
 	}
 	EXPECT_FALSE( std::filesystem::exists( outputPath ) );
 	std::chrono::seconds retrySeconds{ 0 };
-	EXPECT_TRUE( downloader.DownloadFile( url, outputPathString, retrySeconds ) );
+	uintmax_t retries = 3;
+
+    uintmax_t sourceFilesize = std::filesystem::file_size( sourcePathString );
+
+    size_t contextCheck = 0;
+
+	EXPECT_TRUE( downloader.DownloadFile( url, outputPathString, retrySeconds, retries, sourceFilesize, DownloadCallback, &contextCheck ) );
+	EXPECT_EQ( contextCheck, sourceFilesize );
 	EXPECT_TRUE( std::filesystem::exists( outputPath ) );
 
 	// Check if download succeeds.

--- a/tools/include/Downloader.h
+++ b/tools/include/Downloader.h
@@ -4,7 +4,7 @@
 
 #include <filesystem>
 #include <string>
-
+#include <functional>
 #include <curl/curl.h>
 
 namespace ResourceTools
@@ -18,6 +18,9 @@ enum class Response
 	DOWNLOAD_ERROR,
 };
 
+using DownloadFileCallback =  std::function<void( size_t totalSizeBytes, size_t dataSizeBytes, double bytesPerSecond, void* )>;
+
+
 // Utility class for downloading files.
 // Reuse is encouraged for multiple downloads, but do not share across threads.
 class Downloader
@@ -27,7 +30,7 @@ public:
 
 	~Downloader();
 
-	bool DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds );
+	bool DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds, uintmax_t retryCount, size_t expectedTotalSize = 0, DownloadFileCallback callback = nullptr, void* callbackContext = nullptr );
 
     Response GetHeader( const std::string& url, std::string& response );
 

--- a/tools/src/Downloader.cpp
+++ b/tools/src/Downloader.cpp
@@ -35,13 +35,52 @@ void ShutDownCurl()
 	curl_global_cleanup();
 }
 
+struct WriteToFileStreamCallWrapper
+{
+	std::ofstream out;
+
+    ResourceTools::DownloadFileCallback callback = nullptr;
+
+	size_t totalSizeBytes = 0;
+
+	size_t downloadedSizeBytes = 0;
+
+	std::chrono::time_point<std::chrono::high_resolution_clock> startTime;
+
+	void* context = nullptr;
+};
+
 size_t WriteToFileStreamCallback( void* contents, size_t size, size_t nmemb, void* context )
 {
 	const char* charString = static_cast<const char*>( contents );
+
 	const size_t realSize = size * nmemb;
-	std::ofstream* out = static_cast<std::ofstream*>( context );
+
+	WriteToFileStreamCallWrapper* wrapper = static_cast<WriteToFileStreamCallWrapper*>( context );
+
 	std::string str( charString, realSize );
-	*out << str;
+
+	wrapper->out << str;
+
+	wrapper->downloadedSizeBytes += nmemb;
+
+    if (wrapper->callback)
+    {
+        // Calculate bytes per second
+		auto end = std::chrono::high_resolution_clock::now();
+
+		long long durationSecondsSinceSeconds = std::chrono::duration_cast<std::chrono::seconds>( end - wrapper->startTime ).count();
+		
+        double bytesPerSecond = (double)wrapper->downloadedSizeBytes;
+
+        if (durationSecondsSinceSeconds > 0)
+        {
+			bytesPerSecond = (double)wrapper->downloadedSizeBytes / durationSecondsSinceSeconds;
+        }
+
+		wrapper->callback( wrapper->totalSizeBytes, wrapper->downloadedSizeBytes, bytesPerSecond, wrapper->context );
+    }
+
 	return realSize;
 }
 
@@ -84,8 +123,6 @@ Response Downloader::GetHeader( const std::string& url, std::string& response )
 	curl_easy_setopt( m_curlHandle, CURLOPT_HEADER, 1L );
 	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEDATA, &out );
 	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEFUNCTION, WriteToFileStringCallback );
-
-	
 	CURLcode cc = curl_easy_perform( m_curlHandle );
 
 	if( cc == CURLE_OK )
@@ -110,7 +147,7 @@ Response Downloader::GetHeader( const std::string& url, std::string& response )
 	
 }
 
-bool Downloader::DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds )
+bool Downloader::DownloadFile( const std::string& url, const std::filesystem::path& outputPath, const std::chrono::seconds& retrySeconds, uintmax_t retryCount, size_t expectedTotalSize /* = 0*/, DownloadFileCallback callback /* = nullptr */, void* callbackContext /* = nullptr */ )
 {
 	if( std::filesystem::exists( outputPath ) )
 	{
@@ -123,34 +160,44 @@ bool Downloader::DownloadFile( const std::string& url, const std::filesystem::pa
 		// Failed to create directory to place the downloaded file in.
 		return false;
 	}
-	std::ofstream out( outputPath, std::ios_base::app | std::ios::binary );
+
+	WriteToFileStreamCallWrapper callWrapper;
+	callWrapper.out = std::ofstream( outputPath, std::ios_base::app | std::ios::binary );
+	callWrapper.callback = callback;
+	callWrapper.totalSizeBytes = expectedTotalSize;
+	callWrapper.context = callbackContext;
+
 	curl_easy_setopt( m_curlHandle, CURLOPT_URL, url.c_str() );
 	curl_easy_setopt( m_curlHandle, CURLOPT_FAILONERROR, 1 );
-	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEDATA, &out );
+	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEDATA, &callWrapper );
 	curl_easy_setopt( m_curlHandle, CURLOPT_WRITEFUNCTION, WriteToFileStreamCallback );
 	curl_easy_setopt( m_curlHandle, CURLOPT_ACCEPT_ENCODING, "gzip" );
 	CURLcode cc{ CURLE_OK };
-	std::chrono::seconds sleepSeconds{ 1 };
-	auto startTime = std::chrono::steady_clock::now();
-	do
-	{
-		auto duration = std::chrono::duration_cast<std::chrono::seconds>( ( std::chrono::steady_clock::now() - startTime ) );
-		auto remaining = retrySeconds - duration;
+
+    for (auto i = 0; i < retryCount; i++)
+    {
+		callWrapper.startTime = std::chrono::high_resolution_clock::now();
 		cc = curl_easy_perform( m_curlHandle );
-		if( duration >= retrySeconds || s_curl_retry_errors.find( cc ) == s_curl_retry_errors.end() )
-		{
-			return cc == CURLE_OK;
-		}
-		if( remaining < sleepSeconds )
-		{
-			std::this_thread::sleep_for( remaining );
-		}
-		else
-		{
-			std::this_thread::sleep_for( sleepSeconds );
-		}
-		sleepSeconds *= 2;
-	} while( true );
+
+        if( cc == CURLE_OK )
+        {
+			return true;
+        }
+        else if (s_curl_retry_errors.find(cc) == s_curl_retry_errors.end())
+        {
+            // Error is something that a retry wont help with
+			return false;
+        }
+        else
+        {
+            // Sleep with a simple backoff
+			std::this_thread::sleep_for( (i+1) * retrySeconds );
+        }
+
+    }
+
+    return false;
+
 }
 
 bool Downloader::GetAttributeValueFromHeader( const std::string& header, const std::string& attributeName, std::string& value )


### PR DESCRIPTION
* Download status callback exposed to library API
* Temp directory now uses system temp path by default
* Verbosity value is respected in removal CLI operation