### PR TITLE
Use HTTPS for the vcpkg registries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/github.com/microsoft/vcpkg"]
 	path = vendor/github.com/microsoft/vcpkg
-	url = git@github.com:microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg
 [submodule "vendor/github.com/carbonengine/vcpkg-registry"]
 	path = vendor/github.com/carbonengine/vcpkg-registry
-	url = git@github.com:carbonengine/vcpkg-registry.git
+	url = https://github.com/carbonengine/vcpkg-registry

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,9 +7,13 @@
   "registries": [
     {
       "kind": "git",
-      "repository": "git@github.com:carbonengine/vcpkg-registry.git",
+      "repository": "https://github.com/carbonengine/vcpkg-registry.git",
       "baseline": "b3b922c476b0dedfa8342a75e89975c74441fc75",
-      "packages": ["carbon-*", "python3", "bsdiff-drake127"]
+      "packages": [
+        "carbon-*",
+        "python3",
+        "bsdiff-drake127"
+      ]
     }
   ]
 }


### PR DESCRIPTION
For vcpkg, it is much more common to use HTTPS for public registries. Accessing them via SSH isn't always possible, as it requires a key pre-installed.


###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.