### PR TITLE
Increase speed for create and unpack bundle operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (BUILD_TESTING)
     list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-project(resources VERSION 4.3.2)
+project(resources VERSION 4.4.0)
 
 include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (BUILD_TESTING)
     list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-project(resources VERSION 4.4.0)
+project(resources VERSION 5.0.0)
 
 include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)

--- a/cli/src/ApplyPatchCliOperation.cpp
+++ b/cli/src/ApplyPatchCliOperation.cpp
@@ -162,11 +162,11 @@ void ApplyPatchCliOperation::PrintStartBanner( const CarbonResources::ResourceGr
 
     if( patchApplyParams.skipNewFiles )
 	{
-		std::cout << "Skip New Files: Off" << std::endl;
+		std::cout << "Skip New Files: On" << std::endl;
 	}
 	else
 	{
-		std::cout << "Skip New Files: On" << std::endl;
+		std::cout << "Skip New Files: Off" << std::endl;
 	}
 
 	std::cout << "----------------------------\n"

--- a/cli/src/ApplyPatchCliOperation.cpp
+++ b/cli/src/ApplyPatchCliOperation.cpp
@@ -17,7 +17,8 @@ ApplyPatchCliOperation::ApplyPatchCliOperation() :
 	m_nextResourcesBasePathsArgumentId( "--next-resources-base-path" ),
 	m_nextResourcesSourceTypeArgumentId( "--next-resources-source-type" ),
 	m_resourcesToPatchDestinationPathArgumentId( "--output-base-path" ),
-	m_resourcesToPatchDestinationTypeArgumentId( "--output-destination-type" )
+	m_resourcesToPatchDestinationTypeArgumentId( "--output-destination-type" ),
+	m_skipNewFilesArgumentId( "--skip-new-files" )
 {
 	AddRequiredPositionalArgument( m_patchResourceGroupPathArgumentId, "The path to the PatchResourceGroup.yaml file." );
 
@@ -38,6 +39,8 @@ ApplyPatchCliOperation::ApplyPatchCliOperation() :
 	AddArgument( m_resourcesToPatchDestinationPathArgumentId, "The path in which to place the patched version of the files.", false, false, "ApplyPatchOut" );
 
 	AddArgument( m_resourcesToPatchDestinationTypeArgumentId, "The type of repository in which to place the patched version of the files.", false, false, DestinationTypeToString( defaultParams.resourcesToPatchDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+
+    AddArgumentFlag( m_skipNewFilesArgumentId, "Skip new files. New files will need to be sourced another way." );
 }
 
 bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -127,6 +130,8 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	patchApplyParams.temporaryFilePath = "tempFile.resource";
 
+    patchApplyParams.skipNewFiles = m_argumentParser->get<bool>( m_skipNewFilesArgumentId );
+
     if( ShowCliStatusUpdates() )
 	{
 		PrintStartBanner( importParamsPrevious, patchApplyParams );
@@ -152,6 +157,15 @@ void ApplyPatchCliOperation::PrintStartBanner( const CarbonResources::ResourceGr
 	std::cout << "Next Resources Source Type: " << SourceTypeToString( patchApplyParams.nextBuildResourcesSourceSettings.sourceType ) << std::endl;
 	std::cout << "Output Path Base Path: " << patchApplyParams.resourcesToPatchDestinationSettings.basePath << std::endl;
 	std::cout << "Output Path Destination Type: " << DestinationTypeToString( patchApplyParams.resourcesToPatchDestinationSettings.destinationType ) << std::endl;
+
+    if( patchApplyParams.skipNewFiles )
+	{
+		std::cout << "Skip New Files: Off" << std::endl;
+	}
+	else
+	{
+		std::cout << "Skip New Files: On" << std::endl;
+	}
 
 	std::cout << "----------------------------\n"
 			  << std::endl;

--- a/cli/src/ApplyPatchCliOperation.cpp
+++ b/cli/src/ApplyPatchCliOperation.cpp
@@ -28,7 +28,7 @@ ApplyPatchCliOperation::ApplyPatchCliOperation() :
 
 	AddArgument( m_resourcesToPatchSourceBasePathsArgumentId, "The paths to the folders containing resources to patch.", true, true, PathsToString( defaultParams.resourcesToPatchSourceSettings.basePaths ) );
 
-	AddArgument( m_nextResourcesBasePathsArgumentId, "The path to resources after the patch. This is used to get fully added files which are not included in the generated patch files.", true, true, PathListToString( defaultParams.nextBuildResourcesSourceSettings.basePaths ) );
+	AddArgument( m_nextResourcesBasePathsArgumentId, "The path to resources after the patch. This is used to get fully added files which are not included in the generated patch files.", false, true, PathListToString( defaultParams.nextBuildResourcesSourceSettings.basePaths ) );
 
 	AddArgument( m_patchBinariesSourceTypeArgumentId, "The type of repository the patch binaries are sourced from.", false, false, SourceTypeToString( defaultParams.patchBinarySourceSettings.sourceType ), ResourceSourceTypeChoicesAsString() );
 
@@ -58,22 +58,25 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	CarbonResources::PatchApplyParams patchApplyParams;
 
-	std::vector<std::filesystem::path> newBuildResourceSettingBasePaths;
-	std::optional<std::string> nextResources = m_argumentParser->present<std::string>( m_nextResourcesBasePathsArgumentId );
-	if( !nextResources.has_value() )
-	{
-		returnErrorMessage = "Failed to parse next resource base path";
+	patchApplyParams.skipNewFiles = m_argumentParser->get<bool>( m_skipNewFilesArgumentId );
+    
+    if (!patchApplyParams.skipNewFiles)
+    {
+		std::vector<std::filesystem::path> newBuildResourceSettingBasePaths;
 
-		return false;
-	}
-	newBuildResourceSettingBasePaths.push_back( nextResources.value() );
-	std::string nextResourcesType = m_argumentParser->get( m_nextResourcesSourceTypeArgumentId );
-	if( !StringToResourceSourceType( nextResourcesType, patchApplyParams.nextBuildResourcesSourceSettings.sourceType ) )
-	{
-		returnErrorMessage = "Invalid next build source type";
+		std::string nextResources = m_argumentParser->get<std::string>( m_nextResourcesBasePathsArgumentId );
+		newBuildResourceSettingBasePaths.push_back( nextResources );
 
-		return false;
-	}
+        std::string nextResourcesType = m_argumentParser->get( m_nextResourcesSourceTypeArgumentId );
+		if( !StringToResourceSourceType( nextResourcesType, patchApplyParams.nextBuildResourcesSourceSettings.sourceType ) )
+		{
+			returnErrorMessage = "Invalid next build source type";
+
+			return false;
+		}
+
+        patchApplyParams.nextBuildResourcesSourceSettings.basePaths = newBuildResourceSettingBasePaths;
+    }
 
 	std::vector<std::filesystem::path> patchBinarySourceSettingsBasePaths;
 	auto patchBinaries = m_argumentParser->present<std::vector<std::string>>( m_patchBinariesSourceBasePathsArgumentId );
@@ -88,7 +91,7 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 		patchBinarySourceSettingsBasePaths.push_back( path );
 	}
 	patchApplyParams.patchBinarySourceSettings.basePaths = patchBinarySourceSettingsBasePaths;
-	patchApplyParams.nextBuildResourcesSourceSettings.basePaths = newBuildResourceSettingBasePaths;
+	
 	std::string patchBinariesType = m_argumentParser->get( m_patchBinariesSourceTypeArgumentId );
 	if( !StringToResourceSourceType( patchBinariesType, patchApplyParams.patchBinarySourceSettings.sourceType ) )
 	{
@@ -130,7 +133,6 @@ bool ApplyPatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	patchApplyParams.temporaryFilePath = "tempFile.resource";
 
-    patchApplyParams.skipNewFiles = m_argumentParser->get<bool>( m_skipNewFilesArgumentId );
 
     if( ShowCliStatusUpdates() )
 	{

--- a/cli/src/ApplyPatchCliOperation.h
+++ b/cli/src/ApplyPatchCliOperation.h
@@ -26,4 +26,5 @@ private:
 	std::string m_nextResourcesSourceTypeArgumentId;
 	std::string m_resourcesToPatchDestinationPathArgumentId;
 	std::string m_resourcesToPatchDestinationTypeArgumentId;
+	std::string m_skipNewFilesArgumentId;
 };

--- a/cli/src/CliOperation.cpp
+++ b/cli/src/CliOperation.cpp
@@ -205,9 +205,9 @@ bool CliOperation::ProcessCommandLine( int argc, char** argv )
 
 		m_argumentParser->parse_args( arguments );
 	}
-	catch( const std::runtime_error& )
+	catch( const std::runtime_error& e)
 	{
-
+		std::cout << e.what() << std::endl;
 		return false;
 	}
 

--- a/cli/src/CreateBundleCliOperation.cpp
+++ b/cli/src/CreateBundleCliOperation.cpp
@@ -24,7 +24,10 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
 	m_chunkSizeArgumentId( "--chunk-size" ),
 	m_streamChunkSizeId( "--stream-chunk-size" ),
 	m_networkRetryBackoffMultiplierId( "--download-retry-seconds" ),
-	m_networkRetryCountId( "--network-retry-count" )
+	m_networkRetryCountId( "--network-retry-count" ),
+	m_skipCompressionCalculation( "--skip-compression" ),
+	m_splitOnUncompressedSize( "--split-on-uncompressed-size" ),
+	m_numberOfThreadsId( "--number-of-threads" )
 {
 	AddRequiredPositionalArgument( m_inputResourceGroupPathArgumentId, "Path to ResourceGroup to bundle." );
 
@@ -56,6 +59,12 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
     AddArgument( m_networkRetryCountId, "Number of retries to attempt when encountering a failed download.", false, false, SizeToString( defaultParams.downloadSettings.retryCount ) );
 
 	AddArgument( m_networkRetryBackoffMultiplierId, "Multiplier in seconds to wait for when retrying, value will multiply on each retry to backoff.", false, false, SecondsToString( defaultParams.downloadSettings.retrySeconds ) );
+
+    AddArgumentFlag( m_skipCompressionCalculation, "Set skip compression calculations on bundles." );
+
+    AddArgumentFlag( m_splitOnUncompressedSize, "Set to split on uncompressed size rather than the default compressed size. This will likely lead to more inefficient chunking but may run faster." );
+
+    AddArgument( m_numberOfThreadsId, "Nnumber of threads to use for async processes.", false, false, SizeToString( defaultParams.asyncSettings.numberOfThreads ) );
 }
 
 bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -157,6 +166,49 @@ bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 		return false;
 	}
 
+
+    bool skipCompressionCalculation = m_argumentParser->get<bool>( m_skipCompressionCalculation );
+
+    bool splitOnUncompressed = m_argumentParser->get<bool>( m_splitOnUncompressedSize );
+
+	if( skipCompressionCalculation && bundleCreateParams.chunkDestinationSettings.destinationType == CarbonResources::ResourceDestinationType::REMOTE_CDN )
+	{
+		returnErrorMessage = "Cannot skip compression when bundle desination type is REMOTE_CDN, see --chunk-destination-type.";
+
+		return false;
+	}
+
+    if( skipCompressionCalculation && splitOnUncompressed == false )
+	{
+		returnErrorMessage = "Cannot skip compression when chunks are being split on compressed data, see --split-on-uncompressed-size.";
+
+		return false;
+	}
+
+    bundleCreateParams.calculateCompressions = !skipCompressionCalculation;
+
+    bundleCreateParams.splitOnCompressedSize = !splitOnUncompressed;
+
+    try
+	{
+		unsigned long long numberOfThreadsUnsignedLongLong = std::stoull( m_argumentParser->get( m_numberOfThreadsId ) );
+
+		if( numberOfThreadsUnsignedLongLong > std::numeric_limits<uint32_t>::max() )
+		{
+			return false;
+		}
+
+		bundleCreateParams.asyncSettings.numberOfThreads = static_cast<uint32_t>( numberOfThreadsUnsignedLongLong );
+	}
+	catch( std::invalid_argument& )
+	{
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		return false;
+	}
+
 	if( ShowCliStatusUpdates() )
 	{
 		PrintStartBanner( resourceGroupParams, bundleCreateParams );
@@ -199,6 +251,26 @@ void CreateBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
     std::cout << "Network retry count: " << bundleCreateParams.downloadSettings.retryCount << std::endl;
 
 	std::cout << "Network retry backoff multiplier ( Seconds ): " << bundleCreateParams.downloadSettings.retrySeconds.count() << std::endl;
+
+    if( bundleCreateParams.calculateCompressions )
+	{
+		std::cout << "Calculate Compression: Off" << std::endl;
+	}
+	else
+	{
+		std::cout << "Calculate Compression: On" << std::endl;
+	}
+
+    if( bundleCreateParams.splitOnCompressedSize )
+	{
+		std::cout << "Data splitting on: Uncompressed data (Warning, inefficient chunks may be produced)" << std::endl;
+	}
+	else
+	{
+		std::cout << "Data splitting on: Compressed data" << std::endl;
+	}
+
+    std::cout << "Number of threads for async operations: " << bundleCreateParams.asyncSettings.numberOfThreads << std::endl;
 
 	std::cout << "----------------------------\n"
 			  << std::endl;

--- a/cli/src/CreateBundleCliOperation.cpp
+++ b/cli/src/CreateBundleCliOperation.cpp
@@ -64,7 +64,7 @@ CreateBundleCliOperation::CreateBundleCliOperation() :
 
     AddArgumentFlag( m_splitOnUncompressedSize, "Set to split on uncompressed size rather than the default compressed size. This will likely lead to more inefficient chunking but may run faster." );
 
-    AddArgument( m_numberOfThreadsId, "Nnumber of threads to use for async processes.", false, false, SizeToString( defaultParams.asyncSettings.numberOfThreads ) );
+    AddArgument( m_numberOfThreadsId, "Number of threads to use for async processes.", false, false, SizeToString( defaultParams.asyncSettings.numberOfThreads ) );
 }
 
 bool CreateBundleCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -254,11 +254,11 @@ void CreateBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
 
     if( bundleCreateParams.calculateCompressions )
 	{
-		std::cout << "Calculate Compression: Off" << std::endl;
+		std::cout << "Calculate Compression: On" << std::endl;
 	}
 	else
 	{
-		std::cout << "Calculate Compression: On" << std::endl;
+		std::cout << "Calculate Compression: Off" << std::endl;
 	}
 
     if( bundleCreateParams.splitOnCompressedSize )

--- a/cli/src/CreateBundleCliOperation.h
+++ b/cli/src/CreateBundleCliOperation.h
@@ -48,6 +48,12 @@ private:
     std::string m_networkRetryCountId;
 
 	std::string m_networkRetryBackoffMultiplierId;
+
+    std::string m_skipCompressionCalculation;
+
+    std::string m_splitOnUncompressedSize;
+
+    std::string m_numberOfThreadsId;
 };
 
 #endif // CreateBundleCliOperation_H

--- a/cli/src/CreatePatchCliOperation.cpp
+++ b/cli/src/CreatePatchCliOperation.cpp
@@ -12,7 +12,7 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 	m_nextResourceGroupPathArgumentId( "next-resourcegroup-path" ),
 	m_resourceGroupRelativePathArgumentId( "--resourcegroup-relative-path" ),
 	m_patchResourceGroupRelativePathArgumentId( "--patchResourcegroup-relative-path" ),
-	m_newFilesResourceGroupRelativePathArgumentId( "--new-files-Resourcegroup-relative-path" ),
+	m_newFilesResourceGroupRelativePathArgumentId( "--new-files-resourcegroup-relative-path" ),
 	m_resourceSourceTypePreviousArgumentId( "--resource-source-type-previous" ),
 	m_resourceSourceBasePathPreviousArgumentId( "--resource-source-base-path-previous" ),
 	m_resourceSourceTypeNextArgumentId( "--resource-source-type-next" ),

--- a/cli/src/CreatePatchCliOperation.cpp
+++ b/cli/src/CreatePatchCliOperation.cpp
@@ -79,7 +79,7 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 
 	AddArgument( m_newFilesResourceGroupDestinationPathArgumentId, "Represents the base path where the new files ResourceGroup will be saved.", false, false, defaultParams.resourceNewFilesResourceGroupDestinationSettings.basePath.string() );
 
-    AddArgument( m_maxOverallPatchArgumentId, "The maximum overall patch size. If patch generation goes over this value the process will stop with failure. This value represents the uncompressed size.", false, false, SizeToString( defaultParams.maxTotalPatchSize ) );
+    AddArgument( m_maxOverallPatchArgumentId, "The maximum overall patch size. If patch generation goes over this value the process will stop with failure. This value represents the uncompressed size. A value of 0 will be treated as unlimited", false, false, SizeToString( defaultParams.maxTotalPatchSize ) );
 }
 
 bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const

--- a/cli/src/CreatePatchCliOperation.cpp
+++ b/cli/src/CreatePatchCliOperation.cpp
@@ -12,6 +12,7 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 	m_nextResourceGroupPathArgumentId( "next-resourcegroup-path" ),
 	m_resourceGroupRelativePathArgumentId( "--resourcegroup-relative-path" ),
 	m_patchResourceGroupRelativePathArgumentId( "--patchResourcegroup-relative-path" ),
+	m_newFilesResourceGroupRelativePathArgumentId( "--new-files-Resourcegroup-relative-path" ),
 	m_resourceSourceTypePreviousArgumentId( "--resource-source-type-previous" ),
 	m_resourceSourceBasePathPreviousArgumentId( "--resource-source-base-path-previous" ),
 	m_resourceSourceTypeNextArgumentId( "--resource-source-type-next" ),
@@ -25,7 +26,10 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 	m_networkRetryBackoffMultiplierId( "--download-retry" ),
 	m_networkRetryCountId( "--network-retry-count" ),
 	m_indexFolderArgumentId( "--index-folder" ),
-	m_skipCompressionCalculation( "--skip-compression" )
+	m_skipCompressionCalculation( "--skip-compression" ),
+	m_newFilesResourceGroupDestinationTypeArgumentId( "--new-files-resourcegroup-destination-type" ),
+	m_newFilesResourceGroupDestinationPathArgumentId( "--new-files-resourcegroup-destination-base-path" ),
+	m_maxOverallPatchArgumentId( "--max-overall-patch-size" )
 {
 
 	AddRequiredPositionalArgument( m_previousResourceGroupPathArgumentId, "Filename to previous resourceGroup." );
@@ -49,6 +53,8 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 
 	AddArgument( m_patchResourceGroupRelativePathArgumentId, "Relative path for output PatchResourceGroup which will contain all the patches produced.", false, false, defaultParams.resourceGroupPatchRelativePath.string() );
 
+    AddArgument( m_newFilesResourceGroupRelativePathArgumentId, "Relative path for output new files ResourceGroup which will contain all the new files added between supplied builds.", false, false, defaultParams.resourceGroupNewFilesRelativePath.string() );
+
 	AddArgument( m_resourceSourceTypePreviousArgumentId, "Represents the type of repository to source resources for previous.", false, false, SourceTypeToString( defaultParams.resourceSourceSettingsPrevious.sourceType ), ResourceSourceTypeChoicesAsString() );
 
 	AddArgument( m_patchBinaryDestinationBasePathArgumentId, "Represents the base path where binary patches will be saved.", false, false, defaultParams.resourcePatchBinaryDestinationSettings.basePath.string() );
@@ -68,6 +74,12 @@ CreatePatchCliOperation::CreatePatchCliOperation() :
 	AddArgument( m_indexFolderArgumentId, "The folder in which to place indexes generated for patch files.", false, false, defaultParams.indexFolder.string() );
 
     AddArgumentFlag( m_skipCompressionCalculation, "Set skip compression calculations on patches." );
+
+    AddArgument( m_newFilesResourceGroupDestinationTypeArgumentId, "Represents the type of repository where the new files ResourceGroup will be saved.", false, false, DestinationTypeToString( defaultParams.resourceNewFilesResourceGroupDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+
+	AddArgument( m_newFilesResourceGroupDestinationPathArgumentId, "Represents the base path where the new files ResourceGroup will be saved.", false, false, defaultParams.resourceNewFilesResourceGroupDestinationSettings.basePath.string() );
+
+    AddArgument( m_maxOverallPatchArgumentId, "The maximum overall patch size. If patch generation goes over this value the process will stop with failure. This value represents the uncompressed size.", false, false, SizeToString( defaultParams.maxTotalPatchSize ) );
 }
 
 bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -85,6 +97,8 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 	createPatchParams.resourceGroupRelativePath = m_argumentParser->get<std::string>( m_resourceGroupRelativePathArgumentId );
 
 	createPatchParams.resourceGroupPatchRelativePath = m_argumentParser->get<std::string>( m_patchResourceGroupRelativePathArgumentId );
+
+    createPatchParams.resourceGroupNewFilesRelativePath = m_argumentParser->get<std::string>( m_newFilesResourceGroupRelativePathArgumentId );
 
 	std::string resourceSourceTypePrevious = m_argumentParser->get<std::string>( m_resourceSourceTypePreviousArgumentId );
 
@@ -212,6 +226,38 @@ bool CreatePatchCliOperation::Execute( std::string& returnErrorMessage ) const
 
     createPatchParams.calculateCompressions = !skipCompressionCalculation;
 
+    createPatchParams.resourceNewFilesResourceGroupDestinationSettings.basePath = m_argumentParser->get<std::string>( m_newFilesResourceGroupDestinationPathArgumentId );
+
+	std::string newFilesResourceGroupDestinationType = m_argumentParser->get<std::string>( m_newFilesResourceGroupDestinationTypeArgumentId );
+
+	if( !StringToResourceDestinationType( newFilesResourceGroupDestinationType, createPatchParams.resourceNewFilesResourceGroupDestinationSettings.destinationType ) )
+	{
+		returnErrorMessage = "Invalid new file destination type";
+
+		return false;
+	}
+
+    try
+	{
+		unsigned long in = std::stoul( m_argumentParser->get( m_maxOverallPatchArgumentId ) );
+		if( in > std::numeric_limits<uint32_t>::max() )
+		{
+			returnErrorMessage = "Invalid overall patch size";
+			return false;
+		}
+		createPatchParams.maxTotalPatchSize = static_cast<uint32_t>( in );
+	}
+	catch( std::invalid_argument& )
+	{
+		returnErrorMessage = "Invalid overall patch size";
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		returnErrorMessage = "Invalid overall patch size";
+		return false;
+	}
+
 	if( ShowCliStatusUpdates() )
 	{
 		PrintStartBanner( previousResourceGroupParams, nextResourceGroupParams, createPatchParams );
@@ -235,6 +281,8 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 	std::cout << "Resource Group Relative Path: " << createPatchParams.resourceGroupRelativePath << std::endl;
 
 	std::cout << "Resource Group Patch Relative Path: " << createPatchParams.resourceGroupPatchRelativePath << std::endl;
+
+    std::cout << "Resource Group New Files Relative Path: " << createPatchParams.resourceGroupNewFilesRelativePath << std::endl;
 
 	std::cout << "Patch File Relative Path Prefix: " << createPatchParams.patchFileRelativePathPrefix << std::endl;
 
@@ -274,6 +322,12 @@ void CreatePatchCliOperation::PrintStartBanner( const CarbonResources::ResourceG
 	{
 		std::cout << "Calculate Compression: On" << std::endl;
 	}
+
+    std::cout << "New File Resource Group Destination Settings Base Path: " << createPatchParams.resourceNewFilesResourceGroupDestinationSettings.basePath << std::endl;
+
+	std::cout << "New File Resource Group Destination Settings Destination Type: " << DestinationTypeToString( createPatchParams.resourceNewFilesResourceGroupDestinationSettings.destinationType ) << std::endl;
+
+    std::cout << "Max overall patch size: " << createPatchParams.maxTotalPatchSize << std::endl;
 
 	std::cout << "----------------------------\n"
 			  << std::endl;

--- a/cli/src/CreatePatchCliOperation.h
+++ b/cli/src/CreatePatchCliOperation.h
@@ -32,6 +32,8 @@ private:
 
 	std::string m_patchResourceGroupRelativePathArgumentId;
 
+    std::string m_newFilesResourceGroupRelativePathArgumentId;
+
 	std::string m_resourceSourceTypePreviousArgumentId;
 
 	std::string m_resourceSourceBasePathPreviousArgumentId;
@@ -59,6 +61,12 @@ private:
 	std::string m_indexFolderArgumentId;
 
     std::string m_skipCompressionCalculation;
+
+    std::string m_newFilesResourceGroupDestinationTypeArgumentId;
+
+    std::string m_newFilesResourceGroupDestinationPathArgumentId;
+
+    std::string m_maxOverallPatchArgumentId;
 };
 
 #endif // CreatePatchCliOperation_H

--- a/cli/src/UnpackBundleCliOperation.cpp
+++ b/cli/src/UnpackBundleCliOperation.cpp
@@ -11,7 +11,8 @@ UnpackBundleCliOperation::UnpackBundleCliOperation() :
 	m_chunkSourceBasePathsArgumentId( "--chunk-source-base-path" ),
 	m_chunkSourceTypeArgumentId( "--chunk-source-type" ),
 	m_resourceDestinationBasePathArgumentId( "--resource-destination-base-path" ),
-	m_resourceDestinationTypeArgumentId( "--resource-destination-type" )
+	m_resourceDestinationTypeArgumentId( "--resource-destination-type" ),
+	m_chunkReadCacheSize( "--chunk-read-cache-size" )
 {
 	AddRequiredPositionalArgument( m_bundleResourceGroupPathArgumentId, "The path to the BundleResourceGroup.yaml file" );
 
@@ -24,6 +25,8 @@ UnpackBundleCliOperation::UnpackBundleCliOperation() :
 	AddArgument( m_resourceDestinationBasePathArgumentId, "The path to the directory in which to place the unbundled files.", false, false, "UnpackBundleOut" );
 
 	AddArgument( m_resourceDestinationTypeArgumentId, "The type of repository in which to place the bundle files.", false, false, DestinationTypeToString( defaultParams.resourceDestinationSettings.destinationType ), ResourceDestinationTypeChoicesAsString() );
+
+    AddArgument( m_chunkReadCacheSize, "Size of in memory cache to use while reading chunk files. (Higher will give faster performance but use more RAM)", false, false, SizeToString( defaultParams.chunkReadCacheSize ) );
 }
 
 bool UnpackBundleCliOperation::Execute( std::string& returnErrorMessage ) const
@@ -76,6 +79,28 @@ bool UnpackBundleCliOperation::Execute( std::string& returnErrorMessage ) const
 
 	unpackParams.resourceDestinationSettings.basePath = m_argumentParser->get( m_resourceDestinationBasePathArgumentId );
 
+    try
+	{
+		unsigned long in = std::stoul( m_argumentParser->get( m_chunkReadCacheSize ) );
+		if( in > std::numeric_limits<uint32_t>::max() )
+		{
+			returnErrorMessage = "Invalid chunk read cache size";
+			return false;
+		}
+		unpackParams.chunkReadCacheSize = static_cast<uint32_t>( in );
+	}
+	catch( std::invalid_argument& )
+	{
+		returnErrorMessage = "Invalid chunk read cache size";
+		return false;
+	}
+	catch( std::out_of_range& )
+	{
+		returnErrorMessage = "Invalid chunk read cache size";
+		return false;
+	}
+
+
     if (ShowCliStatusUpdates())
     {
 		PrintStartBanner( importParams, unpackParams );
@@ -95,6 +120,7 @@ void UnpackBundleCliOperation::PrintStartBanner( const CarbonResources::Resource
 	std::cout << "Chunk Source Type: " << SourceTypeToString( unpackParams.chunkSourceSettings.sourceType ) << std::endl;
 	std::cout << "Resource Destination Base Path: " << unpackParams.resourceDestinationSettings.basePath << std::endl;
 	std::cout << "Resource Destination Type: " << DestinationTypeToString( unpackParams.resourceDestinationSettings.destinationType ) << std::endl;
+	std::cout << "Chunk read cache size: " << unpackParams.chunkReadCacheSize << std::endl;
 
 	std::cout << "----------------------------\n"
 			  << std::endl;

--- a/cli/src/UnpackBundleCliOperation.h
+++ b/cli/src/UnpackBundleCliOperation.h
@@ -22,4 +22,5 @@ private:
 	std::string m_chunkSourceTypeArgumentId;
 	std::string m_resourceDestinationBasePathArgumentId;
 	std::string m_resourceDestinationTypeArgumentId;
+	std::string m_chunkReadCacheSize;
 };

--- a/doc/source/DesignDocuments/bundles.rst
+++ b/doc/source/DesignDocuments/bundles.rst
@@ -1,0 +1,35 @@
+Bundles
+#######
+
+To efficiently transfer file data across a network, resources combines and splits file data into evenly sized 'chunks'. This collection of 'chunks' is what is referred to as a 'Bundle'.
+
+The two data split methods
+--------------------------
+resources offers two main appraoches to the splitting of the file data:
+
+1. Split on compressed size
+2. Split on uncompressed size
+
+By default resources will split on the compressed size, but this can be changed via argument both through CLI and lib.
+
+Each setting will give vastly different results and it is important to understand the implications of both.
+
+Split on compressed size
+------------------------
+This is the default setting and will create the most efficent bundles in terms of size at the cost of increased processing time during creation.
+
+When chunking files that will ultimately be compressed on the network, it makes the most sense to use the compressed size of the files as they are added to the chunk.
+Files may have vastly different sizes between compressed and uncompressed size. So if splitting on uncompressed size it is possible to create chunks that would eventually
+compress to a very small size. This scenario is very likely for patch files for example. This could lead to tiny chunk files that have very small file sizes.
+
+This process is sequential by nature so calculation time is expensive as it leaves little room for parallelism. This means the process can take considerably longer than the alternative (split on uncompressed).
+
+Split on uncompressed size
+--------------------------
+Splitting on uncompressed size may be preferred if bundle creation time is a concern. The process will complete in a far shorter time but the caveat is that more chunks will be created and these will be less size efficient.
+
+This operation doesn't need to calculate compression as part of chunking and so can defer the compression calculation to a parallel job to achieve much better performance.
+
+This approach is best used for files which have much less compression oportunity than patch files. Although it will be less efficient, it may be acceptible compared to the time tradeoff.
+
+It is also possible to completely skip compression calculation during bundling. This method gives the ultimate processing speed and may make sense depending on the how the data will be processed after this step.

--- a/doc/source/Guides/HowToCreateABundle.rst
+++ b/doc/source/Guides/HowToCreateABundle.rst
@@ -1,7 +1,7 @@
 How To Create A Bundle
 ======================
 
-Patch creation can create many files. This is due many factors such as chunked input.
+Patch creation can create many files. This is due to many factors such as chunked input.
 
 Furthermore, once the patch binaries are compressed their size may reduce dramatically.
 

--- a/doc/source/QuickStart/ExampleDeliveryPipeline.rst
+++ b/doc/source/QuickStart/ExampleDeliveryPipeline.rst
@@ -1,0 +1,146 @@
+Example Delivery Pipeline
+=========================
+
+This is a simple delivery pipeline soley using the CLI with dev tools available.
+
+In a real scenario the consumer of the bundles and patches would use the library api.
+
+
+Scenario
+--------
+
+This will outline a method for updating a new client build.
+
+The build will offer two methods for delivering the updated client.
+
+1. A full bundle containing the new client data.
+2. Patches to bring a current install of a previous client to the new version.
+
+The data used here will simply be both accessible locally, however this doesn't have to be the case, they could be sourced remotely.
+
+1. ClientA (The previous client build)
+2. ClientB (The new client build)
+
+Build Side
+----------
+
+The build side will be responsible for creation of the data and uploading to a remote location.
+
+1. Create Resource Groups for both builds
+
+This will create resource group representations of each directory of data.
+
+``--skip-compression`` is used as we don't need the compression calculation information and this is a slow calculation
+
+``.\resources.exe create-group ClientA --verbosity-level -1 --output-file ResourceGroupClientA.yaml --skip-compression``
+
+``.\resources.exe create-group ClientB --verbosity-level -1 --output-file ResourceGroupClientB.yaml --skip-compression``
+
+2. Create Patch
+
+This will create patch files between the two builds.
+A max overall patch size is specified ``--max-overall-patch-size``, if during processing a patch exceeds this value then the patch process will fail.
+This stops huge inefficient patches being created. In this instance no further processing or upload of patch data is requred and the processing pipeline can skip directly to 5.
+
+``.\resources.exe create-patch ResourceGroupClientA.yaml ResourceGroupClientB.yaml --resource-source-base-path-previous ClientA --resource-source-base-path-next ClientB --chunk-size 1048576 --skip-compression --max-overall-patch-size 1073741824 --verbosity-level -1``
+
+3. Bundle Patch
+
+The patch files will be numerous and have a high opportunity for compression, therefore they are bundled by splitting on compression, which is the default behaviour.
+
+``.\resources.exe create-bundle PatchOut/PatchResourceGroup.yaml --resource-source-path .\PatchOut\Patches\ --resource-source-type LOCAL_CDN --chunk-destination-path ToCDN/BundledPatches/Chunks/ --chunk-destination-type REMOTE_CDN --bundle-resourcegroup-destination-path ToCDN/BundledPatches/ --bundle-resourcegroup-relative-path BundledPatchResourceGroup.yaml --verbosity-level -1``
+
+4. Bundle New Files
+
+By default patch creation in step 2 will also create a Resource Group containing the new files that have been added between the two builds.
+These new files are not included in the patch files and so need to be delivered in some way to the client.
+There are two ways to do this. The default is to supply a location to the ``apply-patch`` operation where resources can download the new files from.
+However this may not be the most efficient approach as the files may be very small or large.
+Therefore here we create a bundle of the new files and deliver as part of our pipeline.
+
+``.\resources.exe create-bundle PatchOut/NewFilesResourceGroup.yaml --resource-source-path ClientB --resource-source-type LOCAL_RELATIVE --chunk-destination-path ToCDN/BundledNewFiles/Chunks/ --chunk-destination-type REMOTE_CDN --bundle-resourcegroup-destination-path ToCDN/BundledNewFiles/ --bundle-resourcegroup-relative-path BundledNewFilesResourceGroup.yaml --verbosity-level -1``
+
+5. Bundle Entire new Build
+
+Finally we will offer a full bundle for the new build. This is useful if a consumer doesn't already have a version of the old build on their system, or if there is no patch available for some reason (e.g. the patch would have been huge).
+This operation has no dependency on the previous steps and can be done in parallel.
+
+``.\resources.exe create-bundle .\ResourceGroupClientB.yaml --verbosity-level -1 --resource-source-path ClientB --split-on-uncompressed-size --chunk-destination-type REMOTE_CDN --chunk-destination-path ToCDN/BundledClient/Chunks/ --bundle-resourcegroup-destination-path ToCDN/BundledClient/``
+
+6. Upload to remote location (CDN)
+
+In this example a dir named ``ToCDN`` now contains everything for this latest build and can be uploaded. If patch creation was also successful this will include directores:
+    1. BundledClient - The full bundle of the ClientB.
+    2. BundledNewFiles - A bundle for all the files added between ClientA and ClientB
+    3. BundledPatches - A bundle for all the patches between ClientA and ClientB
+
+
+Delivery Side
+-------------
+
+This is the side that will be managed by some sort of launcher on the users system.
+
+Current state of the users's system could be a few scenarios and each require a different code path.
+
+1. ClientA is not currently on the system: In this case go unbundle the whole ClientB
+
+2. ClientA is on the system but there is no patch available: Again unbundle the whole ClientB
+
+3. ClientA is on the system and a patch is available: Apply the patch and unbundle the new files, in case of any failure fallback to unbundling full ClientB.
+
+
+Unbundling ClientB
+------------------
+Assuming the build files are available at ``https://cdn.com/ToCDN``
+
+1. Download the bundle resource group file:
+
+``https://cdn.com/ToCDN/BundledClient/BundleResourceGroup.yaml``
+
+2. Unbundle the client
+
+``.\resources.exe unpack-bundle .\ToCDN\BundledClient\BundleResourceGroup.yaml --chunk-source-base-path https://cdn.com/ToCDN/ToCDN/BundledClient/Chunks/ --chunk-source-type REMOTE_CDN --resource-destination-base-path Out/UnpackedClient --resource-destination-type LOCAL_RELATIVE --verbosity-level -1``
+
+3. Copy bundle files to the correct location
+The files are in a staging area, this stops the possibility of a bundle failing half way through and being left with a broken build.
+The files will be in the following location:
+    1. ``Out/UnpackedClient`` - all client files.
+
+
+Patching From ClientA to ClientB
+--------------------------------
+
+Assuming the build files are available at ``https://cdn.com/ToCDN``
+
+1. Download the bundled patch resource group file:
+
+``https://cdn.com/ToCDN/BundledPatches/BundledPatchResourceGroup.yaml``
+
+If this file is not found then assume that no patch is available and download via bundle.
+
+2. Download the bundled new files resource group file:
+
+``https://cdn.com/ToCDN/BundledNewFiles/BundledNewFilesResourceGroup.yaml``
+
+If the bundled patch exists but this doesn't then the patch is corrupt, fall back to download via bundle.
+
+3. Unbundle the patch files
+
+``.\resources.exe unpack-bundle .BundledPatchResourceGroup.yaml --chunk-source-base-path https://cdn.com/ToCDN/ToCDN/BundledNewFiles/Chunks/ --chunk-source-type REMOTE_CDN --resource-destination-base-path Out/UnpackedNewFiles --resource-destination-type LOCAL_RELATIVE --verbosity-level -1``
+
+4. Unbundle the new files
+
+``.\resources.exe unpack-bundle .BundledNewFilesResourceGroup.yaml --chunk-source-base-path https://cdn.com/ToCDN/ToCDN/BundledPatches/Chunks/ --chunk-source-type REMOTE_CDN --resource-destination-base-path Out/UnpackedPatches --resource-destination-type LOCAL_CDN --verbosity-level -1`` 
+
+5. Apply patches
+
+``.\resources.exe apply-patch .\Out\UnpackedPatches\ResourceGroup.yaml --patch-binaries-base-path .\out\UnpackedPatches\ --resources-to-patch-base-path .\ClientA\ --output-base-path Out/PatchedClientFiles/ --skip-new-files --verbosity-level -1``
+
+6. Copy the patch files to the correct location
+
+The files are in a staging area for safety, this stops the possibilty of a patch failing half way through and being left with a broken build.
+Once the patch process has completed succcessfully the files need to be copied to the real ClientA location.
+The files will be in the following locations:
+    1. ``Out/UnpackedNewFiles`` - New files that will need to copied in.
+    2. ``Out/PatchedClientFiles/`` - Updated files after patching procedure sould replace files already present on the system.
+    3. Removed files are returned in the lib in vector '', these will need to be removed from the destination.

--- a/doc/source/QuickStart/ExamplePatchCreationProcedure.rst
+++ b/doc/source/QuickStart/ExamplePatchCreationProcedure.rst
@@ -61,7 +61,7 @@ This will create a patch in the folder ``PatchOut`` which contains:
 Creating a Bundle from the Patch
 --------------------------------
 
-Patch creation can create many files. This is due many factors such as chunked input.
+Patch creation can create many files. This is due to many factors such as chunked input.
 
 Furthermore, once the patch binaries are compressed their size may reduce dramatically.
 

--- a/doc/source/designDocuments.rst
+++ b/doc/source/designDocuments.rst
@@ -9,3 +9,4 @@ Documents contained in this section detail design approaches in resources.
    DesignDocuments/filesystemDesign
    DesignDocuments/resourceGroupFileFormat
    DesignDocuments/fileFiltering
+   DesignDocuments/bundles

--- a/doc/source/quickStart.rst
+++ b/doc/source/quickStart.rst
@@ -7,3 +7,4 @@ Quick start showing real world practical scenarios.
    :maxdepth: 1
    
    QuickStart/ExamplePatchCreationProcedure
+   QuickStart/ExampleDeliveryPipeline

--- a/include/BundleResourceGroup.h
+++ b/include/BundleResourceGroup.h
@@ -36,7 +36,7 @@ struct BundleUnpackParams final
 
     DownloadSettings downloadSettings;
 
-    uintmax_t chunkReadCacheSize = 1073741824;
+    uintmax_t chunkReadCacheSize = 1024 * 1024 * 1024; // 1GB
 };
 
 /** @class BundleResourceGroup

--- a/include/BundleResourceGroup.h
+++ b/include/BundleResourceGroup.h
@@ -23,6 +23,8 @@ namespace CarbonResources
     *  Settings relating to status callback messaging
 	*  @var BundleUnpackParams::DownloadSettings
     *  Settings relating to downloads
+    *  @var BundleUnpackParams::chunkReadCacheSize
+    *  Cache size available for use during the unpacking operation
     */
 struct BundleUnpackParams final
 {
@@ -33,6 +35,8 @@ struct BundleUnpackParams final
 	CallbackSettings callbackSettings;
 
     DownloadSettings downloadSettings;
+
+    uintmax_t chunkReadCacheSize = 1073741824;
 };
 
 /** @class BundleResourceGroup

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -167,7 +167,8 @@ enum class ResultType
 	RESOURCE_NOT_FOUND,
 	REQUIRED_INPUT_PARAMETER_NOT_SET,
 	FAILED_TO_INITIALIZE_RESOURCE_FILTER,
-    INVALID_INPUT_PARAMETER
+    INVALID_INPUT_PARAMETER,
+    PATCH_SIZE_EXCEEDED
 	//NOTE: if adding to this enum, a complimentary entry must be added to resultToString.
 };
 

--- a/include/Enums.h
+++ b/include/Enums.h
@@ -167,6 +167,7 @@ enum class ResultType
 	RESOURCE_NOT_FOUND,
 	REQUIRED_INPUT_PARAMETER_NOT_SET,
 	FAILED_TO_INITIALIZE_RESOURCE_FILTER,
+    INVALID_INPUT_PARAMETER
 	//NOTE: if adding to this enum, a complimentary entry must be added to resultToString.
 };
 

--- a/include/PatchResourceGroup.h
+++ b/include/PatchResourceGroup.h
@@ -30,6 +30,8 @@ namespace CarbonResources
     *  Settings relating to status callback messaging
     *  @var PatchApplyParams::downloadSettings
     *  Settings relating to downloads
+    *  @var PatchApplyParams::skipNewFiles
+    *  If set then any new files will be skipped rather than retrieved from nextBuildResourcesSource
     */
 struct PatchApplyParams final
 {
@@ -46,6 +48,8 @@ struct PatchApplyParams final
 	CallbackSettings callbackSettings;
 
     DownloadSettings downloadSettings;
+
+    bool skipNewFiles = false;
 };
 
 /** @class PatchResourceGroup

--- a/include/PatchResourceGroup.h
+++ b/include/PatchResourceGroup.h
@@ -24,6 +24,8 @@ namespace CarbonResources
     *  Location where the resources to be patched can be sourced.
     *  @var PatchApplyParams::resourcesToPatchDestinationSettings
     *  Location where to place patched resources. This can match PatchApplyParams::resourcesToPatchSourceSettings to overwrite. Allows creation of staging area in case of failure.
+    *  @var PatchApplyParams::resourcesToRemove
+    *  This will be populated with relative paths of the files that have been removed between previous and next supplied.
     *  @var PatchApplyParams::temporaryFilePath
     *  Name of a temporary filename to use when patching large files. This file will be cleaned up on process completion. 
     *  @var PatchApplyParams::callbackSettings
@@ -42,6 +44,8 @@ struct PatchApplyParams final
 	ResourceSourceSettings resourcesToPatchSourceSettings{ ResourceSourceType::LOCAL_RELATIVE };
 
 	ResourceDestinationSettings resourcesToPatchDestinationSettings{ ResourceDestinationType::LOCAL_RELATIVE };
+
+    std::vector<std::filesystem::path> resourcesToRemove;
 
 	std::filesystem::path temporaryFilePath = "tempFile.resource";
 
@@ -71,7 +75,7 @@ public:
 	/// @param params input parameters, See PatchApplyParams for more details.
 	/// @see ResourceGroup::CreatePatch for information regarding patch creation.
 	/// @return Result see CarbonResources::Result for more details.
-	Result Apply( const PatchApplyParams& params );
+	Result Apply( PatchApplyParams& params );
 
 private:
 	PatchResourceGroupImpl* m_impl;

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -101,6 +101,16 @@ struct ResourceDestinationSettings
 	std::filesystem::path basePath = "";
 };
 
+/** @struct AsyncSettings
+    *  @brief Settings related to async processing
+    *  @var AsyncSettings::numberOfThreads
+    *  Number of threads to use for async processes, passing 0 will run all on main thread
+    */
+struct AsyncSettings
+{
+	uint32_t numberOfThreads = std::thread::hardware_concurrency();
+};
+
 /** @struct BundleCreateParams
     *  @brief Function Parameters required for CarbonResources::ResourceGroup::CreatePatch
     *  @var BundleCreateParams::resourceSourceSettings
@@ -124,6 +134,10 @@ struct ResourceDestinationSettings
     *  Settings related to downloads
     *  @var BundleCreateParams::calculateCompressions
     *  Specifies if compression will be calculated for the generated bundle chunks
+    *  @var BundleCreateParams::splitOnCompressedSize
+    *  Chunks are split based on the compressed size rather than uncompressed, this gives the best chunk compression.
+    *  @var BundleCreateParams::asyncSettings
+    *  Settings related to async setup
     */
 struct BundleCreateParams
 {
@@ -146,6 +160,10 @@ struct BundleCreateParams
 	DownloadSettings downloadSettings;
 
     bool calculateCompressions = true;
+
+    bool splitOnCompressedSize = true;
+
+    AsyncSettings asyncSettings;
 };
 
 /** @struct PatchCreateParams
@@ -326,16 +344,6 @@ struct ExportResourceSettings
 		CarbonResources::ResourceDestinationType::LOCAL_CDN,
 		"ExportedResources"
 	};
-};
-
-/** @struct AsyncSettings
-    *  @brief Settings related to async processing
-    *  @var AsyncSettings::numberOfThreads
-    *  Number of threads to use for async processes, passing 0 will run all on main thread
-    */
-struct AsyncSettings
-{
-	uint32_t numberOfThreads = std::thread::hardware_concurrency();
 };
 
 /** @struct CompressionCalculationSettings

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -199,7 +199,7 @@ struct BundleCreateParams
     *  @var PatchCreateParams::calculateCompressions
     *  Specifies if compression will be calculated for the generated bundle chunks
     *  @var PatchCreateParams::maxTotalPatchSize
-    *  The maximum size of total patch data, if exceeded the process will fail.
+    *  The maximum size of total patch data, if exceeded the process will fail, a value of zero will be treated as unlimited.
     */
 struct PatchCreateParams
 {
@@ -233,7 +233,7 @@ struct PatchCreateParams
 
     bool calculateCompressions = true;
 
-    uint32_t maxTotalPatchSize = 1073741824;
+    uint32_t maxTotalPatchSize = 0;
 };
 
 /** @struct ResourceGroupImportFromFileParams

--- a/include/ResourceGroup.h
+++ b/include/ResourceGroup.h
@@ -176,6 +176,8 @@ struct BundleCreateParams
     *  Relative path for output resourceGroup which will contain the diff between PatchCreateParams::previousResourceGroup and this ResourceGroup.
     *  @var PatchCreateParams::resourceGroupPatchRelativePath
     *  Relative path for output PatchResourceGroup which will contain all the patches produced.
+    *  @var PatchCreateParams::resourceGroupNewFilesRelativePath
+    *  Relative path for output NewFilesResourceGroup which will contain all the new files produced.
     *  @var PatchCreateParams::patchFileRelativePathPrefix
     *  Relative path prefix for produced patch binaries. Default is "Patches/Patch" which will produce patches such as Patches/Patch.1 ...
     *  @var PatchCreateParams::resourceSourceSettingsPrevious
@@ -186,6 +188,8 @@ struct BundleCreateParams
     *  Where the produced binary patches will be saved.
     *  @var PatchCreateParams::resourcePatchResourceGroupDestinationSettings
     *  Where the produced PatchResourceGroup will be saved.
+    *  @var PatchCreateParams::resourceNewFilesResourceGroupDestinationSettings
+    *  Where the produced NewFilesResourceGroup will be saved.
     *  @var PatchCreateParams::callbackSettings
     *  Settings relating to status callback messaging
     *  @var PatchCreateParams::downloadSettings
@@ -194,6 +198,8 @@ struct BundleCreateParams
     *  Directory to store index calculation files during patch creation.
     *  @var PatchCreateParams::calculateCompressions
     *  Specifies if compression will be calculated for the generated bundle chunks
+    *  @var PatchCreateParams::maxTotalPatchSize
+    *  The maximum size of total patch data, if exceeded the process will fail.
     */
 struct PatchCreateParams
 {
@@ -205,6 +211,8 @@ struct PatchCreateParams
 
 	std::filesystem::path resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
 
+    std::filesystem::path resourceGroupNewFilesRelativePath = "NewFilesResourceGroup.yaml";
+
 	std::filesystem::path patchFileRelativePathPrefix = "Patches/Patch";
 
 	ResourceSourceSettings resourceSourceSettingsPrevious = { CarbonResources::ResourceSourceType::LOCAL_RELATIVE };
@@ -215,6 +223,8 @@ struct PatchCreateParams
 	
 	ResourceDestinationSettings resourcePatchResourceGroupDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_RELATIVE, "PatchOut/" };
 
+    ResourceDestinationSettings resourceNewFilesResourceGroupDestinationSettings = { CarbonResources::ResourceDestinationType::LOCAL_RELATIVE, "PatchOut/" };
+
 	CallbackSettings callbackSettings;
 
 	DownloadSettings downloadSettings;
@@ -222,6 +232,8 @@ struct PatchCreateParams
 	std::filesystem::path indexFolder = std::filesystem::temp_directory_path() / "carbonResources" / "chunkIndexes";
 
     bool calculateCompressions = true;
+
+    uint32_t maxTotalPatchSize = 1073741824;
 };
 
 /** @struct ResourceGroupImportFromFileParams

--- a/src/BundleResourceGroupImpl.cpp
+++ b/src/BundleResourceGroupImpl.cpp
@@ -56,8 +56,24 @@ Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackP
 {
 	statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 0, 20, "Rebuilding resources." );
 
-	ResourceGroupInfo* resourceGroupResource = m_resourceGroupParameter.GetValue();
+    
+    // Ensure the cache size if enough to hold the largest chunk
+	uintmax_t largestChunkSize;
 
+	Result getLargestChunkResult = GetLargestResourceSize( largestChunkSize );
+
+    if (getLargestChunkResult.type != ResultType::SUCCESS)
+    {
+		return getLargestChunkResult;
+    }
+    
+    if (largestChunkSize > params.chunkReadCacheSize)
+    {
+        // The cache size must be at least able to hold a single chunk
+		return Result{ ResultType::INVALID_INPUT_PARAMETER, "The cache size must at least be as large as the largest chunk" };
+    }
+
+	ResourceGroupInfo* resourceGroupResource = m_resourceGroupParameter.GetValue();
 
 	// Load the resourceGroup from the resourceGroupResource
 	std::string resourceGroupData;
@@ -129,6 +145,57 @@ Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackP
     {
 		StatusSettings innerStatusUpdate;
 		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 40, 40, "Rebuilding resources.", &innerStatusUpdate );
+
+        // Read in chunks up to cache limit
+        while (bundleStream.GetCacheSize() < params.chunkReadCacheSize)
+        {
+			if( chunkIterator != m_resourcesParameter.end() )
+			{
+				ResourceInfo* chunk = ( *chunkIterator );
+
+				// Get chunk data
+				std::string chunkData;
+
+				ResourceGetDataParams resourceGetDataParams;
+
+				resourceGetDataParams.resourceSourceSettings = params.chunkSourceSettings;
+
+				resourceGetDataParams.data = &chunkData;
+
+				Result getChunkChecksumResult = chunk->GetChecksum( resourceGetDataParams.expectedChecksum );
+
+				if( getChunkChecksumResult.type != ResultType::SUCCESS )
+				{
+					return getChunkChecksumResult;
+				}
+
+				Result getChunkDataResult = chunk->GetData( resourceGetDataParams );
+
+				if( getChunkDataResult.type != ResultType::SUCCESS )
+				{
+					return getChunkDataResult;
+				}
+
+				// Add to chunk stream
+				if( !( bundleStream << chunkData ) )
+				{
+					return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+				}
+			}
+			else
+			{
+				break;
+			}
+
+            if( chunkIterator != m_resourcesParameter.end() )
+			{
+				chunkIterator++;
+			}
+            else
+            {
+				return Result{ ResultType::UNEXPECTED_END_OF_CHUNKS };
+            }
+        }
 
 		for( ResourceInfo* resource : toBundle )
 		{
@@ -209,48 +276,6 @@ Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackP
 
             while (resourceDataStreamOut.GetFileSize() < resourceFileUncompressedSize)
             {
-                if (chunkIterator != m_resourcesParameter.end())
-                {
-                    ResourceInfo* chunk = (*chunkIterator);
-
-                    // Get chunk data
-                    std::string chunkData;
-
-                    ResourceGetDataParams resourceGetDataParams;
-
-                    resourceGetDataParams.resourceSourceSettings = params.chunkSourceSettings;
-
-                    resourceGetDataParams.data = &chunkData;
-
-                    Result getChunkChecksumResult = chunk->GetChecksum(resourceGetDataParams.expectedChecksum);
-
-                    if (getChunkChecksumResult.type != ResultType::SUCCESS)
-                    {
-                        return getChunkChecksumResult;
-                    }
-
-                    Result getChunkDataResult = chunk->GetData(resourceGetDataParams);
-
-                    if (getChunkDataResult.type != ResultType::SUCCESS)
-                    {
-                        return getChunkDataResult;
-                    }
-
-                    // Add to chunk stream
-                    if (!(bundleStream << chunkData))
-                    {
-                        return Result{ ResultType::FAIL };
-                    }
-                }
-                else
-                {
-                    if (bundleStream.GetCacheSize() == 0)
-                    {
-                        return Result{ ResultType::UNEXPECTED_END_OF_CHUNKS };
-                    }
-                }
-
-
                 std::string resourceChunkData;
 
                 file.data = &resourceChunkData;
@@ -273,9 +298,61 @@ Result BundleResourceGroup::BundleResourceGroupImpl::Unpack( const BundleUnpackP
                     return Result{ ResultType::FAILED_TO_SAVE_TO_STREAM };
                 }
 
-                if (chunkIterator != m_resourcesParameter.end())
+                //Check if to get more chunks
+				if ((chunkIterator != m_resourcesParameter.end()) && (bundleStream.GetCacheSize() < m_chunkSize.GetValue()))
                 {
-                    chunkIterator++;
+                    //Clear cache
+					bundleStream.clearCache();
+
+					while( bundleStream.GetCacheSize() < params.chunkReadCacheSize )
+					{
+						if( chunkIterator != m_resourcesParameter.end() )
+						{
+							ResourceInfo* chunk = ( *chunkIterator );
+
+							// Get chunk data
+							std::string chunkData;
+
+							ResourceGetDataParams resourceGetDataParams;
+
+							resourceGetDataParams.resourceSourceSettings = params.chunkSourceSettings;
+
+							resourceGetDataParams.data = &chunkData;
+
+							Result getChunkChecksumResult = chunk->GetChecksum( resourceGetDataParams.expectedChecksum );
+
+							if( getChunkChecksumResult.type != ResultType::SUCCESS )
+							{
+								return getChunkChecksumResult;
+							}
+
+							Result getChunkDataResult = chunk->GetData( resourceGetDataParams );
+
+							if( getChunkDataResult.type != ResultType::SUCCESS )
+							{
+								return getChunkDataResult;
+							}
+
+							// Add to chunk stream
+							if( !( bundleStream << chunkData ) )
+							{
+								return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+							}
+						}
+						else
+						{
+							break;
+						}
+
+						if( chunkIterator != m_resourcesParameter.end() )
+						{
+							chunkIterator++;
+						}
+                        else
+                        {
+							return Result{ ResultType::UNEXPECTED_END_OF_CHUNKS };
+                        }
+					}
                 }
             }
 

--- a/src/Enums.cpp
+++ b/src/Enums.cpp
@@ -164,6 +164,10 @@ bool ResultTypeToString( ResultType resultType, std::string& output )
     case ResultType::INVALID_INPUT_PARAMETER:
 		output = "An input parameter was set with an invalid value";
 		return true;
+
+    case ResultType::PATCH_SIZE_EXCEEDED:
+		output = "The patch exceeded the size specified as the maximum overall patch size";
+		return true;
 	}
 
 	output = "Error code unrecognised. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";

--- a/src/Enums.cpp
+++ b/src/Enums.cpp
@@ -160,6 +160,10 @@ bool ResultTypeToString( ResultType resultType, std::string& output )
     case ResultType::FAILED_TO_INITIALIZE_RESOURCE_FILTER:
 		output = "Failed to initialize ResourceFilter";
 		return true;
+
+    case ResultType::INVALID_INPUT_PARAMETER:
+		output = "An input parameter was set with an invalid value";
+		return true;
 	}
 
 	output = "Error code unrecognised. This is an internal library error which shouldn't be encountered. If you encounter this error contact API addministrators.";

--- a/src/PatchResourceGroup.cpp
+++ b/src/PatchResourceGroup.cpp
@@ -16,7 +16,7 @@ PatchResourceGroup::~PatchResourceGroup()
 {
 }
 
-Result PatchResourceGroup::Apply( const PatchApplyParams& params )
+Result PatchResourceGroup::Apply( PatchApplyParams& params )
 {
 	StatusSettings statusSettings;
 	statusSettings.SetCallbackSettings( params.callbackSettings );

--- a/src/PatchResourceGroupImpl.cpp
+++ b/src/PatchResourceGroupImpl.cpp
@@ -244,7 +244,7 @@ Result PatchResourceGroup::PatchResourceGroupImpl::GetTargetResourcePatches( con
 	return Result{ ResultType::SUCCESS };
 }
 
-Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams& params, StatusSettings& statusSettings )
+Result PatchResourceGroup::PatchResourceGroupImpl::Apply( PatchApplyParams& params, StatusSettings& statusSettings )
 {
 	statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 0, 10, "Applying Patch." );
 
@@ -723,6 +723,8 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 				float percentage = static_cast<float>( step * i );
 				removingFilesStatusSettings.Update( StatusProgressType::PERCENTAGE, percentage, step, toRemove.string() );
             }
+
+            params.resourcesToRemove.push_back( path );
 
 			std::error_code ec;
 			if( std::filesystem::exists( toRemove ) )

--- a/src/PatchResourceGroupImpl.cpp
+++ b/src/PatchResourceGroupImpl.cpp
@@ -332,6 +332,9 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 				return Result{ ResultType::FAILED_TO_OPEN_FILE };
 			}
 
+            // This can be skipped if the file is new and new files are skipped in params
+            bool skipChecksumCheck = false;
+
 			// Incrementally calculate checksum for temporary patch file
 			ResourceTools::Md5ChecksumStream patchedFileChecksumStream;
 
@@ -583,115 +586,125 @@ Result PatchResourceGroup::PatchResourceGroupImpl::Apply( const PatchApplyParams
 			else
 			{
 				// No Patch found, indicates this is just a new file
-				// Just replace file directly
-				auto resourceStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
-
-				ResourceGetDataStreamParams resourceGetDataParams;
-
-				resourceGetDataParams.resourceSourceSettings = params.nextBuildResourcesSourceSettings;
-
-				resourceGetDataParams.dataStream = resourceStreamIn;
-
-                resourceGetDataParams.downloadSettings = params.downloadSettings;
-
-				Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
-
-                if (resourceGetDataResult.type != ResultType::SUCCESS)
+                if (!params.skipNewFiles)
                 {
-                    return resourceGetDataResult;
+					// Just replace file directly
+					auto resourceStreamIn = std::make_shared<ResourceTools::FileDataStreamIn>( m_maxInputChunkSize.GetValue() );
+
+					ResourceGetDataStreamParams resourceGetDataParams;
+
+					resourceGetDataParams.resourceSourceSettings = params.nextBuildResourcesSourceSettings;
+
+					resourceGetDataParams.dataStream = resourceStreamIn;
+
+					resourceGetDataParams.downloadSettings = params.downloadSettings;
+
+					Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
+
+					if( resourceGetDataResult.type != ResultType::SUCCESS )
+					{
+						return resourceGetDataResult;
+					}
+
+					while( !resourceStreamIn->IsFinished() )
+					{
+						std::string resourceData;
+
+						if( !( *resourceStreamIn >> resourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+						}
+
+						if( !( temporaryResourceDataStreamOut << resourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+						}
+
+						// Add to incremental checksum calculation
+						if( !( patchedFileChecksumStream << resourceData ) )
+						{
+							return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+						}
+					}
+
+					temporaryResourceDataStreamOut.Finish();
+   
                 }
-
-                while (!resourceStreamIn->IsFinished())
+                else
                 {
-                    std::string resourceData;
-
-                    if (!(*resourceStreamIn >> resourceData))
-                    {
-                        return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                    }
-
-                    if (!(temporaryResourceDataStreamOut << resourceData))
-                    {
-                        return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
-                    }
-
-                    // Add to incremental checksum calculation
-                    if (!(patchedFileChecksumStream << resourceData))
-                    {
-                        return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-                    }
-                }
-
-                temporaryResourceDataStreamOut.Finish();
-            }
-
-
-            // Test checksum against expected
-            std::string destinationExpectedChecksum;
-
-            Result getChecksumResult = resource->GetChecksum(destinationExpectedChecksum);
-
-            if (getChecksumResult.type != ResultType::SUCCESS)
-            {
-                return getChecksumResult;
-            }
-
-            std::string patchedFileChecksum;
-
-            if (!patchedFileChecksumStream.Retrieve(patchedFileChecksum))
-            {
-                return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
-            }
-
-            if (patchedFileChecksum != destinationExpectedChecksum)
-            {
-                return Result{ ResultType::UNEXPECTED_PATCH_CHECKSUM_RESULT };
-            }
-
-
-            // Copy temp file to replace the old resource file
-
-            // Open output stream
-            ResourceTools::FileDataStreamOut resourceStreamOut;
-
-            ResourcePutDataStreamParams patchedResourceResourcePutDataStreamParams;
-
-            patchedResourceResourcePutDataStreamParams.resourceDestinationSettings = params.resourcesToPatchDestinationSettings;
-
-            patchedResourceResourcePutDataStreamParams.dataStream = &resourceStreamOut;
-
-            Result putResourceDataStreamResult = resource->PutDataStream(patchedResourceResourcePutDataStreamParams);
-
-            if (putResourceDataStreamResult.type != ResultType::SUCCESS)
-            {
-                return putResourceDataStreamResult;
-            }
-
-
-            // Open input stream
-            ResourceTools::FileDataStreamIn tempPatchedResourceIn(m_maxInputChunkSize.GetValue());
-
-            if (!tempPatchedResourceIn.StartRead(params.temporaryFilePath))
-            {
-                return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-            }
-
-            while (!tempPatchedResourceIn.IsFinished())
-            {
-                std::string data;
-
-                if (!(tempPatchedResourceIn >> data))
-                {
-                    return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
-                }
-
-                if (!(resourceStreamOut << data))
-                {
-                    return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+					skipChecksumCheck = true;
                 }
             }
 
-            resourceStreamOut.Finish();
+            if (!skipChecksumCheck)
+            {
+				// Test checksum against expected
+				std::string destinationExpectedChecksum;
+
+				Result getChecksumResult = resource->GetChecksum( destinationExpectedChecksum );
+
+				if( getChecksumResult.type != ResultType::SUCCESS )
+				{
+					return getChecksumResult;
+				}
+
+                std::string patchedFileChecksum;
+
+				if( !patchedFileChecksumStream.Retrieve( patchedFileChecksum ) )
+				{
+					return Result{ ResultType::FAILED_TO_GENERATE_CHECKSUM };
+				}
+
+				if( patchedFileChecksum != destinationExpectedChecksum )
+				{
+					return Result{ ResultType::UNEXPECTED_PATCH_CHECKSUM_RESULT };
+				}
+
+                // Copy temp file to replace the old resource file
+
+				// Open output stream
+				ResourceTools::FileDataStreamOut resourceStreamOut;
+
+				ResourcePutDataStreamParams patchedResourceResourcePutDataStreamParams;
+
+				patchedResourceResourcePutDataStreamParams.resourceDestinationSettings = params.resourcesToPatchDestinationSettings;
+
+				patchedResourceResourcePutDataStreamParams.dataStream = &resourceStreamOut;
+
+				Result putResourceDataStreamResult = resource->PutDataStream( patchedResourceResourcePutDataStreamParams );
+
+				if( putResourceDataStreamResult.type != ResultType::SUCCESS )
+				{
+					return putResourceDataStreamResult;
+				}
+
+
+				// Open input stream
+				ResourceTools::FileDataStreamIn tempPatchedResourceIn( m_maxInputChunkSize.GetValue() );
+
+				if( !tempPatchedResourceIn.StartRead( params.temporaryFilePath ) )
+				{
+					return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+				}
+
+				while( !tempPatchedResourceIn.IsFinished() )
+				{
+					std::string data;
+
+					if( !( tempPatchedResourceIn >> data ) )
+					{
+						return Result{ ResultType::FAILED_TO_READ_FROM_STREAM };
+					}
+
+					if( !( resourceStreamOut << data ) )
+					{
+						return Result{ ResultType::FAILED_TO_WRITE_TO_STREAM };
+					}
+				}
+
+				resourceStreamOut.Finish();
+            }
+
         }
     }
 

--- a/src/PatchResourceGroupImpl.h
+++ b/src/PatchResourceGroupImpl.h
@@ -26,7 +26,7 @@ public:
 
 	Result SetMaxInputChunkSize( uintmax_t maxInputChunkSize );
 
-	Result Apply( const PatchApplyParams& params, StatusSettings& statusSettings );
+	Result Apply( PatchApplyParams& params, StatusSettings& statusSettings );
 
 	virtual std::string GetType() const override;
 

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -2449,7 +2449,7 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 		{
 
             // Check the current limit for overall patch size has not been exceeded
-			if( totalSizeOfPatch > params.maxTotalPatchSize )
+			if( ( params.maxTotalPatchSize > 0 ) && ( totalSizeOfPatch > params.maxTotalPatchSize ) )
 			{
 				return Result{ ResultType::PATCH_SIZE_EXCEEDED };
 			}
@@ -2566,7 +2566,7 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 				for( uintmax_t dataOffset = 0; dataOffset < nextUncompressedSize; dataOffset += params.maxInputFileChunkSize )
 				{
                     // Check the current limit for overall patch size has not been exceeded
-                    if (totalSizeOfPatch > params.maxTotalPatchSize)
+					if( ( params.maxTotalPatchSize > 0 ) && ( totalSizeOfPatch > params.maxTotalPatchSize ) )
                     {
 						return Result{ ResultType::PATCH_SIZE_EXCEEDED };
                     }
@@ -2757,7 +2757,7 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
                 // New file  
                 totalSizeOfPatch += nextUncompressedSize;
 
-				if( totalSizeOfPatch > params.maxTotalPatchSize )
+				if( ( params.maxTotalPatchSize > 0 ) && ( totalSizeOfPatch > params.maxTotalPatchSize ) )
 				{
 					return Result{ ResultType::PATCH_SIZE_EXCEEDED };
 				}

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -1887,6 +1887,23 @@ struct ProcessChunkPoolArguments
 
     Result status = Result{ ResultType::SUCCESS };
 
+    std::mutex returnStatusMutex;
+
+    void SetReturnStatus( ResultType type, const char* info = nullptr )
+    {
+		{
+			std::unique_lock<std::mutex> lock( returnStatusMutex );
+
+			status.type = type;
+
+            if (info)
+			{
+				status.info = info;
+            }
+				
+		}
+    }
+
     void RunStatusUpdate()
 	{
 		if( statusSettings.RequiresStatusUpdates() )
@@ -1924,7 +1941,11 @@ struct ProcessChunkThreadArguments
 void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArguments, std::shared_ptr<ProcessChunkThreadArguments> threadArguments )
 {
 	// Create resource from Patch Data
-	BundleResourceInfo* chunkResource = new BundleResourceInfo( { threadArguments->chunkRelativePath } );
+	BundleResourceInfoParams bundleResourceInfoParams;
+
+	bundleResourceInfoParams.relativePath = threadArguments->chunkRelativePath;
+
+	std::unique_ptr<BundleResourceInfo> chunkResource = std::make_unique<BundleResourceInfo>( bundleResourceInfoParams );
 
 	chunkResource->SetDataChecksum( threadArguments->chunkInfo.checksum );
 
@@ -1988,7 +2009,7 @@ void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArgume
 
 			if( !ResourceTools::GetLocalFileData( sourceFile, data ) )
 			{
-				commonArguments->status = Result{ ResultType::FAILED_TO_OPEN_FILE };
+				commonArguments->SetReturnStatus( ResultType::FAILED_TO_OPEN_FILE );
 				return;
 			}
 
@@ -1996,7 +2017,7 @@ void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArgume
 			std::string compressedData;
 			if( !ResourceTools::GZipCompressData( data, compressedData ) )
 			{
-				commonArguments->status = Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+				commonArguments->SetReturnStatus( ResultType::FAILED_TO_COMPRESS_DATA );
 				return;
 			}
 
@@ -2007,7 +2028,7 @@ void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArgume
 				// Save file
 				if( !ResourceTools::SaveFile( targetFile, compressedData ) )
 				{
-					commonArguments->status = Result{ ResultType::FAILED_TO_SAVE_FILE };
+					commonArguments->SetReturnStatus( ResultType::FAILED_TO_SAVE_FILE );
 					return;
 				}
 
@@ -2028,7 +2049,7 @@ void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArgume
 	}
 	catch( std::filesystem::filesystem_error& e )
 	{
-		commonArguments->status = Result{ ResultType::FAILED_TO_SAVE_FILE, e.what() };
+		commonArguments->SetReturnStatus( ResultType::FAILED_TO_SAVE_FILE, e.what() );
 		return;
 	}
 
@@ -2036,7 +2057,7 @@ void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArgume
     {
 		std::unique_lock<std::mutex> lock( commonArguments->bundleResourceGroupMutex );
 
-        commonArguments->bundleResources[threadArguments->chunkIndex] = chunkResource;
+        commonArguments->bundleResources[threadArguments->chunkIndex] = chunkResource.release();
 
         commonArguments->numberOfChunksProcessed++;
 
@@ -2044,7 +2065,6 @@ void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArgume
         commonArguments->RunStatusUpdate();
     }
 	
-	return;
 }
 
 Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams& params, StatusSettings& statusSettings ) const
@@ -2196,9 +2216,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 
 		std::vector<std::shared_ptr<ProcessChunkThreadArguments>> threadArgumentsVector;
 
-		int numThreads = params.asyncSettings.numberOfThreads + 1;
-
-		ThreadPool<std::shared_ptr<ProcessChunkPoolArguments>, std::shared_ptr<ProcessChunkThreadArguments>> threadPool( numThreads - 1 );
+		ThreadPool<std::shared_ptr<ProcessChunkPoolArguments>, std::shared_ptr<ProcessChunkThreadArguments>> threadPool( params.asyncSettings.numberOfThreads );
 
 		threadPool.Start();
 

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -1871,66 +1871,101 @@ Result ResourceGroup::ResourceGroupImpl::ExportCsv( const VersionInternal& outpu
 	return Result{ ResultType::SUCCESS };
 }
 
-Result ResourceGroup::ResourceGroupImpl::ProcessChunk( ResourceTools::GetChunk& chunkFile, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const
+struct ProcessChunkPoolArguments
+{
+    std::map<uintmax_t, BundleResourceInfo*> bundleResources;
+
+    std::mutex bundleResourceGroupMutex;
+
+    bool calculateCompressions = false;
+
+    uintmax_t totalNumberOfChunks = 0;
+
+    std::atomic<uintmax_t> numberOfChunksProcessed = 0;
+
+    StatusSettings statusSettings;
+
+    Result status = Result{ ResultType::SUCCESS };
+
+    void RunStatusUpdate()
+	{
+		if( statusSettings.RequiresStatusUpdates() )
+		{
+			
+			if( ( numberOfChunksProcessed % 20 ) == 0 )
+			{
+
+				float step = static_cast<float>( 100.0 / totalNumberOfChunks );
+				float progress = step * numberOfChunksProcessed;
+
+				std::stringstream ss;
+
+				ss << "Chunks Processed: " << std::to_string( numberOfChunksProcessed );
+
+				statusSettings.Update( StatusProgressType::PERCENTAGE, progress, step, ss.str() );
+			}
+		}
+		
+	}
+};
+
+struct ProcessChunkThreadArguments
+{
+	uintmax_t chunkIndex;
+
+	ResourceTools::ChunkInfo chunkInfo;
+	
+    std::filesystem::path chunkRelativePath;
+
+	ResourceDestinationSettings chunkDestinationSettings;
+
+};
+
+void ProcessChunkWorker( std::shared_ptr<ProcessChunkPoolArguments> commonArguments, std::shared_ptr<ProcessChunkThreadArguments> threadArguments )
 {
 	// Create resource from Patch Data
-	BundleResourceInfo* chunkResource = new BundleResourceInfo( { chunkRelativePath } );
+	BundleResourceInfo* chunkResource = new BundleResourceInfo( { threadArguments->chunkRelativePath } );
 
-	// md5 Checksum
-	ResourceTools::Md5ChecksumStream checksumStream;
-
-	std::string checksum;
-	{
-		std::string chunk;
-
-		while( *chunkFile.uncompressedChunkIn >> chunk )
-		{
-			checksumStream << chunk;
-		}
-	}
-
-	if( !checksumStream.Retrieve( checksum ) )
-	{
-		return Result( { ResultType::FAILED_TO_GENERATE_CHECKSUM } );
-	}
-
-	chunkResource->SetDataChecksum( checksum );
+	chunkResource->SetDataChecksum( threadArguments->chunkInfo.checksum );
 
 	// Compressed Size
-	chunkResource->SetCompressedSize( chunkFile.compressedChunkIn->Size() );
+
+	// Compressed data already exists on disk as part of chunking
+	// Get size from there
+	if( threadArguments->chunkInfo.compressedSize > 0 )
+	{
+		chunkResource->SetCompressedSize( threadArguments->chunkInfo.compressedSize );
+	}
 
 	// Uncompressed Size
-	chunkResource->SetUncompressedSize( chunkFile.uncompressedChunkIn->Size() );
+	chunkResource->SetUncompressedSize( threadArguments->chunkInfo.uncompressedSize );
 
 	// Export chunk file
-	std::filesystem::path sourceFile;
+	std::filesystem::path sourceFile = threadArguments->chunkInfo.path;
 
-	if( chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
+    if( !std::filesystem::exists( sourceFile.parent_path() ) )
 	{
-		sourceFile = chunkFile.compressedChunkIn->GetPath();
-	}
-	else
-	{
-		sourceFile = chunkFile.uncompressedChunkIn->GetPath();
+		commonArguments->status = Result{ ResultType::FILE_NOT_FOUND };
+		return;
 	}
 
 	std::filesystem::path targetFile;
 
-	if( chunkDestinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
+	std::string location;
+
+	if( threadArguments->chunkDestinationSettings.destinationType == ResourceDestinationType::LOCAL_RELATIVE )
 	{
 		std::filesystem::path relativePath;
 
 		chunkResource->GetRelativePath( relativePath );
 
-		targetFile = chunkDestinationSettings.basePath / relativePath;
+		targetFile = threadArguments->chunkDestinationSettings.basePath / relativePath;
 	}
 	else
 	{
-		std::string location;
-
 		chunkResource->GetLocation( location );
 
-		targetFile = chunkDestinationSettings.basePath / location;
+		targetFile = threadArguments->chunkDestinationSettings.basePath / location;
 	}
 
 	if( std::filesystem::exists( targetFile ) )
@@ -1945,24 +1980,71 @@ Result ResourceGroup::ResourceGroupImpl::ProcessChunk( ResourceTools::GetChunk& 
 
 	try
 	{
-		std::filesystem::copy_file( sourceFile, targetFile );
+		if( threadArguments->chunkInfo.compressedSize == 0 && ( commonArguments->calculateCompressions || threadArguments->chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN ) )
+        {
+			// Destination type requires compression but data is not compressed
+			// Load in data and compress
+			std::string data;
+
+			if( !ResourceTools::GetLocalFileData( sourceFile, data ) )
+			{
+				commonArguments->status = Result{ ResultType::FAILED_TO_OPEN_FILE };
+				return;
+			}
+
+			// Compress the data
+			std::string compressedData;
+			if( !ResourceTools::GZipCompressData( data, compressedData ) )
+			{
+				commonArguments->status = Result{ ResultType::FAILED_TO_COMPRESS_DATA };
+				return;
+			}
+
+			chunkResource->SetCompressedSize( compressedData.size() );
+
+            if( threadArguments->chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN )
+			{
+				// Save file
+				if( !ResourceTools::SaveFile( targetFile, compressedData ) )
+				{
+					commonArguments->status = Result{ ResultType::FAILED_TO_SAVE_FILE };
+					return;
+				}
+
+				// Delete tmp file
+				std::filesystem::remove( sourceFile );
+			}
+            else
+            {
+                // Uncompressed data but deferred calculated compression
+				std::filesystem::rename( sourceFile, targetFile );
+            }
+
+        }
+        else
+        {
+			std::filesystem::rename( sourceFile, targetFile );
+        }
 	}
 	catch( std::filesystem::filesystem_error& e )
 	{
-		return Result( { ResultType::FAILED_TO_SAVE_FILE, e.what() } );
+		commonArguments->status = Result{ ResultType::FAILED_TO_SAVE_FILE, e.what() };
+		return;
 	}
 
 	// Add the chunk resource to the bundleResourceGroup
-	Result addResourceResult = bundleResourceGroup.AddResource( chunkResource );
+    {
+		std::unique_lock<std::mutex> lock( commonArguments->bundleResourceGroupMutex );
 
-	if( addResourceResult.type != ResultType::SUCCESS )
-	{
-		delete chunkResource;
+        commonArguments->bundleResources[threadArguments->chunkIndex] = chunkResource;
 
-		return addResourceResult;
-	}
+        commonArguments->numberOfChunksProcessed++;
 
-	return Result{ ResultType::SUCCESS };
+        // This has to be inside a mutex
+        commonArguments->RunStatusUpdate();
+    }
+	
+	return;
 }
 
 Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams& params, StatusSettings& statusSettings ) const
@@ -1983,11 +2065,12 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 		return setChunkSizeResult;
 	}
 
-	ResourceTools::BundleStreamOut bundleStream( params.chunkSize, params.chunkDestinationSettings.basePath, params.chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN );
-
+    // If not splitting on compressed then it will defer compression to later,
+    // This will then calculate compression asyncronously 
+	ResourceTools::BundleStreamOut bundleStream( params.chunkSize, params.chunkDestinationSettings.basePath, params.chunkDestinationSettings.destinationType == ResourceDestinationType::REMOTE_CDN, params.splitOnCompressedSize, params.calculateCompressions );
 
 	// Update status
-	statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 5, 40, "Generating Chunks" );
+	statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 5, 10, "Generating Chunks" );
 
 	int i = 0;
 
@@ -2005,7 +2088,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 	// Loop through all resources and send data for chunking
 	{
 		StatusSettings fileProcessingDetailStatusSettings;
-		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 45, 35, "Generating Chunks", &fileProcessingDetailStatusSettings );
+		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 15, 35, "Generating Chunks", &fileProcessingDetailStatusSettings );
 
 
 		for( ResourceInfo* resource : toBundle )
@@ -2018,6 +2101,8 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 			{
 				return getLocationResult;
 			}
+
+			StatusSettings fileProcessingDetail2StatusSettings;
 
 			if( fileProcessingDetailStatusSettings.RequiresStatusUpdates() )
 			{
@@ -2046,7 +2131,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 
 				i++;
 
-				fileProcessingDetailStatusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, step, message );
+				fileProcessingDetailStatusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, step, message, &fileProcessingDetail2StatusSettings );
 			}
 			if( location.empty() )
 			{
@@ -2065,58 +2150,117 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 
 			Result resourceGetDataResult = resource->GetDataStream( resourceGetDataParams );
 
-            while( !resourceDataStream->IsFinished() )
+			while( !resourceDataStream->IsFinished() )
 			{
-                if (!bundleStream.operator<<(resourceDataStream))
-                {
+				if( fileProcessingDetailStatusSettings.RequiresStatusUpdates() )
+				{
+					size_t currentNumberOfChunks = bundleStream.GetNumberOfChunksCreated();
+
+					if( numberOfChunks < currentNumberOfChunks )
+					{
+						numberOfChunks = currentNumberOfChunks;
+						float step = static_cast<float>( 100.0 / resourceDataStream->Size() );
+						float percentComplete = static_cast<float>( step * resourceDataStream->GetCurrentPosition() );
+
+						std::string message = "Chunk Created: " + std::to_string( currentNumberOfChunks );
+
+						fileProcessingDetail2StatusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, percentComplete, step, message );
+					}
+				}
+
+				if( !bundleStream.operator<<( resourceDataStream ) )
+				{
 					return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
-                }
+				}
 			}
-
 		}
+	}   
 
-        // Finish last chunk
-		if( !bundleStream.Finish() )
-		{
-			return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
-		}
-
-		// Add to BundleResourceGroup
-
-		// Loop through possible created chunks
-		ResourceTools::GetChunk chunkFile;
-
-		chunkFile.clearCache = false;
-
-		bool bundleReadOk{ true };
-
-		while( ( bundleReadOk = bundleStream >> chunkFile ) && !chunkFile.outOfChunks )
-		{
-			std::stringstream ss;
-			ss << chunkBaseName << numberOfChunks << ".chunk";
-			std::string chunkName = ss.str();
-
-			std::filesystem::path chunkPath = params.chunkDestinationSettings.basePath / ss.str();
-
-			Result processChunkResult = ProcessChunk( chunkFile, chunkPath, bundleResourceGroup, params.chunkDestinationSettings );
-
-			if( processChunkResult.type != ResultType::SUCCESS )
-			{
-				return processChunkResult;
-			}
-
-			numberOfChunks++;
-		}
-		if( !bundleReadOk )
-		{
-			return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
-		}
+    // Finish last chunk
+	if( !bundleStream.Finish() )
+	{
+		return Result( { ResultType::FAILED_TO_READ_FROM_STREAM } );
 	}
 
+    numberOfChunks = bundleStream.GetNumberOfChunksCreated();
+
+	// Add to BundleResourceGroup
+    {
+		std::shared_ptr<ProcessChunkPoolArguments> poolArguments = std::make_shared<ProcessChunkPoolArguments>();
+
+		poolArguments->calculateCompressions = params.calculateCompressions;
+
+		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 50, 40, "Processing Chunks", &poolArguments->statusSettings );
+
+		poolArguments->totalNumberOfChunks = numberOfChunks;
+
+		std::vector<std::shared_ptr<ProcessChunkThreadArguments>> threadArgumentsVector;
+
+		int numThreads = params.asyncSettings.numberOfThreads + 1;
+
+		ThreadPool<std::shared_ptr<ProcessChunkPoolArguments>, std::shared_ptr<ProcessChunkThreadArguments>> threadPool( numThreads - 1 );
+
+		threadPool.Start();
+
+		for( int i = 0; i < numberOfChunks; i++ )
+		{
+			std::shared_ptr<ProcessChunkThreadArguments> threadArguments = std::make_shared<ProcessChunkThreadArguments>();
+
+			std::stringstream ss;
+			ss << chunkBaseName << i << ".chunk";
+			std::string chunkName = ss.str();
+			std::filesystem::path chunkPath = params.chunkDestinationSettings.basePath / ss.str();
+
+            if( !bundleStream.GetChunkInfo( i, threadArguments->chunkInfo) )
+            {
+				return Result( { ResultType::FAILED_TO_RETRIEVE_CHUNK_DATA } );
+            }
+
+            threadArguments->chunkIndex = i;
+
+			threadArguments->chunkRelativePath = chunkPath;
+
+			threadArguments->chunkDestinationSettings = params.chunkDestinationSettings;
+
+			threadArgumentsVector.push_back( std::move( threadArguments ) );
+
+			threadPool.AddTask( ProcessChunkWorker, poolArguments, threadArgumentsVector[i] );
+		}
+
+		threadPool.Join();
+
+		if( poolArguments->status.type != ResultType::SUCCESS )
+		{
+			return poolArguments->status;
+		}
+
+        // Add all the bundle chunks in the correct order to the bundle resource group
+		for( int i = 0; i < numberOfChunks; i++ )
+		{
+			auto findResource = poolArguments->bundleResources.find( i );
+
+            if (findResource == poolArguments->bundleResources.end())
+            {
+				return Result{ ResultType::UNEXPECTED_END_OF_CHUNKS };
+            }
+
+			BundleResourceInfo* bundleResourceInfo = findResource->second;
+
+			Result addResourceResult = bundleResourceGroup.AddResource( bundleResourceInfo );
+
+			if( addResourceResult.type != ResultType::SUCCESS )
+			{
+				delete bundleResourceInfo;
+
+				return addResourceResult;
+			}
+		}
+    }
+    
 	// Export this resource list
 	{
 		StatusSettings exportStatusSettings;
-		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 80, 10, "Exporting ResourceGroups", &exportStatusSettings );
+		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 90, 5, "Exporting ResourceGroups", &exportStatusSettings );
 
 		std::string resourceGroupData;
 
@@ -2163,7 +2307,7 @@ Result ResourceGroup::ResourceGroupImpl::CreateBundle( const BundleCreateParams&
 		std::string bundleResourceGroupData;
 
 		StatusSettings exportToDataStatusSettings;
-		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 90, 10, "Exporting ResourceGroups", &exportToDataStatusSettings );
+		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 95, 5, "Exporting ResourceGroups", &exportToDataStatusSettings );
 
 		Result exportBundleResourceGroupToDataResult = bundleResourceGroup.ExportToData( bundleResourceGroupData, exportToDataStatusSettings );
 
@@ -2764,6 +2908,31 @@ Result ResourceGroup::ResourceGroupImpl::RemoveResources( const ResourceGroupRem
     }
 
 	return Result{ ResultType::SUCCESS };
+}
+
+Result ResourceGroup::ResourceGroupImpl::GetLargestResourceSize(uintmax_t &largestResourceSizeOut)
+{
+    largestResourceSizeOut = 0;
+
+    for (auto iter = m_resourcesParameter.begin(); iter != m_resourcesParameter.end(); iter++)
+    {
+		uintmax_t uncompressedSize;
+
+		Result getUncompressedSizeResult = ( *iter )->GetUncompressedSize( uncompressedSize );
+
+        if (getUncompressedSizeResult.type != ResultType::SUCCESS)
+        {
+			return getUncompressedSizeResult;
+        }
+
+        if (uncompressedSize > largestResourceSizeOut)
+        {
+			largestResourceSizeOut = uncompressedSize;
+        }
+
+    }
+
+    return Result{ ResultType::SUCCESS };
 }
 
 Result ResourceGroup::ResourceGroupImpl::RemoveResource( ResourceInfo& resource )

--- a/src/ResourceGroupImpl.cpp
+++ b/src/ResourceGroupImpl.cpp
@@ -2426,7 +2426,9 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 			return subtractionResult;
 		}
 	}
-    
+
+    // Stores references to all the new files
+    ResourceGroup::ResourceGroupImpl newFilesResourceGroup;
 
 	// Ensure that the diff results have the same number of members
 	if( resourceGroupSubtractionPrevious->m_resourcesParameter.GetSize() != resourceGroupSubtractionNext->m_resourcesParameter.GetSize() )
@@ -2436,6 +2438,8 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 
 	int patchId = 0;
 
+    uintmax_t totalSizeOfPatch = 0; // Uncompressed size is used for this limit
+
 	// Update status
     {
 		StatusSettings resourceStatusSettings;
@@ -2443,6 +2447,12 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 
 		for( int i = 0; i < resourceGroupSubtractionNext->m_resourcesParameter.GetSize(); i++ )
 		{
+
+            // Check the current limit for overall patch size has not been exceeded
+			if( totalSizeOfPatch > params.maxTotalPatchSize )
+			{
+				return Result{ ResultType::PATCH_SIZE_EXCEEDED };
+			}
 
 			ResourceInfo* resourcePrevious = resourceGroupSubtractionPrevious->m_resourcesParameter.At( i );
 
@@ -2555,6 +2565,12 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 				// Process one chunk at a time
 				for( uintmax_t dataOffset = 0; dataOffset < nextUncompressedSize; dataOffset += params.maxInputFileChunkSize )
 				{
+                    // Check the current limit for overall patch size has not been exceeded
+                    if (totalSizeOfPatch > params.maxTotalPatchSize)
+                    {
+						return Result{ ResultType::PATCH_SIZE_EXCEEDED };
+                    }
+
 					std::string previousFileData = "";
 
 					if( previousFileDataStream->IsFinished() )
@@ -2719,6 +2735,8 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 
 							return putPatchDataResult;
 						}
+
+                        totalSizeOfPatch += patchData.size();
 					}
 
 					// Add the patch resource to the patchResourceGroup
@@ -2734,6 +2752,20 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 					patchId++;
 				}
 			}
+            else
+            {
+                // New file  
+                totalSizeOfPatch += nextUncompressedSize;
+
+				if( totalSizeOfPatch > params.maxTotalPatchSize )
+				{
+					return Result{ ResultType::PATCH_SIZE_EXCEEDED };
+				}
+
+				ResourceInfo* newResource = new ResourceInfo( *resourceNext );
+                    
+                newFilesResourceGroup.AddResource( newResource );
+            }
 		}
     }
 	
@@ -2787,10 +2819,11 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 		}
     }
 	
+    // Export patch resource group data
 	std::string patchResourceGroupData;
     {
 		StatusSettings exportPatchResourceGroupStatusSettings;
-		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 80, 20, "Export ResourceGroups.", &exportPatchResourceGroupStatusSettings );
+		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 80, 10, "Export ResourceGroups.", &exportPatchResourceGroupStatusSettings );
 
 
 		Result exportToDataResult = patchResourceGroup.ExportToData( patchResourceGroupData, exportPatchResourceGroupStatusSettings );
@@ -2822,6 +2855,44 @@ Result ResourceGroup::ResourceGroupImpl::CreatePatch( const PatchCreateParams& p
 			return patchResourceGroupPutResult;
 		}
     }
+
+    // Export new files resource group
+	std::string newFilesResourceGroupData;
+	{
+		StatusSettings exportNewFilesResourceGroupStatusSettings;
+		statusSettings.Update( CarbonResources::StatusProgressType::PERCENTAGE, 90, 10, "Export ResourceGroups.", &exportNewFilesResourceGroupStatusSettings );
+
+
+		Result exportToDataResult = newFilesResourceGroup.ExportToData( newFilesResourceGroupData, exportNewFilesResourceGroupStatusSettings );
+
+		if( exportToDataResult.type != ResultType::SUCCESS )
+		{
+			return exportToDataResult;
+		}
+
+		PatchResourceGroupInfo newFilesResourceGroupInfo( { params.resourceGroupNewFilesRelativePath } );
+
+		Result setNewFilesParametersFromDataResult = newFilesResourceGroupInfo.SetParametersFromData( newFilesResourceGroupData );
+
+		if( setNewFilesParametersFromDataResult.type != ResultType::SUCCESS )
+		{
+			return setNewFilesParametersFromDataResult;
+		}
+
+		ResourcePutDataParams newFilesPutDataParams;
+
+		newFilesPutDataParams.resourceDestinationSettings = params.resourceNewFilesResourceGroupDestinationSettings;
+
+		newFilesPutDataParams.data = &newFilesResourceGroupData;
+
+		Result newFilesResourceGroupPutResult = newFilesResourceGroupInfo.PutData( newFilesPutDataParams );
+
+		if( newFilesResourceGroupPutResult.type != ResultType::SUCCESS )
+		{
+			return newFilesResourceGroupPutResult;
+		}
+	}
+    
 
 	return Result{ ResultType::SUCCESS };
 }

--- a/src/ResourceGroupImpl.h
+++ b/src/ResourceGroupImpl.h
@@ -115,6 +115,8 @@ public:
 protected:
 	virtual Result CreateResourceFromYaml( YAML::Node& resource, ResourceInfo*& resourceOut );
 
+    Result GetLargestResourceSize( uintmax_t& largestResourceSizeOut );
+
 private:
 	virtual Result CreateResourceFromResource( const ResourceInfo& resourceIn, ResourceInfo*& resourceOut ) const;
 
@@ -128,8 +130,6 @@ private:
 	Result ExportYaml( const VersionInternal& outputDocumentVersion, std::string& data, StatusSettings& statusCallback ) const;
 
 	Result ExportCsv( const VersionInternal& outputDocumentVersion, std::string& data, StatusSettings& statusCallback ) const;
-
-	Result ProcessChunk( ResourceTools::GetChunk& chunkData, const std::filesystem::path& chunkRelativePath, BundleResourceGroup::BundleResourceGroupImpl& bundleResourceGroup, const ResourceDestinationSettings& chunkDestinationSettings ) const;
 
 	Result RemoveResource( ResourceInfo& relativePath );
 

--- a/tests/src/ResourceToolsLibraryTest.cpp
+++ b/tests/src/ResourceToolsLibraryTest.cpp
@@ -284,7 +284,7 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoManyChunkWithUnCompresse
 
 	std::filesystem::path testDir{ "ResourceChunking" };
 
-	ResourceTools::BundleStreamOut bundleStream( chunkSize, testDir, false );
+	ResourceTools::BundleStreamOut bundleStream( chunkSize, testDir, false, false, true );
 
 	// Add test resource1 data
 	std::string resource1Data;
@@ -351,9 +351,7 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoManyChunkWithUnCompresse
 	// Get chunks
 	int numberOfChunks = 0;
 
-	ResourceTools::GetChunk chunk;
-
-	chunk.clearCache = false;
+    ResourceTools::ChunkInfo chunkInfo;
 
 	bool bundleStreamReadOk{ true };
 
@@ -364,9 +362,14 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoManyChunkWithUnCompresse
 
 	std::filesystem::create_directories( "Chunks" );
 
-	while( ( bundleStreamReadOk = ( bundleStream >> chunk ) ) && !chunk.outOfChunks )
-	{
-		// Create Filename
+    for (int i = 0; i < bundleStream.GetNumberOfChunksCreated(); i++)
+    {
+        if (!bundleStream.GetChunkInfo(i, chunkInfo))
+        {
+			FAIL();
+        }
+
+        // Create Filename
 		std::stringstream ss;
 
 		ss << "Chunks/Chunk";
@@ -377,11 +380,11 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoManyChunkWithUnCompresse
 
 		std::string chunkPath = ss.str();
 
-		std::filesystem::copy_file( chunk.uncompressedChunkIn->GetPath(), chunkPath );
+		std::filesystem::copy_file( chunkInfo.path, chunkPath );
 
 		numberOfChunks++;
-	}
-	EXPECT_TRUE( bundleStreamReadOk );
+
+    }
 
 	// Reconsitute the files
 	ResourceTools::BundleStreamIn chunkStreamReconstitute( chunkSize );
@@ -469,7 +472,7 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoSingleChunkWithCompresse
 
 	std::filesystem::path testDir{ "ResourceChunking" };
 
-	ResourceTools::BundleStreamOut bundleStream( chunkSize, testDir, true );
+	ResourceTools::BundleStreamOut bundleStream( chunkSize, testDir, false, true, true );
 
 	// Add test resource1 data
 	std::string resource1Data;
@@ -536,9 +539,8 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoSingleChunkWithCompresse
 	// Get chunks
 	int numberOfChunks = 0;
 
-	ResourceTools::GetChunk chunk;
 
-	chunk.clearCache = false;
+    ResourceTools::ChunkInfo chunkInfo;
 
 	bool bundleStreamReadOk{ true };
 
@@ -549,9 +551,14 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoSingleChunkWithCompresse
 
     std::filesystem::create_directories( "Chunks" );
 
-	while( ( bundleStreamReadOk = ( bundleStream >> chunk ) ) && !chunk.outOfChunks )
-	{
-		// Create Filename
+    for (int i = 0; i < bundleStream.GetNumberOfChunksCreated(); i++)
+    {
+        if (!bundleStream.GetChunkInfo(i, chunkInfo))
+        {
+			FAIL();
+        }
+
+        // Create Filename
 		std::stringstream ss;
 
 		ss << "Chunks/Chunk";
@@ -562,11 +569,11 @@ TEST_F( ResourceToolsTest, ResourceChunkingManyFilesIntoSingleChunkWithCompresse
 
 		std::string chunkPath = ss.str();
 
-		std::filesystem::copy_file( chunk.uncompressedChunkIn->GetPath(), chunkPath );
+		std::filesystem::copy_file( chunkInfo.path, chunkPath );
 
 		numberOfChunks++;
-	}
-	EXPECT_TRUE( bundleStreamReadOk );
+
+    }
 
 	// Reconsitute the files
 	ResourceTools::BundleStreamIn chunkStreamReconstitute( chunkSize );

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -342,6 +342,11 @@ TEST_F( ResourcesCliTest, CreateBundle )
 	arguments.push_back( "--chunk-size" );
 	arguments.push_back( "1000" );
 
+    arguments.push_back( "--split-on-uncompressed-size" );
+
+    arguments.push_back( "--number-of-threads" );
+	arguments.push_back( "0" );
+
 
 	int res = RunCli( arguments, output );
 

--- a/tests/src/ResourcesCliTest.cpp
+++ b/tests/src/ResourcesCliTest.cpp
@@ -360,6 +360,157 @@ TEST_F( ResourcesCliTest, CreateBundle )
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "CreateBundleOut" ) );
 }
 
+TEST_F( ResourcesCliTest, CreateBundleWithThreads )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-bundle" );
+
+	arguments.push_back( "--verbosity-level" );
+	arguments.push_back( "-1" );
+
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" ).string() );
+
+	arguments.push_back( "--resource-source-path" );
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/Res" ).string() );
+
+	arguments.push_back( "--bundle-resourcegroup-relative-path" );
+	arguments.push_back( "BundleResourceGroup.yaml" );
+
+	arguments.push_back( "--bundle-resourcegroup-destination-path" );
+	arguments.push_back( "BundleOut/" );
+
+	arguments.push_back( "--bundle-resourcegroup-destination-type" );
+	arguments.push_back( "LOCAL_RELATIVE" );
+
+	arguments.push_back( "--chunk-destination-path" );
+	arguments.push_back( "CreateBundleOut" );
+
+	arguments.push_back( "--chunk-destination-type" );
+	arguments.push_back( "LOCAL_CDN" );
+
+	arguments.push_back( "--chunk-size" );
+	arguments.push_back( "1000" );
+
+	arguments.push_back( "--split-on-uncompressed-size" );
+
+	int res = RunCli( arguments, output );
+
+	EXPECT_EQ( res, 0 );
+
+	// Check expected outcome
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFile, "BundleOut/BundleResourceGroup.yaml" ) );
+
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" );
+	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "CreateBundleOut" ) );
+}
+
+TEST_F( ResourcesCliTest, CreateBundleSplitOnCompressed )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-bundle" );
+
+	arguments.push_back( "--verbosity-level" );
+	arguments.push_back( "-1" );
+
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" ).string() );
+
+	arguments.push_back( "--resource-source-path" );
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/Res" ).string() );
+
+	arguments.push_back( "--bundle-resourcegroup-relative-path" );
+	arguments.push_back( "BundleResourceGroup.yaml" );
+
+	arguments.push_back( "--bundle-resourcegroup-destination-path" );
+	arguments.push_back( "BundleOut/" );
+
+	arguments.push_back( "--bundle-resourcegroup-destination-type" );
+	arguments.push_back( "LOCAL_RELATIVE" );
+
+	arguments.push_back( "--chunk-destination-path" );
+	arguments.push_back( "CreateBundleOut" );
+
+	arguments.push_back( "--chunk-destination-type" );
+	arguments.push_back( "LOCAL_CDN" );
+
+	arguments.push_back( "--chunk-size" );
+	arguments.push_back( "1000" );
+
+	arguments.push_back( "--number-of-threads" );
+	arguments.push_back( "0" );
+
+
+	int res = RunCli( arguments, output );
+
+	EXPECT_EQ( res, 0 );
+
+	// Check expected outcome
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateBundleSplitOnCompressed/BundleResourceGroup.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFile, "BundleOut/BundleResourceGroup.yaml" ) );
+
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "CreateBundleSplitOnCompressed/CreateBundleOut" );
+	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "CreateBundleOut" ) );
+}
+
+TEST_F( ResourcesCliTest, CreateBundleSkipCompression )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-bundle" );
+
+	arguments.push_back( "--verbosity-level" );
+	arguments.push_back( "-1" );
+
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" ).string() );
+
+	arguments.push_back( "--resource-source-path" );
+	arguments.push_back( GetTestFileAbsolutePath( "Bundle/Res" ).string() );
+
+	arguments.push_back( "--bundle-resourcegroup-relative-path" );
+	arguments.push_back( "BundleResourceGroup.yaml" );
+
+	arguments.push_back( "--bundle-resourcegroup-destination-path" );
+	arguments.push_back( "BundleOut/" );
+
+	arguments.push_back( "--bundle-resourcegroup-destination-type" );
+	arguments.push_back( "LOCAL_RELATIVE" );
+
+	arguments.push_back( "--chunk-destination-path" );
+	arguments.push_back( "CreateBundleOut" );
+
+	arguments.push_back( "--chunk-destination-type" );
+	arguments.push_back( "LOCAL_CDN" );
+
+	arguments.push_back( "--chunk-size" );
+	arguments.push_back( "1000" );
+
+	arguments.push_back( "--split-on-uncompressed-size" );
+
+	arguments.push_back( "--number-of-threads" );
+	arguments.push_back( "0" );
+
+    arguments.push_back( "--skip-compression" );
+
+	int res = RunCli( arguments, output );
+
+	EXPECT_EQ( res, 0 );
+
+	// Check expected outcome
+	std::filesystem::path goldFile = GetTestFileAbsolutePath( "CreateBundle/BundleResourceGroupSkipCompression.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFile, "BundleOut/BundleResourceGroup.yaml" ) );
+
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" );
+	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "CreateBundleOut" ) );
+}
+
 TEST_F( ResourcesCliTest, RemoveResourcesWithUnknownResourceIgnoreOnResourceNotFound )
 {
 	std::string output;
@@ -674,6 +825,9 @@ TEST_F( ResourcesCliTest, CreatePatch )
 	arguments.push_back( "--patch-resourcegroup-destination-path" );
 	arguments.push_back( "PatchOut" );
 
+    arguments.push_back( "--new-files-resourcegroup-destination-base-path" );
+	arguments.push_back( "PatchOut" );
+
 	arguments.push_back( "--patch-destination-base-path" );
 	arguments.push_back( "Patchout/Patches" );
 
@@ -688,11 +842,69 @@ TEST_F( ResourcesCliTest, CreatePatch )
 	EXPECT_EQ( res, 0 );
 
 	// Check expected outcome
-	std::filesystem::path goldFile = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
-	EXPECT_TRUE( FilesMatch( goldFile, "PatchOut/PatchResourceGroup.yaml" ) );
+	std::filesystem::path goldFileResourceGroup = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFileResourceGroup, "PatchOut/PatchResourceGroup.yaml" ) );
+
+    std::filesystem::path goldFileNewFilesGroup = GetTestFileAbsolutePath( "Patch/NewFilesResourceGroup.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFileNewFilesGroup, "PatchOut/NewFilesResourceGroup.yaml" ) );
 
 	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/LocalCDNPatches" );
 	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, "PatchOut/Patches" ) );
+}
+
+TEST_F( ResourcesCliTest, CreatePatchWithMaxSizeLimit )
+{
+	std::string output;
+
+	std::vector<std::string> arguments;
+
+	arguments.push_back( "create-patch" );
+
+	arguments.push_back( "--verbosity-level" );
+	arguments.push_back( "-1" );
+
+	std::string previousResourceGroupPath = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" ).string();
+
+	arguments.push_back( previousResourceGroupPath );
+
+	std::string nextResourceGroupPath = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" ).string();
+
+	arguments.push_back( nextResourceGroupPath );
+
+	arguments.push_back( "--resource-source-type-previous" );
+	arguments.push_back( "LOCAL_RELATIVE" );
+
+	std::string nextResourcesLocation = GetTestFileAbsolutePath( "Patch/NextBuildResources" ).string();
+
+	arguments.push_back( "--resource-source-base-path-next" );
+	arguments.push_back( nextResourcesLocation );
+
+	std::string previousResourcesLocation = GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ).string();
+
+	arguments.push_back( "--resource-source-base-path-previous" );
+	arguments.push_back( previousResourcesLocation );
+
+	arguments.push_back( "--patch-resourcegroup-destination-path" );
+	arguments.push_back( "PatchOut" );
+
+	arguments.push_back( "--new-files-resourcegroup-destination-base-path" );
+	arguments.push_back( "PatchOut" );
+
+	arguments.push_back( "--patch-destination-base-path" );
+	arguments.push_back( "Patchout/Patches" );
+
+	arguments.push_back( "--patch-destination-type" );
+	arguments.push_back( "LOCAL_CDN" );
+
+	arguments.push_back( "--chunk-size" );
+	arguments.push_back( "50000000" );
+
+    arguments.push_back( "--max-overall-patch-size" );
+	arguments.push_back( "1" );
+
+	int res = RunCli( arguments, output );
+
+	EXPECT_EQ( res, 1 );
 }
 
 TEST_F( ResourcesCliTest, CreateGroup )

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -443,6 +443,7 @@ TEST_F( ResourcesLibraryTest, UnpackRemoteBundleAsLocal )
 	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = "UnpackRemoteBundleAsLocal";
 	bundleCreateParams.chunkSize = 1000000000;
 	bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
+	bundleCreateParams.asyncSettings.numberOfThreads = 0;
 
 	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 
@@ -555,6 +556,8 @@ TEST_F( ResourcesLibraryTest, CreateBundleRemoteCDN )
 
 	bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
 
+    bundleCreateParams.asyncSettings.numberOfThreads = 0;
+
 	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 
 	EXPECT_TRUE( StatusIsValid() );
@@ -600,6 +603,10 @@ TEST_F( ResourcesLibraryTest, CreateBundle )
 	bundleCreateParams.chunkSize = 1000;
 
     bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
+
+    bundleCreateParams.splitOnCompressedSize = false;
+
+    bundleCreateParams.asyncSettings.numberOfThreads = 0;
 
 	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 
@@ -647,6 +654,8 @@ TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
 	bundleCreateParams.chunkSize = 1000;
 
     bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
+
+    bundleCreateParams.asyncSettings.numberOfThreads = 0;
 
 	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
 

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -616,6 +616,158 @@ TEST_F( ResourcesLibraryTest, CreateBundle )
 	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" ) ) );
 }
 
+TEST_F( ResourcesLibraryTest, CreateBundleSpitOnCompressed )
+{
+	// Import ResourceGroup
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::ResourceGroupImportFromFileParams importParams;
+
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+
+	importParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+
+	// Create a bundle from the ResourceGroup
+	CarbonResources::BundleCreateParams bundleCreateParams;
+
+	bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+
+	bundleCreateParams.resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
+
+	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
+
+	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
+
+	bundleCreateParams.chunkDestinationSettings.basePath = "CreateBundleOut";
+
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = "resPath";
+
+	bundleCreateParams.chunkSize = 1000;
+
+	bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
+
+	bundleCreateParams.splitOnCompressedSize = true;
+
+	bundleCreateParams.asyncSettings.numberOfThreads = 0;
+
+	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroup.yaml", GetTestFileAbsolutePath( "CreateBundleSplitOnCompressed/BundleResourceGroup.yaml" ) ) );
+	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileAbsolutePath( "CreateBundleSplitOnCompressed/CreateBundleOut" ) ) );
+}
+TEST_F( ResourcesLibraryTest, CreateBundleWithThreading )
+{
+	// Import ResourceGroup
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::ResourceGroupImportFromFileParams importParams;
+
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+
+	importParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+
+	// Create a bundle from the ResourceGroup
+	CarbonResources::BundleCreateParams bundleCreateParams;
+
+	bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+
+	bundleCreateParams.resourceGroupBundleRelativePath = "BundleResourceGroup.yaml";
+
+	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
+
+	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
+
+	bundleCreateParams.chunkDestinationSettings.basePath = "CreateBundleOut";
+
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = "resPath";
+
+	bundleCreateParams.chunkSize = 1000;
+
+	bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
+
+	bundleCreateParams.splitOnCompressedSize = false;
+
+	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroup.yaml", GetTestFileAbsolutePath( "CreateBundle/BundleResourceGroup.yaml" ) ) );
+	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" ) ) );
+}
+
+TEST_F( ResourcesLibraryTest, CreateBundleSkipCompression )
+{
+	// Import ResourceGroup
+	CarbonResources::ResourceGroup resourceGroup;
+
+	CarbonResources::ResourceGroupImportFromFileParams importParams;
+
+	importParams.filename = GetTestFileAbsolutePath( "Bundle/resfileindexShort.txt" );
+
+	importParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroup.ImportFromFile( importParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+
+	// Create a bundle from the ResourceGroup
+	CarbonResources::BundleCreateParams bundleCreateParams;
+
+	bundleCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+
+	bundleCreateParams.resourceGroupBundleRelativePath = "BundleResourceGroupSkipCompression.yaml";
+
+	bundleCreateParams.resourceSourceSettings.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+
+	bundleCreateParams.resourceSourceSettings.basePaths = { GetTestFileAbsolutePath( "Bundle/Res/" ) };
+
+	bundleCreateParams.chunkDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
+
+	bundleCreateParams.chunkDestinationSettings.basePath = "CreateBundleOut";
+
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	bundleCreateParams.resourceBundleResourceGroupDestinationSettings.basePath = "resPath";
+
+	bundleCreateParams.chunkSize = 1000;
+
+	bundleCreateParams.callbackSettings.statusCallback = StatusUpdate;
+
+	bundleCreateParams.splitOnCompressedSize = false;
+
+	bundleCreateParams.asyncSettings.numberOfThreads = 0;
+
+    bundleCreateParams.calculateCompressions = false;
+
+	EXPECT_EQ( resourceGroup.CreateBundle( bundleCreateParams ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	EXPECT_TRUE( FilesMatch( "resPath/BundleResourceGroupSkipCompression.yaml", GetTestFileAbsolutePath( "CreateBundle/BundleResourceGroupSkipCompression.yaml" ) ) );
+	EXPECT_TRUE( DirectoryIsSubset( "CreateBundleOut", GetTestFileAbsolutePath( "CreateBundle/CreateBundleOut" ) ) );
+}
+
 TEST_F( ResourcesLibraryTest, CreateAndUnpackBundle )
 {
 	// Import ResourceGroup
@@ -859,6 +1011,87 @@ TEST_F( ResourcesLibraryTest, CreatePatch )
 
 	patchCreateParams.resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
 
+    patchCreateParams.resourceGroupNewFilesRelativePath = "NewFilesResourceGroup.yaml";
+
+	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+
+	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ) };
+
+	patchCreateParams.resourceSourceSettingsNext.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
+
+	patchCreateParams.resourceSourceSettingsNext.basePaths = { GetTestFileAbsolutePath( "Patch/NextBuildResources" ) };
+
+	patchCreateParams.resourcePatchBinaryDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_CDN;
+
+	patchCreateParams.resourcePatchBinaryDestinationSettings.basePath = "SharedCache";
+
+	patchCreateParams.resourcePatchResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath = "resPath";
+
+    patchCreateParams.resourceNewFilesResourceGroupDestinationSettings.destinationType = CarbonResources::ResourceDestinationType::LOCAL_RELATIVE;
+
+	patchCreateParams.resourceNewFilesResourceGroupDestinationSettings.basePath = "resPath";
+
+	patchCreateParams.patchFileRelativePathPrefix = "Patches/Patch";
+
+	patchCreateParams.previousResourceGroup = &resourceGroupPrevious;
+
+	patchCreateParams.maxInputFileChunkSize = 50000000;
+
+    patchCreateParams.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroupLatest.CreatePatch( patchCreateParams ).type, CarbonResources::ResultType::SUCCESS );
+
+    EXPECT_TRUE( StatusIsValid() );
+
+	// Check expected outcome
+	std::filesystem::path goldFileResourceGroup = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFileResourceGroup, patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath / patchCreateParams.resourceGroupPatchRelativePath ) );
+
+    std::filesystem::path goldFileNewFilesGroup = GetTestFileAbsolutePath( "Patch/NewFilesResourceGroup.yaml" );
+	EXPECT_TRUE( FilesMatch( goldFileNewFilesGroup, patchCreateParams.resourceNewFilesResourceGroupDestinationSettings.basePath / patchCreateParams.resourceGroupNewFilesRelativePath ) );
+
+	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/LocalCDNPatches" );
+	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
+}
+
+TEST_F( ResourcesLibraryTest, CreatePatchWithMaxSizeLimit )
+{
+	// Previous ResourceGroup
+	CarbonResources::ResourceGroup resourceGroupPrevious;
+
+	CarbonResources::ResourceGroupImportFromFileParams importParamsPrevious;
+
+	importParamsPrevious.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_previous.txt" );
+
+	importParamsPrevious.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroupPrevious.ImportFromFile( importParamsPrevious ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+
+	// Latest ResourceGroup
+	CarbonResources::ResourceGroup resourceGroupLatest;
+
+	CarbonResources::ResourceGroupImportFromFileParams importParamsLatest;
+
+	importParamsLatest.filename = GetTestFileAbsolutePath( "Patch/resfileindexShort_build_next.txt" );
+
+	importParamsLatest.callbackSettings.statusCallback = StatusUpdate;
+
+	EXPECT_EQ( resourceGroupLatest.ImportFromFile( importParamsLatest ).type, CarbonResources::ResultType::SUCCESS );
+
+	EXPECT_TRUE( StatusIsValid() );
+
+	// Create a patch from the subtraction index
+	CarbonResources::PatchCreateParams patchCreateParams;
+
+	patchCreateParams.resourceGroupRelativePath = "ResourceGroup.yaml";
+
+	patchCreateParams.resourceGroupPatchRelativePath = "PatchResourceGroup.yaml";
+
 	patchCreateParams.resourceSourceSettingsPrevious.sourceType = CarbonResources::ResourceSourceType::LOCAL_RELATIVE;
 
 	patchCreateParams.resourceSourceSettingsPrevious.basePaths = { GetTestFileAbsolutePath( "Patch/PreviousBuildResources" ) };
@@ -881,18 +1114,13 @@ TEST_F( ResourcesLibraryTest, CreatePatch )
 
 	patchCreateParams.maxInputFileChunkSize = 50000000;
 
-    patchCreateParams.callbackSettings.statusCallback = StatusUpdate;
+    patchCreateParams.maxTotalPatchSize = 1;
 
-	EXPECT_EQ( resourceGroupLatest.CreatePatch( patchCreateParams ).type, CarbonResources::ResultType::SUCCESS );
+	patchCreateParams.callbackSettings.statusCallback = StatusUpdate;
 
-    EXPECT_TRUE( StatusIsValid() );
+	EXPECT_EQ( resourceGroupLatest.CreatePatch( patchCreateParams ).type, CarbonResources::ResultType::PATCH_SIZE_EXCEEDED );
 
-	// Check expected outcome
-	std::filesystem::path goldFile = GetTestFileAbsolutePath( "Patch/PatchResourceGroup.yaml" );
-	EXPECT_TRUE( FilesMatch( goldFile, patchCreateParams.resourcePatchResourceGroupDestinationSettings.basePath / "PatchResourceGroup.yaml" ) );
-
-	std::filesystem::path goldDirectory = GetTestFileAbsolutePath( "Patch/LocalCDNPatches" );
-	EXPECT_TRUE( DirectoryIsSubset( goldDirectory, patchCreateParams.resourcePatchBinaryDestinationSettings.basePath ) );
+	EXPECT_TRUE( StatusIsValid() );
 }
 
 TEST_F( ResourcesLibraryTest, CreatePatchZeroInputChunkSize )

--- a/tests/src/ResourcesLibraryTest.cpp
+++ b/tests/src/ResourcesLibraryTest.cpp
@@ -747,6 +747,10 @@ TEST_F( ResourcesLibraryTest, ApplyPatch )
 
 	EXPECT_EQ( patchResourceGroup.Apply( patchApplyParams ).type, CarbonResources::ResultType::SUCCESS );
 
+    EXPECT_EQ( patchApplyParams.resourcesToRemove.size(), 1 );
+
+    EXPECT_EQ( patchApplyParams.resourcesToRemove.at( 0 ), "testresource.txt" );
+
     EXPECT_TRUE( StatusIsValid() );
 
 	// Check Expected Outcome

--- a/tests/src/ResourcesTestFixture.cpp
+++ b/tests/src/ResourcesTestFixture.cpp
@@ -14,11 +14,28 @@
 
 void ResourcesTestFixture::SetUp()
 {
-
 }
 
 void ResourcesTestFixture::TearDown()
 {
+    // Cleanup test folders
+    // This method isn't the best as it doesn't work with threaded test runs
+    // Future cleanup needed to encapsulate the test files better
+	std::stack<std::filesystem::path> directoriesToRemove;
+	for( auto entry : std::filesystem::directory_iterator( std::filesystem::current_path() ) )
+	{
+		if( entry.is_directory() )
+		{
+			directoriesToRemove.push( entry.path() );
+		}
+	}
+
+    while (directoriesToRemove.size() > 0)
+	{
+		std::filesystem::remove_all( directoriesToRemove.top() );
+		directoriesToRemove.pop();
+    }
+
 }
 
 bool ResourcesTestFixture::FileExists( const std::filesystem::path& filePath )

--- a/tests/testData/CreateBundle/BundleResourceGroupSkipCompression.yaml
+++ b/tests/testData/CreateBundle/BundleResourceGroupSkipCompression.yaml
@@ -1,0 +1,29 @@
+Version: 0.1.0
+Type: BundleGroup
+NumberOfResources: 3
+TotalResourcesSizeCompressed: 0
+TotalResourcesSizeUnCompressed: 41961
+ResourceGroupResource:
+  RelativePath: ResourceGroup.yaml
+  Type: ResourceGroup
+  Location: cc/cc00d34500ea7a31_f32613169b3491afb5d029828d269ff3
+  Checksum: f32613169b3491afb5d029828d269ff3
+  UncompressedSize: 851
+  CompressedSize: 363
+ChunkSize: 1000
+Resources:
+  - RelativePath: CreateBundleOut/ResourceGroup0.chunk
+    Type: BinaryChunk
+    Location: 24/2445432734181d30_5e631fd37d3350e30095d1251b178f2c
+    Checksum: 5e631fd37d3350e30095d1251b178f2c
+    UncompressedSize: 9117
+  - RelativePath: CreateBundleOut/ResourceGroup1.chunk
+    Type: BinaryChunk
+    Location: 03/0399f061050c7001_90d25dac9f4ed3233c5fda72bee3dfe6
+    Checksum: 90d25dac9f4ed3233c5fda72bee3dfe6
+    UncompressedSize: 32815
+  - RelativePath: CreateBundleOut/ResourceGroup2.chunk
+    Type: BinaryChunk
+    Location: 02/02c57328d92d0042_271c8036e4eae5515053e924a0a39e0f
+    Checksum: 271c8036e4eae5515053e924a0a39e0f
+    UncompressedSize: 29

--- a/tests/testData/CreateBundleSplitOnCompressed/BundleResourceGroup.yaml
+++ b/tests/testData/CreateBundleSplitOnCompressed/BundleResourceGroup.yaml
@@ -1,0 +1,20 @@
+Version: 0.1.0
+Type: BundleGroup
+NumberOfResources: 1
+TotalResourcesSizeCompressed: 8389
+TotalResourcesSizeUnCompressed: 41961
+ResourceGroupResource:
+  RelativePath: ResourceGroup.yaml
+  Type: ResourceGroup
+  Location: cc/cc00d34500ea7a31_f32613169b3491afb5d029828d269ff3
+  Checksum: f32613169b3491afb5d029828d269ff3
+  UncompressedSize: 851
+  CompressedSize: 363
+ChunkSize: 1000
+Resources:
+  - RelativePath: CreateBundleOut/ResourceGroup0.chunk
+    Type: BinaryChunk
+    Location: 24/2445432734181d30_c6ffd7f72188cbf71e665c3714b5b148
+    Checksum: c6ffd7f72188cbf71e665c3714b5b148
+    UncompressedSize: 41961
+    CompressedSize: 8389

--- a/tests/testData/CreateBundleSplitOnCompressed/CreateBundleOut/24/2445432734181d30_c6ffd7f72188cbf71e665c3714b5b148
+++ b/tests/testData/CreateBundleSplitOnCompressed/CreateBundleOut/24/2445432734181d30_c6ffd7f72188cbf71e665c3714b5b148
@@ -1,0 +1,1405 @@
+TIME
+"0"
+
+SEQUENCE
+"res:/Scene/introseq.blue"
+
+TEXTGROUP
+"4"
+
+SEGMENT
+0:0.0 - 4:48.86
+"boot"
+
+TCSAUDIO
+0:0.0 - 4:48.86
+"res:/sound/music/intro/intromusic.ogg"
+
+TRANSFORM
+# Noise speckles
+0:0.0 - 4:48.86
+"Overlay"
+
+
+
+SEGMENT
+0:0.0 - 0:18.6
+"Earth (Scene 1)"
+
+TRANSFORM
+0:0.0 - 0:22.6
+"Scene 1"
+
+AUDIO
+0:0.0 - 0:22.6
+"res:/sound/music/intro/s001.ogg"
+
+AUDIO
+0:3.69 - 0:15.31
+"res:/sound/music/intro/01_01.ogg"
+
+SUBTITLE
+# Earth
+0:3.72 - 0:0.48
+"G_EI_01_01"
+
+SUBTITLE
+# A world outgrown
+0:5.87 - 0:1.44
+"G_EI_01_02"
+
+SUBTITLE
+# scarred by war and burdened with the advance of our ancestors
+0:7.69 - 0:4.03
+"G_EI_01_03"
+
+SUBTITLE
+# compelled the first voyages across space
+0:12.69 - 0:2.49
+"G_EI_01_04"
+
+SUBTITLE
+# in a desperate quest to colonize other worlds
+0:15.19 - 0:3.14
+"G_EI_01_05"
+
+SEGMENT
+0:18.6 - 0:18.81
+"Jump gate (Scene 2)"
+
+TRANSFORM
+0:0.0 - 0:22.81
+"Scene 2"
+
+AUDIO
+0:0.0 - 0:22.81
+"res:/sound/music/intro/s002.ogg"
+
+AUDIO
+0:1.75 - 0:11.65
+"res:/sound/music/intro/02_01.ogg"
+
+SUBTITLE
+# Space.
+0:1.77 - 0:0.68
+"G_EI_02_01"
+
+SUBTITLE
+# Its timeless boundaries and infinite horizons
+0:3.84 - 0:2.9
+"G_EI_02_02"
+
+SUBTITLE
+# forged the creation of stargates
+0:7.27 - 0:2.0
+"G_EI_02_03"
+
+SUBTITLE
+# that could bridge the immense distances between the stars
+0:9.27 - 0:3.4
+"G_EI_02_04"
+
+SUBTITLE
+# Through mastery of this technology
+0:14.91 - 0:1.98
+"G_EI_03_01"
+
+SUBTITLE
+# mankind ventured deeper into the cosmos
+0:17.11 - 0:2.73
+"G_EI_03_02"
+
+AUDIO
+0:14.85 - 0:6.04
+"res:/sound/music/intro/03_01.ogg"
+
+
+
+SEGMENT
+0:37.41 - 0:21.52
+"Corp Meeting (Scene 3)"
+
+TRANSFORM
+0:0.0 - 0:25.52
+"Scene 3"
+
+AUDIO
+0:0.0 - 0:25.52
+"res:/sound/music/intro/s003.ogg"
+
+AUDIO
+0:3.21 - 0:6.38
+"res:/sound/music/intro/03_02.ogg"
+
+AUDIO
+0:11.27 - 0:8.82
+"res:/sound/music/intro/03_03.ogg"
+
+SUBTITLE
+# Ruthless corporations rose to power
+0:3.25 - 0:2.52
+"G_EI_03_03"
+
+SUBTITLE
+# seizing every world within their grasp
+0:6.27 - 0:2.37
+"G_EI_03_04"
+
+SUBTITLE
+# When the stargates could take them no further
+0:11.3 - 0:2.29
+"G_EI_03_05"
+
+SUBTITLE
+# they turned against each other
+0:13.91 - 0:1.55
+"G_EI_03_06"
+
+SUBTITLE
+# igniting conflicts that would last for centuries
+0:16.21 - 0:2.83
+"G_EI_03_07"
+
+
+
+SEGMENT
+0:58.93 - 0:32.09
+"Eve gate (Scene 4)"
+
+TRANSFORM
+0:0.0 - 0:36.09
+"Scene 4"
+
+AUDIO
+0:0.0 - 0:36.09
+"res:/sound/music/intro/s004.ogg"
+
+AUDIO
+0:0.1 - 0:9.97
+"res:/sound/music/intro/04_01.ogg"
+
+AUDIO
+0:11.68 - 0:12.38
+"res:/sound/music/intro/04_02.ogg"
+
+AUDIO
+0:24.87 - 0:9.2
+"res:/sound/music/intro/04_03.ogg"
+
+SUBTITLE
+# The battles raged until the historic discovery of a natural wormhole
+0:0.1 - 0:3.8
+"G_EI_04_01"
+
+SUBTITLE
+# A celestial womb through which civilization would be reborn
+0:5.36 - 0:3.77
+"G_EI_04_02"
+
+SUBTITLE
+# The first brave pioneers to enter this portal emerged unscathed
+0:11.68 - 0:4.23
+"G_EI_04_03"
+
+SUBTITLE
+# transported instantly across the universe
+0:17.14 - 0:2.51
+"G_EI_04_04"
+
+SUBTITLE
+# to a virgin system they called New Eden
+0:19.65 - 0:3.38
+"G_EI_04_05"
+
+SUBTITLE
+# Millions of colonists soon followed in their wake
+0:24.89 - 0:2.77
+"G_EI_04_06"
+
+SUBTITLE
+# lured by the vision of paradise
+0:28.75 - 0:1.89
+"G_EI_04_07"
+
+
+SUBTITLE
+#  through the astral gateway known as EVE
+0:30.44 - 0:3.4
+"G_EI_04_08"
+
+
+SEGMENT
+1:31.02 - 0:15.49
+"Map (Scene 5)"
+
+TRANSFORM
+0:0.0 - 0:19.49
+"Scene 5"
+
+AUDIO
+0:3.39 - 0:10.09
+"res:/sound/music/intro/05_01.ogg"
+
+AUDIO
+0:14.17 - 0:7.81
+"res:/sound/music/intro/05_02.ogg"
+
+SUBTITLE
+# Spreading outwards among the stars
+0:3.4 - 0:1.91
+"G_EI_05_01"
+
+SUBTITLE
+# they embraced EVE with the greatest of expectations
+0:5.96 - 0:2.95
+"G_EI_05_02"
+
+SUBTITLE
+# the highest of hopes and the boldest of dreams
+0:9.37 - 0:3.28
+"G_EI_05_03"
+
+SUBTITLE
+# When one day...
+0:14.19 - 0:0.89
+"G_EI_05_04"
+
+
+
+SEGMENT
+1:46.51 - 0:27.52
+"Destruction(Scene 6)"
+
+TRANSFORM
+0:0.0 - 0:31.52
+"Scene 6"
+
+AUDIO
+0:0.0 - 0:31.52
+"res:/sound/music/intro/s006.ogg"
+
+AUDIO
+0:7.6 - 0:16.17
+"res:/sound/music/intro/06_01.ogg"
+
+SUBTITLE
+# Nature conspired with fate...
+0:0.39 - 0:2.03
+"G_EI_05_05"
+
+SUBTITLE
+# to breed the cruelest nightmare of all
+0:3.36 - 0:2.11
+"G_EI_05_06"
+
+SUBTITLE
+# The wormhole leading to New Eden collapsed
+0:7.6 - 0:2.96
+"G_EI_06_01"
+
+SUBTITLE
+# severing young colonies from the home worlds which sustained them
+0:11.19 - 0:3.86
+"G_EI_06_02"
+
+SUBTITLE
+# It was the beginning of a dark age
+0:16.51 - 0:2.35
+"G_EI_06_03"
+
+SUBTITLE
+# that would erase civilization as it was known to be
+0:18.86 - 0:3.45
+"G_EI_06_04"
+
+
+
+
+SEGMENT
+2:14.03 - 0:19.9
+"Snow(Scene 7)"
+
+TRANSFORM
+0:0.0 - 0:23.9
+"Scene 7"
+
+AUDIO
+0:0.0 - 0:23.9
+"res:/sound/music/intro/s007.ogg"
+
+AUDIO
+0:1.88 - 0:9.8
+"res:/sound/music/intro/07_01.ogg"
+
+AUDIO
+0:12.15 - 0:8.11
+"res:/sound/music/intro/07_02.ogg"
+
+SUBTITLE
+# As the accumulated knowledge of millennia slowly eroded
+0:1.91 - 0:3.18
+"G_EI_07_01"
+
+SUBTITLE
+# the unfinished worlds of EVE became the graveyards of millions
+0:5.69 - 0:3.52
+"G_EI_07_02"
+
+SUBTITLE
+# On the few planets that could sustain life
+0:12.15 - 0:2.51
+"G_EI_07_03"
+
+SUBTITLE
+# the last remnants of our race struggled to adapt and survive
+0:15.07 - 0:3.66
+"G_EI_07_04"
+
+
+
+SEGMENT
+2:33.93 - 0:9.07
+"Planets(Scene 8)"
+
+TRANSFORM
+0:0.0 - 0:13.07
+"Scene 8"
+
+AUDIO
+0:2.03 - 0:7.76
+"res:/sound/music/intro/08_01.ogg"
+
+SUBTITLE
+# In time, society was reborn
+0:2.03 - 0:2.6
+"G_EI_08_01"
+
+SUBTITLE
+# and the memories of our past transformed into legend and myth
+0:4.63 - 0:4.0
+"G_EI_08_02"
+
+
+SEGMENT
+2:43.0 - 0:15.34
+"Amarr(Scene 9)"
+
+TRANSFORM
+0:0.0 - 0:19.34
+"Scene 9"
+
+AUDIO
+0:1.77 - 0:14.37
+"res:/sound/music/intro/09_01.ogg"
+
+SUBTITLE
+# The first to emerge from the darkness were the Amarr
+0:1.8 - 0:2.64
+"G_EI_09_01"
+
+SUBTITLE
+# a monotheistic race fervently committed to their faith
+0:5.58 - 0:3.08
+"G_EI_09_02"
+
+SUBTITLE
+# They reinvented space flight and soon discovered they were not alone
+0:10.44 - 0:3.8
+"G_EI_09_03"
+
+
+
+SEGMENT
+2:58.34 - 0:14.8
+"Minmatar(Scene 10)"
+
+TRANSFORM
+0:0.0 - 0:18.8
+"Scene 10"
+
+AUDIO
+0:1.0 - 0:15.23
+"res:/sound/music/intro/10_01.ogg"
+
+SUBTITLE
+# The Amarrians encountered the Minmatar race
+0:1.05 - 0:2.23
+"G_EI_10_01"
+
+SUBTITLE
+# dismissing them as primitive barbarians destined for a life of slavery
+0:3.78 - 0:3.98
+"G_EI_10_02"
+
+SUBTITLE
+# Moving quickly to subjugate them
+0:9.19 - 0:1.76
+"G_EI_10_03"
+
+SUBTITLE
+# they launched a merciless crusade against the Minmatar worlds
+0:11.29 - 0:3.02
+"G_EI_10_04"
+
+
+
+SEGMENT
+3:13.14 - 0:15.04
+"Gallente(Scene 11)"
+
+TRANSFORM
+0:0.0 - 0:19.04
+"Scene 11"
+
+AUDIO
+0:1.75 - 0:14.25
+"res:/sound/music/intro/11_01.ogg"
+
+SUBTITLE
+# At the same time, the Gallente race flourished nearby
+0:1.77 - 0:3.42
+"G_EI_11_01"
+
+SUBTITLE
+# They created the first democratic republic of the new era
+0:6.55 - 0:3.33
+"G_EI_11_02"
+
+SUBTITLE
+# and established a regional federation of independent states
+0:10.65 - 0:3.56
+"G_EI_11_03"
+
+
+
+SEGMENT
+3:28.18 - 0:12.63
+"Caldari(Scene 12)"
+
+TRANSFORM
+0:0.0 - 0:16.63
+"Scene 12"
+
+AUDIO
+0:1.01 - 0:13.66
+"res:/sound/music/intro/12_01.ogg"
+
+SUBTITLE
+# The Caldari emerged as the strongest state among them
+0:1.03 - 0:3.02
+"G_EI_12_01"
+
+SUBTITLE
+# driven by the relentless pursuit of economic and military might
+0:4.28 - 0:3.28
+"G_EI_12_02"
+
+SUBTITLE
+# Their nationalist ideals soon clashed with Gallente liberalism
+0:8.88 - 0:3.72
+"G_EI_12_03"
+
+
+
+
+SEGMENT
+3:40.81 - 0:27.41
+"Bombardment(Scene 13)"
+
+TRANSFORM
+0:0.0 - 0:31.41
+"Scene 13"
+
+AUDIO
+0:0.0 - 0:30.10
+"res:/sound/music/intro/s013.ogg"
+
+AUDIO
+0:2.04 - 0:6.86
+"res:/sound/music/intro/13_01.ogg"
+
+AUDIO
+0:10.67 - 0:5.95
+"res:/sound/music/intro/13_02.ogg"
+
+AUDIO
+0:19.91 - 0:9.57
+"res:/sound/music/intro/13_03.ogg"
+
+SUBTITLE
+# Destruction and suffering once again
+0:2.04 - 0:2.06
+"G_EI_13_01"
+
+SUBTITLE
+# became the defining essence of our civilization
+0:4.1 - 0:2.8
+"G_EI_13_02"
+
+SUBTITLE
+# Four races...
+0:10.83 - 0:0.69
+"G_EI_13_03"
+
+SUBTITLE
+# torn apart by two horrific wars
+0:12.54 - 0:2.28
+"G_EI_13_04"
+
+SUBTITLE
+# When all that remained were the smoldering ruins
+0:19.94 - 0:2.4
+"G_EI_13_05"
+
+SUBTITLE
+# of lost cities and shattered lives
+0:22.34 - 0:2.3
+"G_EI_13_06"
+
+SUBTITLE
+# a universal truce was declared to end the despair
+0:25.01 - 0:2.98
+"G_EI_13_07"
+
+
+
+
+SEGMENT
+4:8.22 - 0:11.18
+"Station(Scene 14)"
+
+TRANSFORM
+0:0.0 - 0:15.18
+"Scene 14"
+
+AUDIO
+0:3.19 - 0:10.88
+"res:/sound/music/intro/14_01.ogg"
+
+SUBTITLE
+# For more than a century the races of EVE have coexisted in relative peace
+0:3.22 - 0:3.97
+"G_EI_14_01"
+
+SUBTITLE
+# Prosperity and the pursuit of wealth govern the mission of mankind
+0:8.72 - 0:3.65
+"G_EI_14_02"
+
+
+
+
+SEGMENT
+4:19.4 - 0:29.07
+"Finale(Scene 15)"
+
+TRANSFORM
+0:0.0 - 0:29.07
+"Scene 15"
+
+AUDIO
+0:3.85 - 0:18.75
+"res:/sound/music/intro/15_01.ogg"
+
+SUBTITLE
+# We have a destiny to meet...
+0:3.85 - 0:1.43
+"G_EI_15_01"
+
+SUBTITLE
+# and the courage of our pilots will show us the path
+0:6.18 - 0:2.58
+"G_EI_15_02"
+
+SUBTITLE
+# On the strength of your wings the fate of empires
+0:10.62 - 0:2.66
+"G_EI_15_03"
+
+SUBTITLE
+and the hopes of worlds will be decided
+0:13.27 - 0:2.4
+"G_EI_15_04"
+
+SUBTITLE
+# Take control of the destiny that is rightfully yours
+0:16.75 - 0:4.394
+"G_EI_15_05"
+
+A_CHANGE_MADE_FOR_PATCHING# Format for the file is:
+# - [[vendor ID, device ID], class, comments]
+# where class is either high, medium or low; comments are ignored by the client.
+# Order or records is not important for the client, but let's keep it sorted for the sake of human beings.
+
+# High
+
+# Medium
+- [[4098, 26393], medium, AMD Radeon HD 6950]
+- [[4098, 26424], medium, AMD Radeon HD 6800 Series]
+- [[4098, 26425], medium, AMD Radeon HD 6800 Series]
+- [[4098, 26776], medium, ATI Radeon HD 5800 Series]
+- [[4098, 26777], medium, ATI Radeon HD 5800 Series]
+- [[4098, 26780], medium, ATI Radeon HD 5970 Series]
+- [[4098, 26782], medium, Radeon HD 5800 Series]
+- [[4098, 26784], medium, ATI Mobility Radeon HD 5800 Series]
+- [[4098, 26785], medium, ATI Mobility Radeon HD 5800 Series]
+- [[4098, 26808], medium, ATI Radeon HD 5700 Series]
+- [[4098, 26814], medium, ATI Radeon HD 5700 Series]
+- [[4318, 1504], medium, GeForce GTX 295]
+- [[4318, 1505], medium, NVIDIA GeForce GTX 280]
+- [[4318, 1507], medium, GeForce GTX 285]
+- [[4318, 1541], medium, NVIDIA GeForce 9800 GT]
+- [[4318, 1555], medium, NVIDIA GeForce 9800 GTX+]
+- [[4318, 1556], medium, NVIDIA GeForce 9800 GT]
+- [[4318, 1728], medium, GeForce GTX 480]
+- [[4318, 1732], medium, nVidia GTX 465]
+- [[4318, 1741], medium, Nvidia Gefore GTX 470]
+- [[4318, 3594], medium, NVIDIA GeForce GTX 680]
+- [[4318, 3618], medium, GTX 460]
+- [[4318, 4053], medium, NVIDIA GeForce GT 650M]
+- [[4318, 4056], medium, NVIDIA GeForce GT 640M]
+- [[4318, 4064], medium, NVIDIA GeForce GTX 660M]
+- [[4318, 4073], medium, NVIDIA GeForce GT 750M]
+- [[4318, 4074], medium, NVIDIA GeForce GT 755M]
+- [[4318, 4224], medium, NVIDIA GeForce GTX 580]
+- [[4318, 4225], medium, NVIDIA GeForce GTX 570]
+- [[4318, 4230], medium, NVIDIA GeForce GTX 570]
+- [[4318, 4480], medium, NVIDIA GeForce GTX 680]
+- [[4318, 4509], medium, NVIDIA GeForce GTX 775M]
+- [[4318, 4510], medium, NVIDIA GeForce GTX 780M]
+- [[4318, 4514], medium, NVIDIA GeForce GTX 675MX]
+- [[4318, 4515], medium, NVIDIA GeForce GTX 680MX]
+- [[4318, 4747], medium, NVIDIA GeForce GT 710]
+- [[4318, 7298], medium, NVIDIA GeForce GTX 1050 Ti]
+- [[32902, 3362], medium, Intel Iris Pro]
+- [[32902, 3366], medium, Intel Iris Pro]
+- [[32902, 5662], medium, Intel HD Graphics 5300]
+- [[32902, 5666], medium, Intel Iris Pro Graphics 6200]
+- [[32902, 6418], medium, Intel HD Graphics 530]
+- [[32902, 6422], medium, Intel HD Graphics 520]
+- [[32902, 6427], medium, Intel HD Graphics 530]
+- [[32902, 6430], medium, Intel HD Graphics 515]
+- [[32902, 6438], medium, Intel Iris Graphics 540]
+- [[32902, 6439], medium, Intel Iris Graphics 550]
+- [[32902, 16017], medium, Intel HD Graphics CFL]
+- [[32902, 16018], medium, Intel HD Graphics CFL]
+- [[32902, 16024], medium, Intel HD Graphics CFL]
+- [[32902, 16027], medium, Intel UHD Graphics 630]
+- [[32902, 16037], medium, Intel Iris Plus Graphics 655]
+- [[32902, 16038], medium, Intel Iris Plus Graphics 645]
+- [[32902, 22802], medium, Intel HD Graphics KBL]
+- [[32902, 22806], medium, Intel HD Graphics 620]
+- [[32902, 22811], medium, Intel HD Graphics 630]
+- [[32902, 22814], medium, Intel HD Graphics 615]
+- [[32902, 22822], medium, Intel Iris Plus Graphics 640]
+- [[32902, 22823], medium, Intel Iris Plus Graphics 650]
+- [[32902, 35409], medium, Intel Iris Plus Graphics]
+- [[32902, 35411], medium, Intel Iris Plus Graphics]
+- [[32902, 35420], medium, Intel Iris Plus Graphics]
+- [[32902, 39877], medium, Intel HD Graphics CFL]
+- [[32902, 39880], medium, Intel HD Graphics CFL]
+
+# Low
+- [[4098, 12624], low, ATI MOBILITY /ATI RADEON X600]
+- [[4098, 15952], low, ATI RADEON X600/X550 Series]
+- [[4098, 16708], low, ATI RADEON 9500]
+- [[4098, 16712], low, ATI RADEON 9800 SE]
+- [[4098, 16720], low, ATI RADEON 9600 Series]
+- [[4098, 16721], low, ATI RADEON 9600 Series]
+- [[4098, 16722], low, ATI RADEON 9600 Series]
+- [[4098, 16723], low, ATI RADEON 9550/X1050 Series]
+- [[4098, 16725], low, ATI RADEON 9600 Series]
+- [[4098, 16752], low, ATI RADEON 9600 Series Secondary]
+- [[4098, 16754], low, '']
+- [[4098, 16755], low, ATI RADEON 9550/X1050 Series Secondary]
+- [[4098, 19017], low, ATI RADEON X800 PRO]
+- [[4098, 19018], low, ATI RADEON X800 Series]
+- [[4098, 19019], low, ATI RADEON X800 XT]
+- [[4098, 19022], low, ATI MOBILITY /ATI RADEON 9800]
+- [[4098, 19024], low, ATI RADEON X800 XT Platinum Edition]
+- [[4098, 19028], low, ATI RADEON X800 VE]
+- [[4098, 19049], low, ATI RADEON X800 PRO Secondary]
+- [[4098, 19273], low, ATI RADEON X850 XT]
+- [[4098, 19275], low, ATI RADEON X850 PRO]
+- [[4098, 19276], low, ATI RADEON X850 XT Platinum Edition]
+- [[4098, 19307], low, '']
+- [[4098, 20036], low, ATI RADEON 9700 PRO]
+- [[4098, 20037], low, ATI RADEON 9500 PRO / 9700]
+- [[4098, 20038], low, ATI RADEON 9600 TX]
+- [[4098, 20039], low, ATI FireGL X1]
+- [[4098, 20040], low, ATI RADEON 9800 PRO]
+- [[4098, 20041], low, ATI RADEON 9800]
+- [[4098, 20042], low, ATI RADEON 9800 XT]
+- [[4098, 20048], low, ATI MOBILITY /ATI RADEON 9600/9700 Series]
+- [[4098, 20049], low, ATI RADEON 9600 Series]
+- [[4098, 20052], low, ATI MOBILITY FIRE GL T2/T2e]
+- [[4098, 20072], low, ATI RADEON 9800 PRO Secondary]
+- [[4098, 20812], low, Radeon 8500 / 8500LE]
+- [[4098, 21600], low, ATI MOBILITY /ATI RADEON X300]
+- [[4098, 21602], low, ATI MOBILITY /ATI RADEON X600 SE]
+- [[4098, 21833], low, ATI RADEON X800 GTO]
+- [[4098, 21835], low, ATI RADEON X800 GT]
+- [[4098, 21837], low, ATI RADEON X800 CrossFire Edition]
+- [[4098, 21839], low, ATI RADEON X800 GTO]
+- [[4098, 22095], low, ATI MOBILITY /ATI RADEON X700 XL]
+- [[4098, 22098], low, ATI MOBILITY /ATI RADEON X700]
+- [[4098, 22099], low, ATI MOBILITY/ATI RADEON X700]
+- [[4098, 22103], low, ATI RADEON X550/X700 Series]
+- [[4098, 22612], low, '']
+- [[4098, 22868], low, ATI RADEON Xpress Series]
+- [[4098, 22869], low, ATI RADEON Xpress Series]
+- [[4098, 22900], low, ATI RADEON Xpress Series]
+- [[4098, 22901], low, ATI RADEON Xpress Series]
+- [[4098, 23105], low, ATI RADEON Xpress Series]
+- [[4098, 23106], low, ATI RADEON Xpress Series]
+- [[4098, 23137], low, ATI Radeon Xpress 200]
+- [[4098, 23138], low, ATI RADEON Xpress Series]
+- [[4098, 23392], low, ATI RADEON X300/X550/X1050 Series]
+- [[4098, 23394], low, ATI RADEON X600 Series]
+- [[4098, 23395], low, ATI RADEON X300/X550/X1050 Series]
+- [[4098, 23396], low, ATI FireGL V3100]
+- [[4098, 23410], low, ATI RADEON X600 Series Secondary]
+- [[4098, 23411], low, ATI RADEON X300/X550/X1050 Series Secondary]
+- [[4098, 23882], low, ATI MOBILITY /ATI RADEON X800]
+- [[4098, 23885], low, ATI RADEON X850 XT Platinum Edition]
+- [[4098, 23887], low, ATI RADEON X800 GTO]
+- [[4098, 23890], low, ATI RADEON X850 XT]
+- [[4098, 23895], low, ATI RADEON X800 XT]
+- [[4098, 24139], low, ATI RADEON X700 PRO]
+- [[4098, 24140], low, ATI RADEON X700 SE]
+- [[4098, 24141], low, ATI RADEON X700]
+- [[4098, 24143], low, ATI RADEON X700/X550 Series]
+- [[4098, 24173], low, ATI RADEON X700 Secondary]
+- [[4098, 24175], low, ATI RADEON X700/X550 Series Secondary]
+- [[4098, 26392], low, '']
+- [[4098, 26397], low, '']
+- [[4098, 26400], low, '']
+- [[4098, 26430], low, '']
+- [[4098, 26432], low, '']
+- [[4098, 26433], low, '']
+- [[4098, 26456], low, '']
+- [[4098, 26457], low, '']
+- [[4098, 26464], low, '']
+- [[4098, 26489], low, '']
+- [[4098, 26760], low, '']
+- [[4098, 26761], low, '']
+- [[4098, 26792], low, '']
+- [[4098, 26793], low, '']
+- [[4098, 26809], low, '']
+- [[4098, 26810], low, '']
+- [[4098, 26815], low, '']
+- [[4098, 26816], low, '']
+- [[4098, 26817], low, '']
+- [[4098, 26823], low, '']
+- [[4098, 26824], low, '']
+- [[4098, 26825], low, '']
+- [[4098, 26840], low, '']
+- [[4098, 26841], low, HD 5570]
+- [[4098, 26842], low, '']
+- [[4098, 26848], low, ATI Mobility Radeon HD 5470]
+- [[4098, 26849], low, '']
+- [[4098, 26852], low, '']
+- [[4098, 26865], low, '']
+- [[4098, 26873], low, ATI Radeon HD 5470]
+- [[4098, 28928], low, ATI RADEON X1800 Series]
+- [[4098, 28930], low, ATI MOBILITY /ATI RADEON X1800]
+- [[4098, 28932], low, ATI FireGL V7200]
+- [[4098, 28937], low, ATI RADEON X1800 Series]
+- [[4098, 28938], low, ATI RADEON X1800 Series]
+- [[4098, 28942], low, ATI FireGL V7300]
+- [[4098, 28960], low, '']
+- [[4098, 28964], low, '']
+- [[4098, 28969], low, ATI RADEON X1800 Series Secondary]
+- [[4098, 28992], low, ATI RADEON X1600 Series]
+- [[4098, 28994], low, ATI RADEON X1300/X1550 Series]
+- [[4098, 28995], low, ATI RADEON X1550 Series]
+- [[4098, 28997], low, ATI MOBILITY /ATI RADEON X1400]
+- [[4098, 28998], low, ATI RADEON X1300 / X1550 Series]
+- [[4098, 28999], low, ATI RADEON X1550 64-bit]
+- [[4098, 29001], low, ATI MOBILITY /ATI RADEON X1300]
+- [[4098, 29002], low, ATI MOBILITY /ATI RADEON X1300]
+- [[4098, 29010], low, ATI FireGL V3300]
+- [[4098, 29011], low, ATI FireGL V3350]
+- [[4098, 29023], low, ATI RADEON X1550 64-bit]
+- [[4098, 29026], low, ATI RADEON X1300/X1550 Series Secondary]
+- [[4098, 29030], low, ATI RADEON X1300 / X1550 Series Secondary]
+- [[4098, 29031], low, ATI RADEON X1550 64-bit Secondary]
+- [[4098, 29057], low, ATI RADEON X1600 Series]
+- [[4098, 29059], low, ATI RADEON X1300/X1550 Series]
+- [[4098, 29062], low, ATI MOBILITY /ATI RADEON X1450]
+- [[4098, 29063], low, ATI RADEON X1300/X1550 Series]
+- [[4098, 29064], low, ATI MOBILITY /ATI RADEON X2300]
+- [[4098, 29066], low, ATI MOBILITY /ATI RADEON X2300]
+- [[4098, 29067], low, ATI MOBILITY /ATI RADEON X1350]
+- [[4098, 29071], low, '']
+- [[4098, 29078], low, ATI MOBILITY /ATI RADEON X1350]
+- [[4098, 29087], low, ATI RADEON X1550 64-bit]
+- [[4098, 29091], low, ATI RADEON X1300/X1550 Series Secondary]
+- [[4098, 29095], low, ATI RADEON X1300/X1550 Series Secondary]
+- [[4098, 29120], low, ATI RADEON X1600 Series]
+- [[4098, 29121], low, ATI RADEON X1650 Series]
+- [[4098, 29122], low, ATI RADEON X1600 Series]
+- [[4098, 29123], low, ATI RADEON X1650 Series]
+- [[4098, 29124], low, ATI MOBILITY FireGL V5200]
+- [[4098, 29125], low, ATI MOBILITY /ATI RADEON X1600]
+- [[4098, 29126], low, ATI RADEON X1650 Series]
+- [[4098, 29127], low, ATI RADEON X1650 Series]
+- [[4098, 29133], low, ATI RADEON X1600 Series]
+- [[4098, 29134], low, ATI RADEON X1600 Pro / ATI RADEON X1300 XT]
+- [[4098, 29138], low, ATI FireGL V3400]
+- [[4098, 29140], low, ATI MOBILITY FireGL V5250]
+- [[4098, 29141], low, ATI MOBILITY /ATI RADEON X1700]
+- [[4098, 29146], low, ATI FireGL V5200]
+- [[4098, 29150], low, ATI MOBILITY /ATI RADEON X1700]
+- [[4098, 29152], low, ATI RADEON X1600 Series Secondary]
+- [[4098, 29153], low, ATI RADEON X1650 Series Secondary]
+- [[4098, 29154], low, ATI RADEON X1600 Series Secondary]
+- [[4098, 29159], low, ATI RADEON X1650 Series Secondary]
+- [[4098, 29165], low, '']
+- [[4098, 29178], low, ATI FireGL V5200 Secondary]
+- [[4098, 29200], low, ATI MOBILITY /ATI RADEON HD 2300]
+- [[4098, 29201], low, ATI MOBILITY /ATI RADEON HD 2300]
+- [[4098, 29248], low, ATI RADEON X1950 Series]
+- [[4098, 29252], low, ATI RADEON X1950 Series]
+- [[4098, 29256], low, ATI RADEON X1900 Series]
+- [[4098, 29257], low, ATI RADEON X1900 Series]
+- [[4098, 29259], low, ATI RADEON X1900 Series]
+- [[4098, 29280], low, ATI RADEON X1950 Series Secondary]
+- [[4098, 29284], low, ATI RADEON X1950 Series Secondary]
+- [[4098, 29289], low, ATI RADEON X1900 Series Secondary]
+- [[4098, 29291], low, ATI RADEON X1900 Series Secondary]
+- [[4098, 29312], low, ATI RADEON X1950 Series]
+- [[4098, 29316], low, ATI MOBILITY /ATI RADEON X1900]
+- [[4098, 29320], low, ATI RADEON X1950 GT]
+- [[4098, 29329], low, ATI RADEON X1650 Series]
+- [[4098, 29344], low, ATI RADEON X1950 Series Secondary]
+- [[4098, 29352], low, ATI RADEON X1950 GT Secondary]
+- [[4098, 29361], low, ATI RADEON X1650 Series Secondary]
+- [[4098, 31006], low, ATI RADEON X1200 Series]
+- [[4098, 31007], low, ATI Mobility Radeon x1100]
+- [[4098, 31041], low, ATI RADEON Xpress 1200 Series]
+- [[4098, 31042], low, ATI RADEON Xpress 1200 Series]
+- [[4098, 31086], low, ATI RADEON 2100]
+- [[4098, 37888], low, ATI Radeon HD 2900 XT]
+- [[4098, 37891], low, ATI RADEON HD 2900 PRO]
+- [[4098, 37893], low, ATI RADEON HD 2900 GT]
+- [[4098, 37952], low, ATI Radeon HD 4870]
+- [[4098, 37953], low, ATI Radeon HD 4870 X2]
+- [[4098, 37954], low, ATI Radeon HD 4800 Series]
+- [[4098, 37955], low, ATI Radeon HD 4850 X2]
+- [[4098, 37956], low, ATI FirePro V8750 (FireGL)]
+- [[4098, 37962], low, ATI Mobility Radeon HD 4850]
+- [[4098, 37964], low, ATI Radeon HD 4800 Series]
+- [[4098, 37966], low, ATI Radeon HD 4700 Series]
+- [[4098, 37974], low, ATI FirePro V8700 (FireGL)]
+- [[4098, 37978], low, ATI Mobility Radeon HD 4870]
+- [[4098, 37984], low, ATI Radeon HD 4800 Series]
+- [[4098, 37986], low, ATI Mobility Radeon HD 5650]
+- [[4098, 38016], low, ATI Mobility Radeon HD 4650]
+- [[4098, 38024], low, ATI Mobility Radeon HD 4670]
+- [[4098, 38032], low, ATI Radeon HD 4600 Series]
+- [[4098, 38037], low, ATI RADEON HD4650]
+- [[4098, 38040], low, ATI Radeon HD 4650]
+- [[4098, 38044], low, '']
+- [[4098, 38046], low, ATI FirePro V5700 (FireGL)]
+- [[4098, 38047], low, ATI FirePro V3750 (FireGL)]
+- [[4098, 38048], low, ATI Mobility Radeon HD 4830]
+- [[4098, 38051], low, ATI FirePro M7740]
+- [[4098, 38067], low, ATI Radeon HD 4770]
+- [[4098, 38081], low, ATI Radeon HD 2400 XT]
+- [[4098, 38083], low, ATI Radeon HD 2400 PRO]
+- [[4098, 38084], low, ATI Radeon HD 2400 PRO AGP]
+- [[4098, 38087], low, ATI RADEON HD 2350]
+- [[4098, 38088], low, ATI MOBILITY /ATI RADEON HD 2400 XT]
+- [[4098, 38089], low, ATI MOBILITY /ATI RADEON HD 2400]
+- [[4098, 38092], low, ATI RADEON HD 2400]
+- [[4098, 38144], low, '']
+- [[4098, 38145], low, ATI Radeon HD 3870]
+- [[4098, 38148], low, ATI MOBILITY /ATI RADEON HD 3850]
+- [[4098, 38149], low, ATI RADEON HD 3850]
+- [[4098, 38152], low, ATI MOBILITY /ATI RADEON HD 3870]
+- [[4098, 38153], low, ATI MOBILITY /ATI RADEON HD 3870 X2]
+- [[4098, 38159], low, ATI RADEON HD 3870 X2]
+- [[4098, 38163], low, ATI Radeon HD 3850 X2]
+- [[4098, 38165], low, ATI Radeon HD 3850 AGP]
+- [[4098, 38208], low, ATI Radeon HD 4550]
+- [[4098, 38223], low, ATI Radeon HD 4350]
+- [[4098, 38226], low, ATI Mobility Radeon HD 4330 Series]
+- [[4098, 38227], low, ATI Mobility Radeon HD 4570 Series]
+- [[4098, 38229], low, ATI Mobility Radeon HD 4500 Series]
+- [[4098, 38272], low, '']
+- [[4098, 38273], low, ATI Mobility Radeon HD 2600]
+- [[4098, 38275], low, ATI MOBILITY /ATI RADEON HD 2600 XT]
+- [[4098, 38278], low, ATI RADEON HD 2600 XT AGP]
+- [[4098, 38279], low, ATI Radeon HD 2600 Pro AGP]
+- [[4098, 38280], low, ATI Radeon HD 2600 XT]
+- [[4098, 38281], low, ATI Radeon HD 2600 Pro]
+- [[4098, 38284], low, ATI FireGL V5600]
+- [[4098, 38285], low, ATI FireGL V3600]
+- [[4098, 38289], low, ATI Mobility Radeon HD 3650]
+- [[4098, 38291], low, ATI Mobility Radeon HD 3670]
+- [[4098, 38294], low, ATI RADEON HD 3600 Series]
+- [[4098, 38295], low, ATI RADEON HD 3600 Series]
+- [[4098, 38296], low, ATI Radeon HD 3600 Series]
+- [[4098, 38297], low, ATI RADEON HD 3600 Series]
+- [[4098, 38336], low, ATI RADEON HD 3470]
+- [[4098, 38338], low, ATI MOBILITY /ATI RADEON HD 3430]
+- [[4098, 38340], low, ATI Mobility Radeon HD 3450]
+- [[4098, 38341], low, ATI Radeon HD 3450]
+- [[4098, 38342], low, ATI Radeon HD 3450]
+- [[4098, 38348], low, ATI FirePRO V3700]
+- [[4098, 38351], low, ATI FireMV 2260]
+- [[4098, 38416], low, ATI Radeon HD 3200 Graphics]
+- [[4098, 38417], low, ATI RADEON 3100 Graphics]
+- [[4098, 38418], low, ATI RADEON HD 3200 Graphics]
+- [[4098, 38419], low, ATI RADEON 3100 Graphics]
+- [[4098, 38420], low, ATI RADEON HD 3300 Graphics]
+- [[4098, 38422], low, AMD 760G]
+- [[4098, 38432], low, '']
+- [[4098, 38672], low, ATI Radeon HD 4200]
+- [[4098, 38674], low, ATI Mobility Radeon HD 4290]
+- [[4098, 38675], low, ATI Mobility Radeon 4100]
+- [[4098, 38676], low, '']
+- [[4098, 38677], low, '']
+- [[4098, 38914], low, '']
+- [[4098, 38915], low, '']
+- [[4098, 38916], low, '']
+- [[4139, 1344], low, '']
+- [[4153, 25381], low, '']
+- [[4153, 25425], low, SiS IGP Graphics family SIS66x/SIS76x & SIS67x]
+- [[4318, 64], low, NVIDIA GeForce 6800 Ultra]
+- [[4318, 65], low, NVIDIA GeForce 6800]
+- [[4318, 66], low, NVIDIA GeForce 6800 LE]
+- [[4318, 68], low, NVIDIA GeForce 6800 XT]
+- [[4318, 69], low, NVIDIA GeForce 6800 GT]
+- [[4318, 71], low, NVIDIA GeForce 6800 GS]
+- [[4318, 72], low, NVIDIA GeForce 6800 XT]
+- [[4318, 144], low, NVIDIA GeForce 7800 GTX]
+- [[4318, 145], low, NVIDIA GeForce 7800 GTX]
+- [[4318, 146], low, NVIDIA GeForce 7800 GT]
+- [[4318, 152], low, NVIDIA GeForce Go 7800]
+- [[4318, 153], low, NVIDIA GeForce Go 7800 GTX]
+- [[4318, 157], low, NVIDIA Quadro FX 4500]
+- [[4318, 192], low, NVIDIA GeForce 6800 GS]
+- [[4318, 193], low, NVIDIA GeForce 6800]
+- [[4318, 194], low, NVIDIA GeForce 6800 LE]
+- [[4318, 195], low, NVIDIA GeForce 6800 XT]
+- [[4318, 200], low, NVIDIA GeForce Go 6800]
+- [[4318, 201], low, NVIDIA GeForce Go 6800 Ultra]
+- [[4318, 204], low, NVIDIA Quadro FX Go 1400]
+- [[4318, 205], low, NVIDIA Quadro FX 3450/4000 SDI]
+- [[4318, 206], low, NVIDIA Quadro FX 1400]
+- [[4318, 241], low, NVIDIA GeForce 6600 GT]
+- [[4318, 242], low, NVIDIA GeForce 6600]
+- [[4318, 243], low, NVIDIA GeForce 6200]
+- [[4318, 244], low, NVIDIA GeForce 6600 LE]
+- [[4318, 245], low, NVIDIA GeForce 7800 GS]
+- [[4318, 246], low, NVIDIA GeForce 6800 GS/XT]
+- [[4318, 248], low, NVIDIA Quadro FX 3400/4400]
+- [[4318, 249], low, NVIDIA GeForce 6800 Series GPU]
+- [[4318, 250], low, NVIDIA GeForce PCX 5750]
+- [[4318, 251], low, NVIDIA GeForce PCX 5900]
+- [[4318, 253], low, NVIDIA Quadro PCI-E Series]
+- [[4318, 254], low, NVIDIA Quadro FX 1300]
+- [[4318, 256], low, NVIDIA GeForce 256]
+- [[4318, 320], low, NVIDIA GeForce 6600 GT]
+- [[4318, 321], low, nVIDIA GeForce 6600 PCI-E Video Adapter]
+- [[4318, 322], low, NVIDIA GeForce 6600 LE]
+- [[4318, 324], low, NVIDIA GeForce Go 6600]
+- [[4318, 325], low, NVIDIA GeForce 6610 XL]
+- [[4318, 326], low, NVIDIA GeForce Go 6200 TE/6600 TE]
+- [[4318, 327], low, NVIDIA GeForce 6700 XL]
+- [[4318, 328], low, NVIDIA GeForce Go 6600]
+- [[4318, 333], low, NVIDIA Quadro FX 550]
+- [[4318, 334], low, NVIDIA Quadro FX 540]
+- [[4318, 335], low, NVIDIA GeForce 6200]
+- [[4318, 352], low, NVIDIA GeForce 6500]
+- [[4318, 353], low, GeForce 6200 TurboCache]
+- [[4318, 354], low, NVIDIA GeForce 6200SE TurboCache(TM)]
+- [[4318, 355], low, NVIDIA GeForce 6200 LE]
+- [[4318, 357], low, NVIDIA Quadro NVS 285]
+- [[4318, 359], low, NVIDIA GeForce Go 6200]
+- [[4318, 360], low, NVIDIA GeForce Go 6400]
+- [[4318, 362], low, NVIDIA GeForce 7100 GS]
+- [[4318, 401], low, NVIDIA GeForce 8800 GTX]
+- [[4318, 403], low, NVIDIA GeForce 8800 GTS]
+- [[4318, 404], low, NVIDIA GeForce 8800 Ultra]
+- [[4318, 413], low, NVIDIA Quadro FX 5600]
+- [[4318, 414], low, NVIDIA Quadro FX 4600]
+- [[4318, 464], low, NVIDIA GeForce 7350 LE]
+- [[4318, 465], low, NVIDIA GeForce 7300 LE]
+- [[4318, 467], low, NVIDIA GeForce 7300 SE/7200 GS]
+- [[4318, 470], low, '']
+- [[4318, 471], low, NVIDIA GeForce Go 7300]
+- [[4318, 472], low, NVIDIA GeForce Go 7400]
+- [[4318, 474], low, '']
+- [[4318, 476], low, NVIDIA Quadro FX 350M]
+- [[4318, 477], low, NVIDIA GeForce 7500 LE]
+- [[4318, 479], low, NVIDIA GeForce 7300 GS]
+- [[4318, 529], low, '']
+- [[4318, 533], low, NVIDIA GeForce 6800 GT]
+- [[4318, 545], low, NVIDIA GeForce 6200]
+- [[4318, 546], low, NVIDIA GeForce 6200 A-LE]
+- [[4318, 576], low, NVIDIA GeForce 6150]
+- [[4318, 577], low, NVIDIA GeForce 6150 LE]
+- [[4318, 578], low, NVIDIA GeForce 6100]
+- [[4318, 580], low, Geforce Go 6150]
+- [[4318, 581], low, NVIDIA Quadro NVS 210S / NVIDIA GeForce 6150LE]
+- [[4318, 583], low, Geforce 6100 Go]
+- [[4318, 595], low, NVIDIA GeForce4 Ti 4200]
+- [[4318, 656], low, NVIDIA GeForce 7900 GTX]
+- [[4318, 657], low, NVIDIA GeForce 7900 GT/GTO]
+- [[4318, 658], low, NVIDIA GeForce 7900 GS]
+- [[4318, 659], low, NVIDIA GeForce 7950 GX2]
+- [[4318, 660], low, NVIDIA GeForce 7950 GX2]
+- [[4318, 661], low, NVIDIA GeForce 7950 GT]
+- [[4318, 663], low, NVIDIA GeForce Go 7950 GTX]
+- [[4318, 664], low, NVIDIA GeForce Go 7900 GS]
+- [[4318, 665], low, NVIDIA GeForce Go 7900 GTX]
+- [[4318, 666], low, '']
+- [[4318, 667], low, '']
+- [[4318, 668], low, NVIDIA Quadro FX 5500]
+- [[4318, 669], low, NVIDIA Quadro FX 3500]
+- [[4318, 670], low, NVIDIA Quadro FX 1500]
+- [[4318, 736], low, NVIDIA GeForce 7600 GT]
+- [[4318, 737], low, NVIDIA GeForce 7600 GS]
+- [[4318, 738], low, NVIDIA GeForce 7300 GT]
+- [[4318, 739], low, NVIDIA GeForce 7900 GS]
+- [[4318, 740], low, NVIDIA GeForce 7950 GT]
+- [[4318, 770], low, NVIDIA GeForce FX 5800]
+- [[4318, 785], low, NVIDIA GeForce FX 5600 Ultra]
+- [[4318, 786], low, NVIDIA GeForce FX 5600]
+- [[4318, 788], low, NVIDIA GeForce FX 5600XT]
+- [[4318, 794], low, NVIDIA GeForce FX Go 5600]
+- [[4318, 800], low, NVIDIA GeForce FX 5200]
+- [[4318, 801], low, NVIDIA GeForce FX 5200 Ultra]
+- [[4318, 802], low, NVIDIA GeForce FX 5200]
+- [[4318, 804], low, NVIDIA GeForce FX Go 5200]
+- [[4318, 806], low, NVIDIA GeForce FX 5500]
+- [[4318, 811], low, NVIDIA Quadro FX 500/FX 600]
+- [[4318, 816], low, NVIDIA GeForce FX 5900 Ultra]
+- [[4318, 817], low, NVIDIA GeForce FX 5900]
+- [[4318, 818], low, NVIDIA GeForce FX 5900XT]
+- [[4318, 819], low, NVIDIA GeForce FX 5950 Ultra]
+- [[4318, 824], low, NVIDIA Quadro FX 3000]
+- [[4318, 833], low, NVIDIA GeForce FX 5700 Ultra]
+- [[4318, 834], low, NVIDIA GeForce FX 5700]
+- [[4318, 835], low, NVIDIA GeForce FX 5700LE]
+- [[4318, 836], low, NVIDIA GeForce FX 5700VE]
+- [[4318, 840], low, NVIDIA GeForce FX Go 5700]
+- [[4318, 912], low, NVIDIA GeForce 7650 GS]
+- [[4318, 913], low, NVIDIA GeForce 7600 GT]
+- [[4318, 914], low, NVIDIA GeForce 7600 GS]
+- [[4318, 915], low, NVIDIA GeForce 7300 GT]
+- [[4318, 916], low, NVIDIA GeForce 7600 LE]
+- [[4318, 917], low, NVIDIA GeForce 7300 GT]
+- [[4318, 918], low, '']
+- [[4318, 919], low, '']
+- [[4318, 920], low, NVIDIA GeForce Go 7600]
+- [[4318, 921], low, '']
+- [[4318, 926], low, NVIDIA Quadro FX 560]
+- [[4318, 976], low, NVIDIA GeForce 6150SE nForce 430]
+- [[4318, 977], low, NVIDIA GeForce 6100 nForce 405]
+- [[4318, 978], low, NVIDIA GeForce 6100 nForce 400]
+- [[4318, 981], low, NVIDIA GeForce 6100 nForce 420]
+- [[4318, 982], low, '']
+- [[4318, 1024], low, NVIDIA GeForce 8600 GTS]
+- [[4318, 1025], low, NVIDIA GeForce 8600 GT]
+- [[4318, 1026], low, NVIDIA GeForce 8600 GT]
+- [[4318, 1027], low, NVIDIA GeForce 8600GS]
+- [[4318, 1028], low, NVIDIA GeForce 8400 GS]
+- [[4318, 1029], low, GeForce 9500m GS]
+- [[4318, 1031], low, NVIDIA GeForce 8600M GT]
+- [[4318, 1032], low, '']
+- [[4318, 1033], low, '']
+- [[4318, 1034], low, NVIDIA Quadro FX 370]
+- [[4318, 1035], low, '']
+- [[4318, 1036], low, Mobile Quadro FX/NVS video card]
+- [[4318, 1037], low, '']
+- [[4318, 1038], low, NVIDIA Quadro FX 570]
+- [[4318, 1039], low, NVIDIA Quadro FX 1700]
+- [[4318, 1040], low, '']
+- [[4318, 1056], low, NVIDIA GeForce 8400 SE]
+- [[4318, 1057], low, NVIDIA GeForce 8500 GT]
+- [[4318, 1058], low, NVIDIA GeForce 8400 GS]
+- [[4318, 1059], low, NVIDIA GeForce 8300 GS]
+- [[4318, 1060], low, NVIDIA GeForce 8400 GS]
+- [[4318, 1061], low, NVIDIA 8600m GS]
+- [[4318, 1062], low, Geforce 8400M GT GPU]
+- [[4318, 1063], low, Geforce 8400M GS]
+- [[4318, 1064], low, NVIDIA GeForce 8400M G]
+- [[4318, 1065], low, nVidia Quadro NVS 135M or Quadro NVS 140M]
+- [[4318, 1066], low, '']
+- [[4318, 1067], low, NVIDIA Quadro NVS 135M]
+- [[4318, 1068], low, NVIDIA GeForce 9400 GT]
+- [[4318, 1069], low, Quadro FX 360 M (Mobile)]
+- [[4318, 1070], low, '']
+- [[4318, 1071], low, NVIDIA Quadro NVS 290]
+- [[4318, 1329], low, NVIDIA GeForce Go 7150M (UMA)]
+- [[4318, 1331], low, nVidia GeForce 7000M / nForce 610M]
+- [[4318, 1338], low, NVIDIA GeForce 7050 PV / NVIDIA nForce 630a]
+- [[4318, 1339], low, NVIDIA GeForce 7050 PV / NVIDIA nForce 630a]
+- [[4318, 1342], low, NVIDIA GeForce 7025 / NVIDIA nForce 630a]
+- [[4318, 1506], low, NVIDIA GeForce GTX 260]
+- [[4318, 1510], low, NVIDIA GeForce GT 240M]
+- [[4318, 1514], low, NVIDIA GeForce GTX 260]
+- [[4318, 1515], low, '']
+- [[4318, 1529], low, NVIDIA Quadro CX]
+- [[4318, 1533], low, NVIDIA Quadro FX 5800]
+- [[4318, 1534], low, NVIDIA Quadro FX 4800]
+- [[4318, 1535], low, '']
+- [[4318, 1536], low, NVIDIA GeForce 8800 GTS 512]
+- [[4318, 1537], low, NVIDIA GeForce 9800 GT]
+- [[4318, 1538], low, NVIDIA GeForce 8800 GT]
+- [[4318, 1539], low, '']
+- [[4318, 1540], low, NVIDIA GeForce 9800 GX2]
+- [[4318, 1542], low, NVIDIA GeForce 8800 GS]
+- [[4318, 1543], low, '']
+- [[4318, 1544], low, NVIDIA Geforce 9800M GTX]
+- [[4318, 1545], low, '']
+- [[4318, 1546], low, '']
+- [[4318, 1547], low, GeForce 9800M GT]
+- [[4318, 1548], low, '']
+- [[4318, 1551], low, '']
+- [[4318, 1552], low, NVIDIA GeForce 9600 GSO]
+- [[4318, 1553], low, NVIDIA GeForce 8800 GT]
+- [[4318, 1554], low, NVIDIA GeForce 9800 GTX/9800 GTX+]
+- [[4318, 1557], low, GeForce GTS 250]
+- [[4318, 1559], low, '']
+- [[4318, 1560], low, '']
+- [[4318, 1562], low, NVIDIA Quadro FX 3700]
+- [[4318, 1564], low, '']
+- [[4318, 1565], low, '']
+- [[4318, 1566], low, '']
+- [[4318, 1567], low, '']
+- [[4318, 1569], low, '']
+- [[4318, 1570], low, NVIDIA GeForce 9600 GT]
+- [[4318, 1571], low, NVIDIA GeForce 9600 GS]
+- [[4318, 1572], low, '']
+- [[4318, 1573], low, NVIDIA GeForce 9600 GSO 512]
+- [[4318, 1574], low, '']
+- [[4318, 1575], low, '']
+- [[4318, 1576], low, '']
+- [[4318, 1578], low, '']
+- [[4318, 1579], low, '']
+- [[4318, 1580], low, G-Force 9800M GTS]
+- [[4318, 1582], low, NVIDIA GeForce 9600 GT]
+- [[4318, 1583], low, '']
+- [[4318, 1585], low, '']
+- [[4318, 1587], low, '']
+- [[4318, 1592], low, NVIDIA Quadro FX 1800]
+- [[4318, 1594], low, '']
+- [[4318, 1600], low, NVIDIA GeForce 9500 GT]
+- [[4318, 1601], low, NVIDIA GeForce 9400 GT]
+- [[4318, 1603], low, NVIDIA GeForce 9500 GT]
+- [[4318, 1604], low, NVIDIA GeForce 9500 GS]
+- [[4318, 1605], low, NVIDIA GeForce 9500 GS]
+- [[4318, 1606], low, Geforce 9500GS]
+- [[4318, 1607], low, '']
+- [[4318, 1608], low, NVIDIA GeForce 9600M GS]
+- [[4318, 1609], low, nVidia GeForce 9600M GT]
+- [[4318, 1610], low, GeForce 9700M GT]
+- [[4318, 1611], low, '']
+- [[4318, 1612], low, '']
+- [[4318, 1614], low, '']
+- [[4318, 1617], low, '']
+- [[4318, 1618], low, Ge Force GT 130M]
+- [[4318, 1619], low, '']
+- [[4318, 1620], low, '']
+- [[4318, 1621], low, '']
+- [[4318, 1624], low, Quadro FX]
+- [[4318, 1625], low, '']
+- [[4318, 1626], low, '']
+- [[4318, 1627], low, '']
+- [[4318, 1628], low, Quadro FX 770M]
+- [[4318, 1738], low, '']
+- [[4318, 1752], low, '']
+- [[4318, 1753], low, '']
+- [[4318, 1754], low, '']
+- [[4318, 1757], low, nVidia Quadro 4000]
+- [[4318, 1760], low, NVIDIA GeForce 9300 GE]
+- [[4318, 1761], low, NVIDIA GeForce 9300 GS]
+- [[4318, 1762], low, NVIDIA GeForce 8400]
+- [[4318, 1764], low, NVIDIA GeForce 8400 GS]
+- [[4318, 1765], low, '']
+- [[4318, 1766], low, nVidia G100]
+- [[4318, 1768], low, '']
+- [[4318, 1769], low, NVIDIA GeForce 9300M GS]
+- [[4318, 1770], low, nvidia quadro nvs 150m]
+- [[4318, 1771], low, Quadro NVS 160M]
+- [[4318, 1772], low, Nvidia Corp]
+- [[4318, 1773], low, '']
+- [[4318, 1774], low, '']
+- [[4318, 1775], low, NVIDIA GeForce G 103M]
+- [[4318, 1777], low, '']
+- [[4318, 1784], low, NVIDIA Quadro NVS 420]
+- [[4318, 1785], low, NVIDIA Quadro FX 370 LP]
+- [[4318, 1786], low, NVIDIA Quadro NVS 450]
+- [[4318, 1787], low, '']
+- [[4318, 1789], low, NVidia NVS 295]
+- [[4318, 2016], low, NVIDIA GeForce 7150 / NVIDIA nForce 630i]
+- [[4318, 2017], low, NVIDIA GeForce 7100 / NVIDIA nForce 630i]
+- [[4318, 2018], low, NVIDIA GeForce 7050 / NVIDIA nForce 630i]
+- [[4318, 2019], low, NVIDIA GeForce 7050 / NVIDIA nForce 610i]
+- [[4318, 2021], low, NVIDIA GeForce 7050 / NVIDIA nForce 620i]
+- [[4318, 2116], low, '']
+- [[4318, 2117], low, '']
+- [[4318, 2119], low, '']
+- [[4318, 2120], low, NVIDIA GeForce 8300]
+- [[4318, 2121], low, NVIDIA GeForce 8200]
+- [[4318, 2123], low, NVIDIA GeForce 8200]
+- [[4318, 2124], low, NVIDIA nForce 780a SLI]
+- [[4318, 2125], low, NVIDIA nForce 750a SLI]
+- [[4318, 2127], low, NVIDIA GeForce 8100 / nForce 720a]
+- [[4318, 2144], low, NVIDIA GeForce 9300]
+- [[4318, 2145], low, NVIDIA GeForce 9400]
+- [[4318, 2146], low, '']
+- [[4318, 2147], low, NVIDIA GeForce 9400M]
+- [[4318, 2150], low, '']
+- [[4318, 2151], low, '']
+- [[4318, 2152], low, NVIDIA nForce 760i SLI]
+- [[4318, 2153], low, '']
+- [[4318, 2154], low, NVIDIA GeForce 9400]
+- [[4318, 2156], low, NVIDIA GeForce 9300 / nForce 730i]
+- [[4318, 2157], low, NVIDIA GeForce 9200]
+- [[4318, 2158], low, '']
+- [[4318, 2159], low, GeForce 8200M G]
+- [[4318, 2160], low, '']
+- [[4318, 2161], low, NVIDIA GeForce 9200]
+- [[4318, 2163], low, '']
+- [[4318, 2164], low, '']
+- [[4318, 2166], low, '']
+- [[4318, 2170], low, '']
+- [[4318, 2173], low, '']
+- [[4318, 2174], low, '']
+- [[4318, 2175], low, '']
+- [[4318, 2208], low, '']
+- [[4318, 2210], low, '']
+- [[4318, 2211], low, '']
+- [[4318, 2212], low, '']
+- [[4318, 2592], low, NVIDIA GeForce GT 220]
+- [[4318, 2594], low, GeForce 315]
+- [[4318, 2595], low, '']
+- [[4318, 2600], low, '']
+- [[4318, 2601], low, '']
+- [[4318, 2602], low, '']
+- [[4318, 2603], low, '']
+- [[4318, 2604], low, '']
+- [[4318, 2605], low, '']
+- [[4318, 2612], low, '']
+- [[4318, 2613], low, '']
+- [[4318, 2620], low, '']
+- [[4318, 2656], low, '']
+- [[4318, 2658], low, '']
+- [[4318, 2659], low, '']
+- [[4318, 2660], low, '']
+- [[4318, 2661], low, Nvidia 200 Series]
+- [[4318, 2662], low, '']
+- [[4318, 2663], low, '']
+- [[4318, 2664], low, '']
+- [[4318, 2665], low, '']
+- [[4318, 2666], low, '']
+- [[4318, 2668], low, '']
+- [[4318, 2670], low, '']
+- [[4318, 2671], low, '']
+- [[4318, 2672], low, '']
+- [[4318, 2674], low, '']
+- [[4318, 2676], low, '']
+- [[4318, 2677], low, GeForce 310M]
+- [[4318, 2678], low, '']
+- [[4318, 2680], low, '']
+- [[4318, 2682], low, '']
+- [[4318, 2684], low, '']
+- [[4318, 3232], low, '']
+- [[4318, 3234], low, '']
+- [[4318, 3235], low, GeForce GT 240]
+- [[4318, 3236], low, '']
+- [[4318, 3237], low, '']
+- [[4318, 3241], low, '']
+- [[4318, 3244], low, '']
+- [[4318, 3247], low, '']
+- [[4318, 3248], low, '']
+- [[4318, 3249], low, '']
+- [[4318, 3260], low, '']
+- [[4318, 3520], low, '']
+- [[4318, 3524], low, NVIDIA GeForce GTS 450]
+- [[4318, 3525], low, '']
+- [[4318, 3526], low, '']
+- [[4318, 3533], low, '']
+- [[4318, 3537], low, '']
+- [[4318, 3538], low, '']
+- [[4318, 3539], low, '']
+- [[4318, 3542], low, '']
+- [[4318, 3544], low, '']
+- [[4318, 3546], low, '']
+- [[4318, 3552], low, '']
+- [[4318, 3553], low, '']
+- [[4318, 3554], low, '']
+- [[4318, 3564], low, '']
+- [[4318, 3566], low, '']
+- [[4318, 3568], low, '']
+- [[4318, 3569], low, '']
+- [[4318, 3570], low, '']
+- [[4318, 3571], low, '']
+- [[4318, 3572], low, '']
+- [[4318, 3573], low, '']
+- [[4318, 3576], low, '']
+- [[4318, 3619], low, '']
+- [[4318, 3620], low, '']
+- [[4318, 3632], low, '']
+- [[4318, 3633], low, '']
+- [[4318, 4160], low, '']
+- [[4318, 4182], low, '']
+- [[4318, 4183], low, '']
+- [[4318, 4232], low, '']
+- [[4318, 4291], low, '']
+- [[4318, 4293], low, '']
+- [[4318, 4312], low, '']
+- [[4318, 4608], low, '']
+- [[4318, 4676], low, '']
+- [[4318, 4677], low, '']
+- [[4358, 12848], low, Integrated Graphics]
+- [[4358, 13169], low, VIA Chrome9 HC IGP]
+- [[5549, 1029], low, NVIDIA]
+- [[6840, 16389], low, '']
+- [[21299, 36933], low, '']
+- [[32902, 66], low, Intel Q57/H55 Clarkdale (Onboard on D2912-A1x)]
+- [[32902, 70], low, Intel Graphics Media Accelerator HD]
+- [[32902, 258], low, '']
+- [[32902, 274], low, '']
+- [[32902, 278], low, '']
+- [[32902, 290], low, '']
+- [[32902, 294], low, '']
+- [[32902, 338], low, Intel HD Graphics 4000]
+- [[32902, 354], low, Intel HD Graphics 4000]
+- [[32902, 358], low, Intel HD Graphics 4000]
+- [[32902, 1042], low, Intel Iris Pro]
+- [[32902, 2598], low, Intel HD Graphics 5000]
+- [[32902, 2606], low, Intel Iris]
+- [[32902, 5670], low, Intel HD Graphics 6000]
+- [[32902, 5675], low, Intel Iris Graphics 6100]
+- [[32902, 9586], low, Integrated Graphics Device]
+- [[32902, 9602], low, 82915g/gv/910gl Express Chipset Family]
+- [[32902, 9618], low, Graphic controller family]
+- [[32902, 10098], low, Chipset Intel 82945G Express]
+- [[32902, 10146], low, Mobile Intel(R) 945 Express Chipset Family]
+- [[32902, 10158], low, Mobile Intel(R) 945 Express Chipset Family]
+- [[32902, 10610], low, Onboard Video Device for 82946GZ chips]
+- [[32902, 10626], low, '']
+- [[32902, 10642], low, Intel(R) Express Chipset video]
+- [[32902, 10658], low, '']
+- [[32902, 10674], low, Intel(R) Q35 Express Chipset Family]
+- [[32902, 10690], low, Intel(R) G33 chipset GMA3100 video]
+- [[32902, 10706], low, '']
+- [[32902, 10754], low, "Intel GM965, Intel X3100"]
+- [[32902, 10770], low, Mobile Intel(R) 965 Express Chipset Family]
+- [[32902, 10818], low, Intel Mobile Graphic]
+- [[32902, 11794], low, '']
+- [[32902, 11810], low, '']
+- [[32902, 11826], low, Intel G41 express graphics]
+- [[32902, 2598], low, Intel HD Graphics 5000]
+- [[32902, 33032], low, Intel(R) Graphics Media Accelerator 500]
+- [[32902, 34752], low, Intel UHD Graphics 617]
+- [[32902, 40961], low, Intel Media Accelerator 3150]
+- [[32902, 40977], low, Intel(R) Graphics Media Accelerator 3150]
+- [[65535, 65535], low, '']This is another test resource

--- a/tests/testData/CreateBundleSplitOnCompressed/CreateBundleOut/cc/cc00d34500ea7a31_f32613169b3491afb5d029828d269ff3
+++ b/tests/testData/CreateBundleSplitOnCompressed/CreateBundleOut/cc/cc00d34500ea7a31_f32613169b3491afb5d029828d269ff3
@@ -1,0 +1,27 @@
+Version: 0.1.0
+Type: ResourceGroup
+NumberOfResources: 3
+TotalResourcesSizeCompressed: 8359
+TotalResourcesSizeUnCompressed: 41961
+Resources:
+  - RelativePath: intromovie.txt
+    Type: Resource
+    Location: a7/a7e3d1a9f1c5d99d_5e631fd37d3350e30095d1251b178f2c
+    Checksum: 5e631fd37d3350e30095d1251b178f2c
+    UncompressedSize: 9117
+    CompressedSize: 3259
+    Prefix: res
+  - RelativePath: videocardcategories.yaml
+    Type: Resource
+    Location: 14/14c712837859ba7f_90d25dac9f4ed3233c5fda72bee3dfe6
+    Checksum: 90d25dac9f4ed3233c5fda72bee3dfe6
+    UncompressedSize: 32815
+    CompressedSize: 5003
+    Prefix: res
+  - RelativePath: testresource2.txt
+    Type: Resource
+    Location: 06/0649f60a478bf633_271c8036e4eae5515053e924a0a39e0f
+    Checksum: 271c8036e4eae5515053e924a0a39e0f
+    UncompressedSize: 29
+    CompressedSize: 97
+    Prefix: res

--- a/tests/testData/Patch/NewFilesResourceGroup.yaml
+++ b/tests/testData/Patch/NewFilesResourceGroup.yaml
@@ -1,0 +1,13 @@
+Version: 0.1.0
+Type: ResourceGroup
+NumberOfResources: 1
+TotalResourcesSizeCompressed: 47
+TotalResourcesSizeUnCompressed: 29
+Resources:
+  - RelativePath: testresource2.txt
+    Type: Resource
+    Location: 06/0649f60a478bf633_271c8036e4eae5515053e924a0a39e0f
+    Checksum: 271c8036e4eae5515053e924a0a39e0f
+    UncompressedSize: 29
+    CompressedSize: 47
+    Prefix: res

--- a/tools/include/BundleStreamIn.h
+++ b/tools/include/BundleStreamIn.h
@@ -33,6 +33,10 @@ public:
 
 	bool operator>>( GetFile& fileData );
 
+    void clearCache();
+
+private:
+	
 
 private:
 	uintmax_t m_chunkSize;
@@ -40,6 +44,10 @@ private:
 	std::string m_cache;
 
 	uintmax_t m_dataReadOfCurrentFile;
+
+	uintmax_t m_cacheOffset;
+
+    uintmax_t m_cacheSize;
 };
 
 

--- a/tools/include/BundleStreamOut.h
+++ b/tools/include/BundleStreamOut.h
@@ -7,46 +7,44 @@
 #include <FileDataStreamIn.h>
 #include <FileDataStreamOut.h>
 #include <ScopedFile.h>
-
+#include <Md5ChecksumStream.h>
 #include <string>
+
 #include "GzipCompressionStream.h"
 
 namespace ResourceTools
 {
 
-struct GetChunk
+struct ChunkInfo
 {
-	std::shared_ptr<ResourceTools::FileDataStreamIn> uncompressedChunkIn;
+	std::string checksum = "";
 
-	std::shared_ptr<ResourceTools::FileDataStreamIn> compressedChunkIn;
+    uintmax_t uncompressedSize = 0;
 
-	bool clearCache{ false };
+	uintmax_t compressedSize = 0;
 
-	bool outOfChunks{ false };
+    std::filesystem::path path = "";
 };
 
 class BundleStreamOut
 {
 public:
-	BundleStreamOut( uintmax_t chunkSize, std::filesystem::path outputDirectory, bool splitOnCompressed);
+	BundleStreamOut( uintmax_t chunkSize, std::filesystem::path outputDirectory, bool outputCompressed, bool splitOnCompressed, bool calculateCompressions );
 
 	~BundleStreamOut();
 
 	bool operator<<( std::shared_ptr<ResourceTools::FileDataStreamIn> streamIn );
 
-	// Outputs chunks
-	bool operator>>( GetChunk& data );
+	bool GetChunkInfo( int index, ChunkInfo& chunkInfo );
 
 	bool Finish();
+
+    size_t GetNumberOfChunksCreated();
 
 private:
     bool Flush();
 
-	bool AddChunkFilesToGetChunk( GetChunk& data );
-
-	bool InitializeOutputStreams();
-
-	std::vector<std::shared_ptr<ResourceTools::ScopedFile>> m_chunkFiles;
+    bool InitializeOutputStream();
 
 	uintmax_t m_chunkSize;
 
@@ -58,17 +56,22 @@ private:
 
 	std::unique_ptr<GzipCompressionStream> m_compressionStream;
 
-	std::unique_ptr<ResourceTools::FileDataStreamOut> m_compressedOut;
-
-	std::unique_ptr<ResourceTools::FileDataStreamOut> m_uncompressedOut;
+	std::unique_ptr<ResourceTools::FileDataStreamOut> m_chunkOut;
 
 	std::filesystem::path m_outputDirectory;
 
-	uint32_t m_chunksCreated{ 0 };
+    std::unique_ptr<ResourceTools::Md5ChecksumStream> m_checksumStream;
 
-	uint32_t m_chunksExported{ 0 };
+    bool m_outputCompressed;
 
-    bool m_splitOnCompressed;
+    std::vector<ChunkInfo> m_chunkInfos;
+
+    ChunkInfo m_currentChunk;
+
+    bool m_splitOnCompressedSize;
+
+    bool m_calculateCompressions;
+
 };
 
 }

--- a/tools/include/GzipCompressionStream.h
+++ b/tools/include/GzipCompressionStream.h
@@ -22,14 +22,15 @@ public:
 
 	bool Finish();
 
+private:
+    bool ProcessBuffer( bool finish );
 
 private:
 	bool m_compressionInProgress;
 	z_stream m_stream;
 	std::string m_buffer;
 	std::string* m_out;
-
-	bool ProcessBuffer( bool finish );
+	uintmax_t m_buffer_position;
 };
 
 

--- a/tools/src/BundleStreamIn.cpp
+++ b/tools/src/BundleStreamIn.cpp
@@ -8,7 +8,9 @@ namespace ResourceTools
 
 BundleStreamIn::BundleStreamIn( uintmax_t chunkSize ) :
 	m_chunkSize( chunkSize ),
-	m_dataReadOfCurrentFile( 0 )
+	m_dataReadOfCurrentFile( 0 ),
+	m_cacheOffset(0),
+	m_cacheSize(0)
 {
 }
 
@@ -18,26 +20,36 @@ BundleStreamIn ::~BundleStreamIn()
 
 uintmax_t BundleStreamIn::GetCacheSize()
 {
-	return m_cache.size();
+	return m_cacheSize;
 }
 
 bool BundleStreamIn::operator<<( const std::string& dataData )
 {
 	m_cache.append( dataData );
 
+    auto test = dataData.size();
+
+    m_cacheSize += dataData.size();
+
 	return true;
+}
+
+void BundleStreamIn::clearCache()
+{
+    // If value is over the total cache size in ram then remove used data
+    // This adjusts the buffer size less often to speed up processing
+	m_cache.erase( 0, m_cacheOffset );
+	m_cacheOffset = 0; 
+	
 }
 
 bool BundleStreamIn::operator>>( GetFile& fileData )
 {
-	size_t cacheSize = m_cache.size();
-
-	if( cacheSize == 0 )
+	if( m_cacheSize == 0 )
 	{
 		// No data in cache
 		return false;
 	}
-
 
 	std::string& dataRef = *fileData.data;
 
@@ -45,17 +57,19 @@ bool BundleStreamIn::operator>>( GetFile& fileData )
 	{
 		uintmax_t remainingDataSize = fileData.fileSize - m_dataReadOfCurrentFile;
 
-		dataRef = m_cache.substr( 0, remainingDataSize );
+		dataRef = m_cache.substr( m_cacheOffset, remainingDataSize );
 
-		m_cache.erase( 0, remainingDataSize );
+        m_cacheOffset += remainingDataSize;
+		m_cacheSize -= remainingDataSize;
 
 		m_dataReadOfCurrentFile = 0;
 	}
 	else
 	{
-		dataRef = m_cache.substr( 0, m_chunkSize );
+		dataRef = m_cache.substr( m_cacheOffset, m_chunkSize );
 
-		m_cache.erase( 0, m_chunkSize );
+        m_cacheOffset += m_chunkSize;
+		m_cacheSize -= m_chunkSize;
 
 		m_dataReadOfCurrentFile += m_chunkSize;
 	}
@@ -70,14 +84,16 @@ uintmax_t BundleStreamIn::GetChunkSize() const
 
 bool BundleStreamIn::ReadBytes( size_t n, std::string& out )
 {
-	if( m_cache.size() < n )
+	if( m_cacheSize < n )
 	{
 		return false;
 	}
 
-	out = m_cache.substr( 0, n );
+	out = m_cache.substr( m_cacheOffset, n );
 
-	m_cache.erase( 0, n );
+    m_cacheOffset += n;
+
+    clearCache();
 
 	return true;
 }

--- a/tools/src/BundleStreamOut.cpp
+++ b/tools/src/BundleStreamOut.cpp
@@ -7,56 +7,64 @@
 
 namespace ResourceTools
 {
-BundleStreamOut::BundleStreamOut( uintmax_t chunkSize, std::filesystem::path outputDirectory, bool splitOnCompressed ) :
+
+// outputCompressed will only create compressed output from this job
+// if split on compressed is on
+// If it isn't then this work is deferred until the processing step
+// This allows the work to be done asynchronously
+BundleStreamOut::BundleStreamOut( uintmax_t chunkSize, std::filesystem::path outputDirectory, bool outputCompressed, bool splitOnCompressedSize, bool calculateCompressions ) :
 	m_chunkSize( chunkSize ),
 	m_outputDirectory( outputDirectory ),
-	m_splitOnCompressed( splitOnCompressed )
+	m_outputCompressed( outputCompressed ),
+	m_splitOnCompressedSize( splitOnCompressedSize ),
+	m_calculateCompressions( calculateCompressions ),
+	m_checksumStream( std::make_unique<ResourceTools::Md5ChecksumStream>() )
 {
+   
 }
 
 BundleStreamOut::~BundleStreamOut()
 {
 }
 
-std::filesystem::path RawFilename( std::filesystem::path outputDirectory, uint32_t chunkNumber )
+std::filesystem::path RawFilename( std::filesystem::path outputDirectory, size_t chunkNumber )
 {
-	std::string filename = "chunk" + std::to_string( chunkNumber ) + ".raw";
+	std::string filename = "chunk" + std::to_string( chunkNumber ) + ".tmp";
 
 	return outputDirectory / filename;
 }
 
-std::filesystem::path CompressedFilename( std::filesystem::path outputDirectory, uint32_t chunkNumber )
+
+bool BundleStreamOut::InitializeOutputStream()
 {
-	std::string filename = "chunk" + std::to_string( chunkNumber ) + ".compressed";
+	std::filesystem::path rawPath = RawFilename( m_outputDirectory, m_chunkInfos.size() );
 
-	return outputDirectory / filename;
-}
+	m_chunkOut = std::make_unique<ResourceTools::FileDataStreamOut>();
 
-bool BundleStreamOut::InitializeOutputStreams()
-{
-	std::filesystem::path compressedPath = CompressedFilename( m_outputDirectory, m_chunksCreated );
-
-	std::filesystem::path rawPath = RawFilename( m_outputDirectory, m_chunksCreated );
-
-	m_uncompressedOut = std::make_unique<ResourceTools::FileDataStreamOut>();
-
-	if( !m_uncompressedOut->StartWrite( rawPath ) )
+	if( !m_chunkOut->StartWrite( rawPath ) )
 	{
 		return false;
 	}
 
-	m_compressedOut = std::make_unique<ResourceTools::FileDataStreamOut>();
+    m_currentChunk.path = rawPath;
+	m_currentChunk.checksum = "";
+	m_currentChunk.compressedSize = 0;
+	m_currentChunk.uncompressedSize = 0;
 
-	if( !m_compressedOut->StartWrite( compressedPath ) )
-	{
-		return false;
-	}
+    // Setup compression stream
+	if( m_splitOnCompressedSize )
+    {
+		m_compressionStream = std::make_unique<GzipCompressionStream>( &m_compressedData );
 
-	m_chunkFiles.push_back( std::make_shared<ScopedFile>( rawPath ) );
+		m_compressedData.clear();
 
-	m_chunkFiles.push_back( std::make_shared<ScopedFile>( compressedPath ) );
-
-	return true;
+		if( !m_compressionStream->Start() )
+		{
+			return false;
+		}
+    }
+    
+    return true;
 }
 
 bool BundleStreamOut::Finish()
@@ -66,30 +74,60 @@ bool BundleStreamOut::Finish()
 
 bool BundleStreamOut::Flush()
 {
+	
 	// Chunk size achieved after compression
-	if( !m_compressionStream )
-	{
-		return true;
-	}
+	if( m_splitOnCompressedSize )
+    {
+		if( !m_compressionStream )
+		{
+			return true;
+		}
 
-	if( !m_compressionStream->Finish() )
-	{
+		if( !m_compressionStream->Finish() )
+		{
+			return false;
+		}
+
+		if( m_outputCompressed )
+		{
+			*m_chunkOut << m_compressedData;
+		}
+
+        if (m_calculateCompressions)
+        {
+			m_currentChunk.compressedSize = m_compressedData.size();
+        }
+
+        m_compressedData.clear();
+
+		m_compressionStream.reset();
+    }
+	
+
+	m_chunkOut->Finish();
+
+    m_chunkOut.reset();
+
+    // Retrieve checksum and store
+    std::string chunkChecksum;
+
+    if (!m_checksumStream->Retrieve(chunkChecksum))
+    {
 		return false;
-	}
+    }
 
-	*m_compressedOut << m_compressedData;
+    m_currentChunk.checksum = chunkChecksum;
 
-	m_compressedData.clear();
+    m_checksumStream = std::make_unique<ResourceTools::Md5ChecksumStream>();
 
-	++m_chunksCreated;
-
-	m_compressionStream.release();
-
-    m_compressedOut->Finish();
-
-    m_uncompressedOut->Finish();
+    m_chunkInfos.push_back( m_currentChunk );
 
 	return true;
+}
+
+size_t BundleStreamOut::GetNumberOfChunksCreated()
+{
+	return m_chunkInfos.size();
 }
 
 bool BundleStreamOut::operator<<( std::shared_ptr<FileDataStreamIn> streamIn )
@@ -98,41 +136,49 @@ bool BundleStreamOut::operator<<( std::shared_ptr<FileDataStreamIn> streamIn )
 
 	while( *streamIn >> data )
 	{
-		if( !m_compressionStream )
+		if( !m_chunkOut )
 		{
-			m_compressionStream = std::make_unique<GzipCompressionStream>( &m_compressedData );
-
-			m_compressedData.clear();
-
-			if( !m_compressionStream->Start() )
-			{
-				return false;
-			}
-
-			if( !InitializeOutputStreams() )
+			if( !InitializeOutputStream() )
 			{
 				return false;
 			}
 		}
+
+        m_currentChunk.uncompressedSize += data.size();
+
+        if( m_splitOnCompressedSize )
+        {
+			m_compressionStream->operator<<( &data );
+        }
 
         // Output uncompressed data
-        *m_uncompressedOut << data;
+		bool outputUncompressed = !m_outputCompressed;
 
-        // Compress the data
-		if( !m_compressionStream->operator<<( &data ) )
-		{
-			return false;
-		}
-
-        // If split on uncompressed size then there is much more chance of stable chunk sizes
-        // If splitting on compressed size then the chunk size will vary
-        // This is due to the fact that compression of the data is not predictable
-        size_t splitSize = m_uncompressedOut->GetFileSize();
-
-        if (m_splitOnCompressed)
+        if (m_outputCompressed && !m_splitOnCompressedSize)
         {
-			splitSize = m_compressedData.size();
+            // Destination should be compressed but as this doesn't
+            // split on compressed then the compression will be defferred
+			outputUncompressed = true;
         }
+
+        if( outputUncompressed )
+        {
+			if( !( *m_chunkOut << data ) )
+			{
+				return false;
+			}
+        }
+        
+        // Checksum calculation
+		if(!(m_checksumStream->operator<<(data)))
+        {
+			return false;
+        }
+
+        // Can either be split based on the current compressed or uncompressed total size
+        // If using uncompressed then it is expected that the output chunks will be less efficient
+        // But the split will be more accurate and it can be faster if also not processing compression
+        size_t splitSize = m_splitOnCompressedSize ? m_compressedData.size() : m_currentChunk.uncompressedSize;
 
         // See if the current output is greater than the chunk size indicator
 		if( splitSize >= m_chunkSize )
@@ -151,52 +197,17 @@ bool BundleStreamOut::operator<<( std::shared_ptr<FileDataStreamIn> streamIn )
 	return true;
 }
 
-bool BundleStreamOut::AddChunkFilesToGetChunk( GetChunk& data )
+bool BundleStreamOut::GetChunkInfo( int index, ChunkInfo& chunkInfo )
 {
-	// Needs to be called after all changes have been made to the file,
-	// since FileDataStreamIn assumes filesize does not change once created.
-	auto rawDir = RawFilename( m_outputDirectory, m_chunksExported );
-
-	auto compressedDir = CompressedFilename( m_outputDirectory, m_chunksExported );
-
-	if( !exists( rawDir ) || !exists( compressedDir ) )
-	{
+	if( index > m_chunkInfos.size() )
+    {
 		return false;
-	}
-
-	data.uncompressedChunkIn = std::make_shared<FileDataStreamIn>();
-
-	if( !data.uncompressedChunkIn->StartRead( rawDir ) )
-	{
-		return false;
-	}
-
-	data.compressedChunkIn = std::make_shared<FileDataStreamIn>();
-
-	if( !data.compressedChunkIn->StartRead( compressedDir ) )
-	{
-		return false;
-	}
-
-	return true;
+    }
+    else
+    {
+		chunkInfo = m_chunkInfos.at( index );
+		return true;
+    }
 }
 
-bool BundleStreamOut::operator>>( GetChunk& data )
-{
-	if( m_chunksCreated == m_chunksExported )
-	{
-		// Not enough data to create chunk
-		data.outOfChunks = true;
-	}
-	else
-	{
-        if (!AddChunkFilesToGetChunk(data))
-        {
-			return false;
-        }
-		m_chunksExported++;
-	}
-
-	return true;
-}
 }

--- a/tools/src/BundleStreamOut.cpp
+++ b/tools/src/BundleStreamOut.cpp
@@ -148,7 +148,10 @@ bool BundleStreamOut::operator<<( std::shared_ptr<FileDataStreamIn> streamIn )
 
         if( m_splitOnCompressedSize )
         {
-			m_compressionStream->operator<<( &data );
+			if(!m_compressionStream->operator<<( &data ))
+			{
+				return false;
+			}
         }
 
         // Output uncompressed data
@@ -199,7 +202,7 @@ bool BundleStreamOut::operator<<( std::shared_ptr<FileDataStreamIn> streamIn )
 
 bool BundleStreamOut::GetChunkInfo( int index, ChunkInfo& chunkInfo )
 {
-	if( index > m_chunkInfos.size() )
+	if( index >= m_chunkInfos.size() )
     {
 		return false;
     }

--- a/tools/src/GzipCompressionStream.cpp
+++ b/tools/src/GzipCompressionStream.cpp
@@ -19,6 +19,7 @@ GzipCompressionStream ::~GzipCompressionStream()
 
 bool GzipCompressionStream::Start()
 {
+	m_buffer_position = 0;
 
 	m_stream.zalloc = Z_NULL;
 
@@ -42,18 +43,23 @@ bool GzipCompressionStream::Start()
 
 bool GzipCompressionStream::ProcessBuffer( bool finish )
 {
+	const char* buffer_ptr = m_buffer.c_str();
+
 	constexpr size_t CHUNK = 16384; // 16kb
 	int ret = Z_OK;
 	unsigned char outbuffer[CHUNK];
 	int flush{ Z_NO_FLUSH };
-	while( ret == Z_OK && ( finish || !m_buffer.empty() ) )
+	while( ret == Z_OK && ( finish || m_buffer_position != m_buffer.size() ) )
 	{
-		size_t available = m_buffer.size();
-		m_stream.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( m_buffer.c_str() ) );
+		size_t available = m_buffer.size() - m_buffer_position;
+		m_stream.next_in = reinterpret_cast<Bytef*>( const_cast<char*>( buffer_ptr + m_buffer_position ) );
 		m_stream.avail_in = static_cast<uInt>( available );
 		m_stream.next_out = outbuffer;
 		m_stream.avail_out = CHUNK;
-		if( finish && m_buffer.size() <= CHUNK )
+
+        auto remaining = m_buffer.size() - m_buffer_position;
+
+		if( finish && remaining <= CHUNK )
 		{
 			flush = Z_FINISH;
 		}
@@ -63,11 +69,12 @@ bool GzipCompressionStream::ProcessBuffer( bool finish )
 		uLong outBytes = m_stream.total_out - alreadyOut;
 		uLong inBytes = m_stream.total_in - alreadyIn;
 		m_out->append( std::string( reinterpret_cast<const char*>( outbuffer ), outBytes ) );
-		m_buffer = m_buffer.substr( inBytes );
+		m_buffer_position += inBytes;
 	}
 
 	if( ret != Z_OK && ret != Z_STREAM_END )
 	{
+		m_buffer.clear();
 		deflateEnd( &m_stream );
 		return false;
 	}


### PR DESCRIPTION
The focus of this change is to increase both creation and unpacking of bundles so it can be used for delivery of large datasets.
Especially focused on datasets which contain very large files.

# Local speed test results running on large data set
create-bundle
before: ~38mins
after: ~2mins

unpack-bundle
before: ~8mins
after: ~2mins

# create-bundle operation
Now can support bundles split on uncompressed size. This allows for compression to be deferred and run asynchronously. This method is not appropriate for all data types. Split on compressed size remains the default.

Memory operations that were causing speed degredation have been mitigated. Processing bottleneck is now md5 calculations and compression.

Thread options have been added. Chunk processing is now conducted asynchronously. With deferred compression this is a considerable speed increase.

# unpack-bundle operation

Memory operations that were causing speed degredation  have been mitigated. This is aided by caching more in RAM and the cache value is exposed to the user. Processing bottleneck is now md5 checksum and IO.

# apply-patch operation

Apply patch now exposes the resource relative paths that have been removed between previous and next. This is exposed in input parameters as a vector.

# Tests

Tests functionally remain the same, changes were made to make them work with the changes in internal interfaces.
Further tests to cover new options will follow.

# Documentation

Options added to CLI contain appropriate documentation through help interface. Auto generated c++ api covers all additions to the interface. Supporting bundle documentation is now out of date, an update will follow.