### PR TITLE
Ignore the .cmake build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,9 @@ __pycache__/
 ### CMake ###
 # User generated local cmake configuration
 CMakeUserPresets.json
-
+# Intermediate cmake build flavor folders #
+cmake-build-*/
+.cmake-*
 
 ### IDE ###
 # User generated local IDE configuration


### PR DESCRIPTION
Just to avoid people accidentally adding their build folders in PRs. All other repositories already have these entries in the `.gitignore`.

###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.