### PR TITLE
Align CMakePresets with the other repositories

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,7 @@
         "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/triplets"
       },
       "environment": {
-        "PATH_TO_VCPKG_ROOT": "${sourceDir}/vendor/github.com/microsoft/vcpkg"
+        "VCPKG_ROOT": "${sourceDir}/vendor/github.com/microsoft/vcpkg"
       },
       "hidden": true
     },


### PR DESCRIPTION
The "common" preset set PATH_TO_VCPKG_ROOT, but vcpkg looks at VCPKG_ROOT. Without it, vcpkg fails to detect the compiler on Linux.

###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.